### PR TITLE
feat(portrait): 添加 REQ-036 统一画像基础能力

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -657,7 +657,7 @@
     }
   },
   "private_companion_bridge": {
-    "description": "陪伴插件协同",
+    "description": "记忆插件协同",
     "hint": "与主动陪伴插件协调记忆、连续对话和自我时间线，减少重复注入和提示词污染。",
     "type": "object",
     "items": {

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -71,6 +71,85 @@
       }
     }
   },
+  "portrait": {
+    "description": "统一用户画像",
+    "hint": "画像事实、证据、敏感等级和检索前隐私裁决由 Memory 维护；人物身份、关系和私聊权限仍由 Companion 维护。",
+    "type": "object",
+    "items": {
+      "min_independent_evidence": {
+        "description": "智能画像独立证据阈值",
+        "type": "int",
+        "default": 3,
+        "hint": "同一人物、同一候选至少三条去重后的本人消息证据；不要求与 Bot 互动或跨会话。"
+      },
+      "daily_success_limit_per_person": {
+        "description": "单用户每日成功更新上限",
+        "type": "int",
+        "default": 1,
+        "hint": "智能画像每天最多成功更新一次。"
+      },
+      "daily_attempt_limit_per_person": {
+        "description": "单用户每日尝试上限",
+        "type": "int",
+        "default": 2,
+        "hint": "允许一次失败退避重试；达到上限后当天不再生成。"
+      },
+      "daily_dispatch_enabled": {
+        "description": "启用每日画像批处理",
+        "type": "bool",
+        "default": true,
+        "hint": "只在设定窗口扫描已有证据队列；不会在每条消息后调用画像模型。"
+      },
+      "update_window_start_hour": {
+        "description": "画像更新窗口开始小时",
+        "type": "int",
+        "default": 3,
+        "hint": "按 Asia/Shanghai 时区执行每日批处理。"
+      },
+      "update_window_end_hour": {
+        "description": "画像更新窗口结束小时",
+        "type": "int",
+        "default": 5,
+        "hint": "窗口外只收集哈希化证据，不整理智能画像。"
+      },
+      "token_budget_per_person_day": {
+        "description": "单用户每日画像 Token 预算",
+        "type": "int",
+        "default": 4000,
+        "hint": "预留给后续经批准的批量推断；当前确定性证据聚合不调用画像 LLM。"
+      },
+      "token_budget_global_day": {
+        "description": "全局每日画像 Token 预算",
+        "type": "int",
+        "default": 40000,
+        "hint": "预留给后续经批准的批量推断；预算不足时必须跳过而不是降级为逐消息调用。"
+      },
+      "usage_min_confidence": {
+        "description": "智能画像使用置信度",
+        "type": "float",
+        "default": 0.75,
+        "hint": "低于此值的智能推断不会进入表达适配。"
+      },
+      "inferred_freshness_days": {
+        "description": "智能推断新鲜期",
+        "type": "int",
+        "default": 90,
+        "hint": "超过期限的智能推断停止使用，等待新的独立证据。"
+      },
+      "context_message_limit": {
+        "description": "画像上下文消息上限",
+        "type": "int",
+        "default": 8,
+        "hint": "后续需要语义消歧时只允许使用同场景最小窗口；第三方消息不能作为事实证据。"
+      },
+      "context_char_limit": {
+        "description": "画像上下文字符上限",
+        "type": "int",
+        "default": 6000,
+        "hint": "上下文仅作当场解释，不写入画像表，也不跨场景拼接。"
+      }
+    }
+  },
   "memory_summary": {
     "description": "长期记忆总结",
     "hint": "把时间线整理为可长期保存、可召回的阶段性记忆。模型、触发阈值和证据长度都在这里配置。",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -685,6 +685,18 @@
         "type": "bool",
         "default": true
       },
+      "enable_p5_b1_recall_gate": {
+        "description": "启用 P5-B1 召回闸门",
+        "hint": "默认关闭。开启后普通记忆注入和主动 recall 需要陪伴侧当前请求的一次性 attestation；无效时返回明确 degraded。",
+        "type": "bool",
+        "default": false
+      },
+      "enable_p5_b1_bridge_gate": {
+        "description": "启用 P5-B1 Bridge 闸门",
+        "hint": "默认关闭。开启后 Bridge 搜索、上下文和序列化入口需要一次性 attestation；不会删除原版娱乐写入。",
+        "type": "bool",
+        "default": false
+      },
       "dedupe_prompt_context": {
         "description": "协同去重陪伴注入",
         "hint": "开启后会和陪伴插件协调，让重复的自我时间线、私聊上下文等段落只由一侧注入。",

--- a/core/affect_modulation.py
+++ b/core/affect_modulation.py
@@ -1,0 +1,46 @@
+"""Bounded affect modulation DTO shared across companion plugins."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Any, Mapping
+
+AFFECT_MODULATION_VERSION = "affect_modulation.v1"
+AFFECT_MODULATION_FIELDS = ("schema_version", "valence", "arousal", "vulnerability", "confidence", "source_event_ids", "computed_at")
+AFFECT_MODULATION_FINGERPRINT = hashlib.sha256("|".join(AFFECT_MODULATION_FIELDS).encode("ascii")).hexdigest()[:20]
+
+
+def _number(value: Any, default: float, low: float, high: float) -> float:
+    if type(value) not in {int, float}:
+        return default
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        return default
+    return round(max(low, min(high, numeric)), 4)
+
+
+def normalize_affect_modulation(value: Any) -> dict[str, Any]:
+    source = dict(value) if isinstance(value, Mapping) else {}
+    raw_ids = source.get("source_event_ids")
+    ids: list[str] = []
+    if isinstance(raw_ids, (list, tuple)):
+        for item in raw_ids[:12]:
+            if type(item) is not str:
+                continue
+            cleaned = " ".join(item.split())[:96]
+            if cleaned and cleaned not in ids:
+                ids.append(cleaned)
+    computed_at = source.get("computed_at")
+    return {
+        "schema_version": AFFECT_MODULATION_VERSION,
+        "valence": _number(source.get("valence"), 0.0, -1.0, 1.0),
+        "arousal": _number(source.get("arousal"), 0.0, 0.0, 1.0),
+        "vulnerability": _number(source.get("vulnerability"), 0.0, 0.0, 1.0),
+        "confidence": _number(source.get("confidence"), 0.0, 0.0, 1.0),
+        "source_event_ids": ids,
+        "computed_at": float(computed_at) if type(computed_at) in {int, float} and math.isfinite(float(computed_at)) else 0.0,
+    }
+
+
+__all__ = ["AFFECT_MODULATION_FIELDS", "AFFECT_MODULATION_FINGERPRINT", "AFFECT_MODULATION_VERSION", "normalize_affect_modulation"]

--- a/core/bot_personal_consumer.py
+++ b/core/bot_personal_consumer.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Failure-contained consumer for the optional Bot Personal Bridge."""
+
+from copy import deepcopy
+from typing import Any
+
+from .bot_personal_dto import BotPersonalArchiveDTO, BotPersonalValidationError, build_bot_personal_archive
+
+
+def _base(*, state: str = "retry", attempts: int = 0, error_code: str | None = None) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "record_id": "",
+        "deduplicated": False,
+        "version": 0,
+        "error_code": error_code,
+        "state": state,
+        "attempts": max(0, int(attempts or 0)),
+    }
+
+
+class BotPersonalConsumer:
+    def __init__(self, bridge: Any, *, max_attempts: int = 3) -> None:
+        self.bridge = bridge
+        self.max_attempts = max(1, int(max_attempts or 3))
+
+    async def consume_bot_personal_archive(
+        self,
+        envelope: BotPersonalArchiveDTO | dict[str, Any],
+        *,
+        attempt: int = 1,
+        max_attempts: int | None = None,
+    ) -> dict[str, Any]:
+        attempts = max(1, int(attempt or 1))
+        ceiling = max(1, int(max_attempts or self.max_attempts))
+        try:
+            dto = build_bot_personal_archive(envelope)
+        except BotPersonalValidationError as exc:
+            return {**_base(state="invalid", attempts=attempts, error_code=exc.error_code), "field": exc.field}
+        try:
+            sender = getattr(self.bridge, "record_bot_personal_archive", None)
+        except Exception:
+            sender = None
+        if not callable(sender):
+            return _base(state="dead_letter" if attempts >= ceiling else "retry", attempts=attempts, error_code="bridge_method_unavailable")
+        try:
+            result = await sender(dto)
+        except Exception:
+            return _base(state="dead_letter" if attempts >= ceiling else "retry", attempts=attempts, error_code="bridge_exception")
+        if not isinstance(result, dict):
+            return _base(state="dead_letter" if attempts >= ceiling else "retry", attempts=attempts, error_code="invalid_bridge_response")
+        normalized = _base(
+            state=str(result.get("state") or ("deduplicated" if result.get("deduplicated") else "sent" if result.get("ok") else "retry")),
+            attempts=attempts,
+            error_code=result.get("error_code"),
+        )
+        normalized.update({key: result[key] for key in ("record_id", "deduplicated", "version", "field") if key in result})
+        normalized["ok"] = bool(result.get("ok"))
+        if normalized["ok"]:
+            normalized["state"] = "deduplicated" if normalized["deduplicated"] else "sent"
+            return normalized
+        if normalized["state"] not in {"invalid", "version_conflict", "stale_version", "dead_letter"}:
+            normalized["state"] = "dead_letter" if attempts >= ceiling else "retry"
+        return normalized
+
+    async def consume(self, envelope: BotPersonalArchiveDTO | dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        return await self.consume_bot_personal_archive(envelope, **kwargs)
+
+
+async def consume_bot_personal_archive(
+    bridge: Any,
+    envelope: BotPersonalArchiveDTO | dict[str, Any],
+    *,
+    attempt: int = 1,
+    max_attempts: int = 3,
+) -> dict[str, Any]:
+    return await BotPersonalConsumer(bridge, max_attempts=max_attempts).consume_bot_personal_archive(
+        deepcopy(envelope) if isinstance(envelope, dict) else envelope,
+        attempt=attempt,
+    )
+
+
+__all__ = ["BotPersonalConsumer", "consume_bot_personal_archive"]

--- a/core/bot_personal_contract.py
+++ b/core/bot_personal_contract.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+"""跨插件共享合同：Bot 个人归档 + 日程分级（陪伴分支）
+
+⚠️  这个文件在两个插件里**各有一份，必须逐字相同**：
+        陪伴插件：astrbot_plugin_private_companion/bot_personal_contract.py
+        记忆插件：astrbot_plugin_memory_companion/core/bot_personal_contract.py
+    权威副本在 peiban/doc/shared/bot_personal_contract.py。
+
+    两个插件是独立的 AstrBot 插件包，互相不能 import，所以「共享常量」只能靠
+    「同一份文件复制两份 + 启动时指纹互校」来保证。任何改动必须同时满足三条：
+
+        ① 两侧同一次提交（不允许一侧先合）
+        ② 升 CONTRACT_REVISION
+        ③ 重算并更新 CONTRACT_FINGERPRINT（python bot_personal_contract.py 会打印）
+
+    只依赖标准库。不要在这里 import 任何插件内部模块，否则复制到对侧会炸。
+
+修改规则与背景见：peiban/doc/跨插件共享合同.md
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+CONTRACT_NAME = "bot_personal_archive"
+CONTRACT_REVISION = 1
+
+# ---------------------------------------------------------------------------
+# 一、日程分级（原「四段」→ 陪伴分支五段）
+#
+# 这是**唯一定义源**。两侧任何地方需要窗口划分，都必须从这张表派生，不允许再写
+# 第二份硬编码——OPS 分支就是因为存在四份互不派生的副本，改一处改不动全部。
+#
+# 边界与原版已持久化的主动配额桶（user["proactive_daypart_counts"]，
+# constants.py:489）完全对齐，所以「日程窗口」与「主动配额桶」共享切点，
+# 但**仍是两套独立存储**：配额桶是计数器，窗口是快照/归档的维度，不要合并。
+#
+# 字段：(slug, 中文名, 起始分钟, 结束分钟)。结束分钟 <= 起始分钟表示跨午夜。
+# ---------------------------------------------------------------------------
+SCHEDULE_WINDOWS: tuple[tuple[str, str, int, int], ...] = (
+    ("late_night", "深夜", 21 * 60, 6 * 60),        # 21:00 - 次日 06:00
+    ("morning",    "早晨",  6 * 60, 11 * 60),       # 06:00 - 11:00
+    ("noon",       "中午", 11 * 60, 14 * 60 + 30),  # 11:00 - 14:30
+    ("afternoon",  "下午", 14 * 60 + 30, 18 * 60),  # 14:30 - 18:00
+    ("evening",    "晚上", 18 * 60, 21 * 60),       # 18:00 - 21:00
+)
+
+WINDOW_SLUGS: tuple[str, ...] = tuple(item[0] for item in SCHEDULE_WINDOWS)
+WINDOW_NAMES: tuple[str, ...] = tuple(item[1] for item in SCHEDULE_WINDOWS)
+WINDOW_SLUG_BY_NAME: dict[str, str] = {item[1]: item[0] for item in SCHEDULE_WINDOWS}
+WINDOW_NAME_BY_SLUG: dict[str, str] = {item[0]: item[1] for item in SCHEDULE_WINDOWS}
+
+# 记忆侧 validate_bot_personal_envelope 用它做**硬校验**：不在集合里 → invalid_window，
+# 归档静默失败。所以它必须由上表派生，不能手写。
+BOT_PERSONAL_WINDOWS = frozenset(WINDOW_SLUGS)
+
+# LLM 与用户口语里的窗口别名 → slug。只做输入归一，不参与判定。
+WINDOW_ALIASES: dict[str, str] = {
+    "深夜": "late_night", "凌晨": "late_night", "半夜": "late_night", "夜里": "late_night",
+    "早晨": "morning", "早上": "morning", "清晨": "morning", "上午": "morning",
+    "中午": "noon", "正午": "noon", "午间": "noon", "晌午": "noon",
+    "下午": "afternoon",
+    "晚上": "evening", "傍晚": "evening", "晚间": "evening",
+}
+
+# 旧四段（OPS 22/06/12/18）→ 新五段的迁移映射。
+# 值为 None 表示「靠窗口名判不出来，必须看时间戳」，见 migrate_legacy_window()。
+LEGACY_WINDOW_MIGRATION: dict[str, str | None] = {
+    "late_night": "late_night",  # 旧 22:00-06:00 ⊂ 新 21:00-06:00，可直接沿用
+    "morning": None,             # 旧 06:00-12:00 → 新 morning(06-11) + noon(11-12)
+    "afternoon": None,           # 旧 12:00-18:00 → 新 noon(12-14:30) + afternoon(14:30-18)
+    "evening": None,             # 旧 18:00-22:00 → 新 evening(18-21) + late_night(21-22)
+}
+
+
+def window_for_minutes(minutes: int) -> str:
+    """把「当日分钟数」归入窗口 slug。跨午夜的窗口拆成两截判定。
+
+    这是**唯一判定实现**。带日期的判定（跨午夜时 window_date 归属哪一天）留在
+    陪伴侧 agenda_contracts.window_for_datetime，但它必须调用本函数取窗口名，
+    不允许自己再判一次阈值。
+    """
+    try:
+        value = int(minutes) % (24 * 60)
+    except (TypeError, ValueError):
+        return ""
+    for slug, _name, start, end in SCHEDULE_WINDOWS:
+        if start < end:
+            if start <= value < end:
+                return slug
+        elif value >= start or value < end:
+            return slug
+    return ""
+
+
+def normalize_window(value: object) -> str:
+    """把窗口名/别名/slug 归一成 slug；无法识别返回空串（**不要猜**）。"""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    lowered = text.lower()
+    if lowered in BOT_PERSONAL_WINDOWS:
+        return lowered
+    return WINDOW_ALIASES.get(text, "")
+
+
+def migrate_legacy_window(old_window: object, minutes: object = None) -> str:
+    """旧四段窗口值 → 新五段 slug。
+
+    拿得到当日分钟数就按时间重算；拿不到且旧值本身不唯一对应新值时返回空串，
+    调用方应当**按旧名保留、只读不重算**，不要猜——猜错会让历史快照的窗口归属
+    和它内部的时间戳自相矛盾。
+    """
+    old = normalize_window(old_window) or str(old_window or "").strip().lower()
+    if minutes is not None:
+        recomputed = window_for_minutes(minutes)
+        if recomputed:
+            return recomputed
+    return LEGACY_WINDOW_MIGRATION.get(old) or ""
+
+
+# ---------------------------------------------------------------------------
+# 二、Bot 个人归档域
+#
+# memory_domain 保持 OPS 时期的取值 "bot_self_schedule"：它描述的是「Bot 自有
+# 日程域」，不含运维语义，改名要同步两侧 7 处 + 存量数据迁移，收益为零。
+# ---------------------------------------------------------------------------
+BOT_PERSONAL_MEMORY_DOMAIN = "bot_self_schedule"
+BOT_PERSONAL_SUBJECT = "bot_self"
+BOT_PERSONAL_SESSION_ID = "bot_personal"
+BOT_PERSONAL_SCOPE = "private"
+BOT_PERSONAL_VISIBILITY = "bot_self"
+BOT_PERSONAL_MAX_PAYLOAD_BYTES = 16 * 1024
+
+# payload 结构本身未变 → 保持 1.0。
+BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION = "1.0"
+# 信封字段 window 的**值域**变了（四段→五段）→ 能力版本必升，且必须在能力探测里
+# 回传 windows，让调用方启动时就能发现两侧值域不一致，而不是等到归档 invalid_window。
+BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION = "1.1"
+
+BOT_PERSONAL_MEMORY_TYPES: tuple[str, ...] = (
+    "bot_schedule_plan",
+    "bot_observed_activity",
+    "bot_schedule_reconciliation",
+    "bot_window_snapshot",
+    "bot_daily_diary",
+    "bot_creative_work",
+    "bot_media_memory",
+    "bot_subjective_memory",
+    "bot_shared_activity",
+    "bot_detail_fragment",
+    "bot_calendar_event",
+    "bot_proactive_message",
+)
+
+# memory_type → (source_kind, 默认 evidence_level, 默认 status)。
+# 记忆侧一律用合同 source_kind 覆盖调用方上报值，所以两侧必须同表，
+# 否则创作/梦境/日历会被标成「真实观察」。
+TYPE_CONTRACTS: dict[str, tuple[str, str, str]] = {
+    "bot_schedule_plan": ("planned", "L0", "planned"),
+    "bot_observed_activity": ("observed", "L2", "active"),
+    "bot_schedule_reconciliation": ("reconciled", "L3", "completed"),
+    "bot_window_snapshot": ("projection", "L2", "completed"),
+    "bot_daily_diary": ("subjective", "L1", "completed"),
+    "bot_creative_work": ("creative", "L1", "active"),
+    "bot_media_memory": ("media", "L1", "active"),
+    "bot_subjective_memory": ("subjective", "L1", "active"),
+    "bot_shared_activity": ("shared", "L1", "active"),
+    "bot_detail_fragment": ("detail", "L1", "active"),
+    "bot_calendar_event": ("calendar", "L1", "active"),
+    "bot_proactive_message": ("proactive", "L1", "active"),
+}
+
+EVIDENCE_LEVELS: tuple[str, ...] = ("L0", "L1", "L2", "L3")
+
+# 幂等键前缀表。归档链路每条写入都要落在这些前缀之一下，方便对账与去重排查。
+# ⚠️ agenda_snapshot / reconciliation 两类的 id 内部含窗口 slug，改分级后新旧 key
+#    不同源：**旧 key 不重写，新记录用新 slug**（见迁移策略）。
+IDEMPOTENCY_KEY_PREFIXES: tuple[str, ...] = (
+    "agenda_snapshot",   # agenda_snapshot:{snapshot_id}        含窗口 slug
+    "reconciliation",    # reconciliation:{reconciliation_id}   含窗口 slug
+    "observed",          # observed:{activity_id}
+    "daily_plan",        # daily_plan:{date}
+    "detail",            # detail:{date}:{start}:{end}
+    "diary",             # diary:{date}
+    "calendar",          # calendar:{event_id}:{action}
+    "proactive",         # proactive:{user_id}:{action}:{content[:80]}
+    "creative",          # creative:{project_id|title}:{chunks}
+    "photo",             # photo:{media_id}
+    "daily_outfit",      # daily_outfit:{date}
+    "dream",             # dream:{text[:120]}:{mood}
+    "qzone",             # qzone:{tid|content[:100]}            ← 娱乐能力，陪伴分支保留
+)
+
+
+def capability_descriptor(*, available: bool = True, read_only: bool = False) -> dict[str, object]:
+    """记忆侧 probe_bot_personal_memory_capabilities 的标准返回骨架。
+
+    windows / memory_types / contract_fingerprint 三个字段是给陪伴侧做启动自检用的：
+    对不上就说明两侧合同文件漂移了，应当直接告警并停用归档，而不是带着不一致跑。
+    """
+    return {
+        "available": bool(available),
+        "read_only": bool(read_only),
+        "memory_domain": BOT_PERSONAL_MEMORY_DOMAIN,
+        "contract_name": CONTRACT_NAME,
+        "contract_revision": CONTRACT_REVISION,
+        "contract_fingerprint": CONTRACT_FINGERPRINT,
+        "capability_schema_version": BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION,
+        "payload_schema_version": BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION,
+        "windows": list(WINDOW_SLUGS),
+        "memory_types": list(BOT_PERSONAL_MEMORY_TYPES),
+        "max_payload_bytes": BOT_PERSONAL_MAX_PAYLOAD_BYTES,
+        "warnings": [],
+    }
+
+
+def _fingerprint_source() -> str:
+    """参与指纹的只有**跨插件必须一致**的值。注释、别名表、辅助函数不参与——
+    别名只影响本地输入归一，两侧不一致不会造成数据不一致。"""
+    canonical = {
+        "contract_name": CONTRACT_NAME,
+        "contract_revision": CONTRACT_REVISION,
+        "windows": [[slug, name, start, end] for slug, name, start, end in SCHEDULE_WINDOWS],
+        "memory_domain": BOT_PERSONAL_MEMORY_DOMAIN,
+        "subject": BOT_PERSONAL_SUBJECT,
+        "session_id": BOT_PERSONAL_SESSION_ID,
+        "scope": BOT_PERSONAL_SCOPE,
+        "visibility": BOT_PERSONAL_VISIBILITY,
+        "max_payload_bytes": BOT_PERSONAL_MAX_PAYLOAD_BYTES,
+        "payload_schema_version": BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION,
+        "capability_schema_version": BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION,
+        "memory_types": list(BOT_PERSONAL_MEMORY_TYPES),
+        "type_contracts": {k: list(v) for k, v in TYPE_CONTRACTS.items()},
+        "evidence_levels": list(EVIDENCE_LEVELS),
+        "idempotency_key_prefixes": list(IDEMPOTENCY_KEY_PREFIXES),
+    }
+    return json.dumps(canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def compute_contract_fingerprint() -> str:
+    return hashlib.sha256(_fingerprint_source().encode("utf-8")).hexdigest()[:16]
+
+
+# 由 compute_contract_fingerprint() 生成。改了上面任何常量都要重跑本文件更新它。
+CONTRACT_FINGERPRINT = "5b8a97c1527dcc62"
+
+
+def contract_self_check() -> list[str]:
+    """两侧启动时各自跑一遍，再互相比对 CONTRACT_FINGERPRINT。"""
+    problems: list[str] = []
+    if CONTRACT_FINGERPRINT != compute_contract_fingerprint():
+        problems.append("contract_fingerprint_stale: 常量改过但没重算指纹")
+    if len(set(WINDOW_SLUGS)) != len(WINDOW_SLUGS):
+        problems.append("duplicate_window_slug")
+    if set(TYPE_CONTRACTS) != set(BOT_PERSONAL_MEMORY_TYPES):
+        problems.append("type_contracts_out_of_sync")
+    covered = {window_for_minutes(m) for m in range(0, 24 * 60)}
+    if covered != set(WINDOW_SLUGS):
+        problems.append(f"window_coverage_gap: 未覆盖或多余 {covered ^ set(WINDOW_SLUGS)}")
+    for alias, slug in WINDOW_ALIASES.items():
+        if slug not in BOT_PERSONAL_WINDOWS:
+            problems.append(f"alias_points_to_unknown_window: {alias}->{slug}")
+    return problems
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("CONTRACT_FINGERPRINT =", compute_contract_fingerprint())
+    issues = contract_self_check()
+    print("self_check:", "OK" if not issues else issues)

--- a/core/bot_personal_dto.py
+++ b/core/bot_personal_dto.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+"""Structured, privacy-limited DTOs for the Bot Personal archive boundary."""
+
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from typing import Any, Mapping
+
+from . import bot_personal_contract
+from .bot_personal_contract import (
+    BOT_PERSONAL_MEMORY_DOMAIN,
+    BOT_PERSONAL_MEMORY_TYPES,
+    BOT_PERSONAL_MAX_PAYLOAD_BYTES,
+    BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION,
+    BOT_PERSONAL_SUBJECT,
+    BOT_PERSONAL_WINDOWS,
+    TYPE_CONTRACTS,
+    WINDOW_SLUGS,
+)
+
+
+class BotPersonalValidationError(ValueError):
+    def __init__(self, error_code: str, field: str = "", message: str = "") -> None:
+        self.error_code = str(error_code or "invalid").strip()[:80]
+        self.field = str(field or "").strip()[:160]
+        self.message = str(message or self.error_code).strip()[:300]
+        super().__init__(self.message)
+
+
+_FORBIDDEN_KEY_PARTS = (
+    "prompt", "conversation", "transcript", "message_chain", "message_history", "raw_message",
+    "messages",
+    "raw_prompt", "chat_history", "cookie", "token", "secret", "credential", "password",
+    "passwd", "authorization", "bearer", "api_key", "apikey", "private_key", "base64",
+    "binary", "media_bytes", "image_bytes", "audio_bytes", "video_bytes", "media_binary",
+    "media_data", "media_content", "media_blob", "file_path", "filepath", "absolute_path",
+    "local_path", "raw_payload",
+)
+_SENSITIVE_VALUE_PATTERNS = (
+    re.compile(r"(?i)^bearer\s+\S+"),
+    re.compile(r"(?i)(?:password|passwd|secret|token|api[_-]?key|authorization)\s*[:=]\s*\S+"),
+    re.compile(r"(?i)base64,"),
+    re.compile(r"(?i)^data:[a-z0-9.+-]+/[a-z0-9.+-]+[;,]"),
+    re.compile(r"(?i)^-----begin "),
+    re.compile(r"(?i)(?:^|[\s=:;,])(?:[A-Za-z]:[\\/]|\\\\|/home/|/root/|/tmp/|/var/|/volume\d+/)"),
+)
+_FORBIDDEN_TOP_LEVEL_KEYS = frozenset({
+    "conversation", "transcript", "message_chain", "raw_prompt", "raw_payload", "payload_raw",
+})
+
+
+def _key_name(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _text(value: Any, limit: int) -> str:
+    return str(value or "").strip()[:limit]
+
+
+def _check_string(value: str, path: str) -> str:
+    text = _text(value, BOT_PERSONAL_MAX_PAYLOAD_BYTES)
+    if any(pattern.search(text) for pattern in _SENSITIVE_VALUE_PATTERNS):
+        raise BotPersonalValidationError("privacy_rejected", path, "credential, binary media or absolute path is not accepted")
+    return text
+
+
+def sanitize_bot_personal_value(value: Any, *, path: str = "payload", depth: int = 0) -> Any:
+    if depth > 8:
+        raise BotPersonalValidationError("privacy_rejected", path, "payload nesting is too deep")
+    if isinstance(value, Mapping):
+        if len(value) > 64:
+            raise BotPersonalValidationError("payload_too_large", path, "too many fields")
+        result: dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            key = _text(raw_key, 80)
+            normalized = _key_name(key)
+            if not key:
+                raise BotPersonalValidationError("invalid", path, "empty field name")
+            if any(part in normalized for part in _FORBIDDEN_KEY_PARTS):
+                raise BotPersonalValidationError("privacy_rejected", f"{path}.{key}", "sensitive or raw field is not accepted")
+            result[key] = sanitize_bot_personal_value(raw_value, path=f"{path}.{key}", depth=depth + 1)
+        return result
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raise BotPersonalValidationError("privacy_rejected", path, "binary media is not accepted")
+    if isinstance(value, (list, tuple)):
+        if len(value) > 64:
+            raise BotPersonalValidationError("payload_too_large", path, "too many list items")
+        return [sanitize_bot_personal_value(item, path=f"{path}[{index}]", depth=depth + 1) for index, item in enumerate(value)]
+    if isinstance(value, str):
+        return _check_string(value, path)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    raise BotPersonalValidationError("invalid", path, "value is not JSON serializable")
+
+
+def _json_size(value: Any) -> int:
+    try:
+        return len(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise BotPersonalValidationError("invalid", "payload", f"payload is not JSON serializable: {exc}") from exc
+
+
+def _parse_datetime(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise BotPersonalValidationError("invalid", field, f"{field} must be ISO-8601") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise BotPersonalValidationError("invalid", field, f"{field} requires a timezone")
+    return parsed
+
+
+def _derive_window(occurred_at: str) -> str:
+    hour = _parse_datetime(occurred_at, "occurred_at").hour
+    minutes = hour * 60 + _parse_datetime(occurred_at, "occurred_at").minute
+    return bot_personal_contract.window_for_minutes(minutes)
+
+
+def _record_id(memory_type: str, idempotency_key: str) -> str:
+    digest = hashlib.sha256(f"{BOT_PERSONAL_MEMORY_DOMAIN}|{memory_type}|{idempotency_key}".encode("utf-8")).hexdigest()[:24]
+    return f"botmem_{digest}"
+
+
+def _fingerprint(data: Mapping[str, Any]) -> str:
+    canonical = json.dumps(dict(data), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def validate_bot_personal_idempotency_key(value: Any) -> str:
+    if not isinstance(value, str):
+        raise BotPersonalValidationError("invalid", "idempotency_key", "idempotency_key must be a string")
+    key = _text(value, 240)
+    if not key or any(ord(char) < 32 for char in key):
+        raise BotPersonalValidationError("invalid", "idempotency_key", "idempotency_key is required and must be printable")
+    normalized = _key_name(key)
+    if any(part in normalized for part in _FORBIDDEN_KEY_PARTS) or any(pattern.search(key) for pattern in _SENSITIVE_VALUE_PATTERNS):
+        raise BotPersonalValidationError("privacy_rejected", "idempotency_key", "unsafe idempotency_key")
+    return key
+
+
+@dataclass(frozen=True)
+class BotPersonalArchiveDTO:
+    record_id: str
+    memory_domain: str
+    memory_type: str
+    subject: str
+    date: str
+    window: str
+    occurred_at: str
+    source_kind: str
+    source_refs: tuple[str, ...]
+    certainty: float
+    evidence_level: str
+    status: str
+    version: int
+    idempotency_key: str
+    payload_schema_version: str
+    payload: dict[str, Any]
+
+    def envelope(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "memory_domain": self.memory_domain,
+            "memory_type": self.memory_type,
+            "subject": self.subject,
+            "date": self.date,
+            "window": self.window,
+            "occurred_at": self.occurred_at,
+            "source_kind": self.source_kind,
+            "source_refs": list(self.source_refs),
+            "certainty": self.certainty,
+            "evidence_level": self.evidence_level,
+            "status": self.status,
+            "version": self.version,
+            "idempotency_key": self.idempotency_key,
+            "payload_schema_version": self.payload_schema_version,
+            "payload": deepcopy(self.payload),
+        }
+
+    to_dict = envelope
+
+
+def build_bot_personal_archive(
+    envelope: BotPersonalArchiveDTO | Mapping[str, Any] | None = None,
+    *,
+    memory_type: str | None = None,
+    payload: Mapping[str, Any] | None = None,
+    record_id: str = "",
+    memory_domain: str | None = None,
+    subject: str | None = None,
+    date: str = "",
+    window: str = "",
+    occurred_at: str = "",
+    source_kind: str = "",
+    source_refs: Any = None,
+    certainty: Any = None,
+    evidence_level: str = "",
+    status: str = "",
+    version: Any = None,
+    idempotency_key: str = "",
+    payload_schema_version: str | None = None,
+) -> BotPersonalArchiveDTO:
+    if isinstance(envelope, BotPersonalArchiveDTO):
+        return envelope
+    source: dict[str, Any] = dict(envelope or {}) if isinstance(envelope, Mapping) else {}
+    if envelope is not None and not isinstance(envelope, (BotPersonalArchiveDTO, Mapping)):
+        raise BotPersonalValidationError("invalid", "envelope", "envelope must be an object")
+    supplied = {key: value for key, value in {
+        "memory_type": memory_type, "payload": payload, "record_id": record_id, "memory_domain": memory_domain,
+        "subject": subject, "date": date, "window": window, "occurred_at": occurred_at, "source_kind": source_kind,
+        "source_refs": source_refs, "certainty": certainty, "evidence_level": evidence_level, "status": status,
+        "version": version, "idempotency_key": idempotency_key, "payload_schema_version": payload_schema_version,
+    }.items() if value not in (None, "")}
+    source.update(supplied)
+    for key in source:
+        if _key_name(key) in _FORBIDDEN_TOP_LEVEL_KEYS or any(part in _key_name(key) for part in _FORBIDDEN_KEY_PARTS):
+            raise BotPersonalValidationError("privacy_rejected", str(key), "sensitive or raw field is not accepted")
+
+    kind = _text(source.get("memory_type"), 80).lower()
+    if kind not in BOT_PERSONAL_MEMORY_TYPES or kind not in TYPE_CONTRACTS:
+        raise BotPersonalValidationError("invalid", "memory_type", "unknown Bot Personal memory type")
+    if _text(source.get("memory_domain"), 80) not in ("", BOT_PERSONAL_MEMORY_DOMAIN):
+        raise BotPersonalValidationError("invalid", "memory_domain", "Bot Personal domain is fixed")
+    if _text(source.get("subject"), 80) not in ("", BOT_PERSONAL_SUBJECT):
+        raise BotPersonalValidationError("invalid", "subject", "Bot Personal subject is fixed")
+
+    key = validate_bot_personal_idempotency_key(source.get("idempotency_key"))
+    derived_record_id = _record_id(kind, key)
+    supplied_record_id = source.get("record_id")
+    if supplied_record_id not in (None, ""):
+        if not isinstance(supplied_record_id, str):
+            raise BotPersonalValidationError("invalid", "record_id", "record_id must be a string")
+        record_id = _check_string(_text(supplied_record_id, 120), "record_id")
+        if record_id != derived_record_id:
+            raise BotPersonalValidationError("invalid", "record_id", "record_id must match the idempotency key")
+    raw_payload = source.get("payload")
+    if not isinstance(raw_payload, Mapping):
+        raise BotPersonalValidationError("invalid", "payload", "payload must be an object")
+    safe_payload = sanitize_bot_personal_value(raw_payload, path="payload")
+    if _json_size(safe_payload) > BOT_PERSONAL_MAX_PAYLOAD_BYTES:
+        raise BotPersonalValidationError("payload_too_large", "payload", "payload exceeds the contract limit")
+
+    occurred = _text(source.get("occurred_at"), 80)
+    if not occurred:
+        occurred = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    _parse_datetime(occurred, "occurred_at")
+    record_date = _text(source.get("date"), 20) or occurred[:10]
+    try:
+        datetime.strptime(record_date, "%Y-%m-%d")
+    except ValueError as exc:
+        raise BotPersonalValidationError("invalid", "date", "date must be YYYY-MM-DD") from exc
+    record_window = _text(source.get("window"), 40).lower() or _derive_window(occurred)
+    if record_window not in BOT_PERSONAL_WINDOWS or record_window not in WINDOW_SLUGS:
+        raise BotPersonalValidationError("invalid", "window", "window is outside the shared contract")
+    try:
+        confidence = float(source.get("certainty", 0.6))
+    except (TypeError, ValueError) as exc:
+        raise BotPersonalValidationError("invalid", "certainty", "certainty must be numeric") from exc
+    if not 0.0 <= confidence <= 1.0:
+        raise BotPersonalValidationError("invalid", "certainty", "certainty must be between 0 and 1")
+    try:
+        record_version = int(source.get("version", 1))
+    except (TypeError, ValueError) as exc:
+        raise BotPersonalValidationError("invalid", "version", "version must be a positive integer") from exc
+    if record_version < 1:
+        raise BotPersonalValidationError("invalid", "version", "version must be a positive integer")
+    schema = _text(source.get("payload_schema_version"), 40) or BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION
+    if schema != BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION:
+        raise BotPersonalValidationError("invalid", "payload_schema_version", "unsupported payload schema")
+    refs_value = source.get("source_refs")
+    if refs_value is None:
+        refs_value = [f"archive:{key}"]
+    if not isinstance(refs_value, (list, tuple)):
+        raise BotPersonalValidationError("invalid", "source_refs", "source_refs must be a list")
+    refs_list: list[str] = []
+    for item in refs_value:
+        if not isinstance(item, str):
+            raise BotPersonalValidationError("invalid", "source_refs", "source_refs must contain strings")
+        reference = _check_string(_text(item, 240), "source_refs")
+        if reference:
+            refs_list.append(reference)
+    refs = tuple(refs_list)
+    if not refs:
+        raise BotPersonalValidationError("invalid", "source_refs", "source_refs must not be empty")
+    contract_source, contract_evidence, contract_status = TYPE_CONTRACTS[kind]
+    return BotPersonalArchiveDTO(
+        record_id=derived_record_id,
+        memory_domain=BOT_PERSONAL_MEMORY_DOMAIN,
+        memory_type=kind,
+        subject=BOT_PERSONAL_SUBJECT,
+        date=record_date,
+        window=record_window,
+        occurred_at=occurred,
+        source_kind=contract_source,
+        source_refs=refs,
+        certainty=confidence,
+        evidence_level=contract_evidence,
+        status=contract_status,
+        version=record_version,
+        idempotency_key=key,
+        payload_schema_version=schema,
+        payload=deepcopy(safe_payload),
+    )
+
+
+def bot_personal_payload_fingerprint(dto: BotPersonalArchiveDTO) -> str:
+    payload = dto.envelope()
+    payload.pop("record_id", None)
+    return _fingerprint(payload)
+
+
+__all__ = [
+    "BotPersonalArchiveDTO", "BotPersonalValidationError", "build_bot_personal_archive",
+    "bot_personal_payload_fingerprint", "sanitize_bot_personal_value", "validate_bot_personal_idempotency_key",
+]

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -166,13 +166,29 @@ def sanitize_companion_relationship_projection(value: Any) -> dict[str, Any]:
     if type(current_interaction) is dict:
         expression_band = current_interaction.get("expression_band")
         if type(expression_band) is str and expression_band in _COMPANION_INTERACTION_BANDS:
-            projection["current_interaction"] = {
+            interaction_projection = {
                 "expression_band": expression_band,
                 "label": clean_text(current_interaction.get("label"), 40),
                 "source": clean_text(current_interaction.get("source"), 40),
                 "reason": clean_text(current_interaction.get("reason"), 120),
                 "manual_override": current_interaction.get("manual_override") is True,
             }
+            dynamics_version = current_interaction.get("dynamics_version")
+            recovery_band = current_interaction.get("recovery_band")
+            expires_at = current_interaction.get("expires_at")
+            projection_revision = current_interaction.get("projection_revision")
+            if dynamics_version == "interaction_dynamics.v1" and recovery_band in {"steady", "recovering", "reinforced"}:
+                if type(expires_at) not in {int, float} or type(expires_at) is bool:
+                    return fallback
+                if type(projection_revision) is not int or not 1 <= projection_revision <= 1000000:
+                    return fallback
+                interaction_projection.update({
+                    "dynamics_version": dynamics_version,
+                    "recovery_band": recovery_band,
+                    "expires_at": max(0.0, min(10**12, float(expires_at))),
+                    "projection_revision": projection_revision,
+                })
+            projection["current_interaction"] = interaction_projection
     return {"status": "accepted", "read_only": True, "projection": projection}
 
 

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -14,6 +14,61 @@ from .person_projection import consume_person_projection
 
 LOCAL_TZ = ZoneInfo("Asia/Shanghai")
 
+_COMPANION_RELATIONSHIP_PHASES = {
+    "deeply_distant",
+    "strongly_distant",
+    "distant",
+    "acquaintance",
+    "familiar",
+    "close",
+    "intimate",
+    "deeply_bonded",
+}
+
+
+def sanitize_companion_relationship_projection(value: Any) -> dict[str, Any]:
+    fallback = {"status": "invalid", "read_only": True, "projection": {}}
+    if type(value) is not dict:
+        return fallback
+    if value.get("schema_version") != "chat.relationship_projection.v1":
+        return fallback
+    if value.get("authority") != "private_companion.relationship_score" or value.get("read_only") is not True:
+        return fallback
+    phase_key = value.get("phase_key")
+    if type(phase_key) is not str or phase_key not in _COMPANION_RELATIONSHIP_PHASES:
+        return fallback
+    score = value.get("score")
+    if type(score) is not int or not -1200 <= score <= 1200:
+        return fallback
+    soft = value.get("soft_behaviors")
+    if type(soft) is not dict or any(type(item) is not bool for item in soft.values()):
+        return fallback
+    try:
+        proactive_care_limit = int(value.get("proactive_care_limit") or 0)
+    except (TypeError, ValueError):
+        proactive_care_limit = 0
+    projection = {
+        "schema_version": "chat.relationship_projection.v1",
+        "authority": "private_companion.relationship_score",
+        "read_only": True,
+        "score": score,
+        "phase_key": phase_key,
+        "phase_label": clean_text(value.get("phase_label"), 40),
+        "tone": clean_text(value.get("tone"), 160),
+        "address_level": clean_text(value.get("address_level"), 120),
+        "proactive_care_limit": max(0, min(30, proactive_care_limit)),
+        "soft_behaviors": {
+            key: bool(soft.get(key, False))
+            for key in (
+                "allow_playful_jokes",
+                "allow_followup",
+                "allow_memory_mention",
+                "allow_daily_care",
+            )
+        },
+    }
+    return {"status": "accepted", "read_only": True, "projection": projection}
+
 
 def _local_time_label(value: Any) -> str:
     text = clean_text(value, 80)
@@ -39,6 +94,10 @@ class MemoryCompanionBridge:
     def __init__(self, plugin: Any):
         self._plugin = plugin
         self._capability_cache = CapabilityCache()
+
+    def consume_relationship_projection(self, projection: Any) -> dict[str, Any]:
+        """Validate a read-only Companion relationship projection without persisting it."""
+        return sanitize_companion_relationship_projection(projection)
 
     async def record_event(
         self,

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -6,6 +6,7 @@ from zoneinfo import ZoneInfo
 
 from . import bot_personal_contract
 from .bot_personal_dto import BotPersonalArchiveDTO, build_bot_personal_archive
+from .capability_probe import CapabilityCache, PROFILE_NAMES as C4_PROFILE_NAMES, build_capability_snapshot
 from .context_consumer import consume_context_projection
 from .models import EntityRef, MemoryRecord, SessionContext, clean_text
 from .person_projection import consume_person_projection
@@ -37,6 +38,7 @@ class MemoryCompanionBridge:
 
     def __init__(self, plugin: Any):
         self._plugin = plugin
+        self._capability_cache = CapabilityCache()
 
     async def record_event(
         self,
@@ -315,6 +317,74 @@ class MemoryCompanionBridge:
     async def search_bot_personal_profile(self, query: str = "", *, limit: int = 10) -> dict[str, Any]:
         return await self.read_bot_personal_profile(query=query, limit=limit)
 
+    async def read_bot_profile(
+        self,
+        profile: str,
+        query: str = "",
+        *,
+        limit: int = 10,
+        current_date: str = "",
+        current_window: str = "",
+        authorized: bool = False,
+    ) -> dict[str, Any]:
+        """Read a C4 Bot Profile through a privacy-limited bridge boundary."""
+
+        base = {
+            "ok": False,
+            "read_only": True,
+            "state": "degraded",
+            "degraded": True,
+            "pending": True,
+            "profile": clean_text(profile, 80),
+            "items": [],
+            "warnings": [],
+        }
+        try:
+            getter = getattr(self._plugin, "read_bot_profile", None)
+        except Exception:
+            getter = None
+        if not callable(getter):
+            return {**base, "error_code": "bridge_method_unavailable"}
+        try:
+            result = await getter(
+                profile,
+                query=query,
+                limit=limit,
+                current_date=current_date,
+                current_window=current_window,
+                authorized=authorized,
+            )
+        except Exception:
+            return {**base, "error_code": "bridge_exception"}
+        if not isinstance(result, dict):
+            return {**base, "error_code": "invalid_bridge_response"}
+        safe_item_keys = {
+            "record_id", "memory_domain", "memory_type", "subject", "date", "window",
+            "occurred_at", "source_kind", "source_refs", "evidence_level", "status",
+            "version", "summary", "reference",
+        }
+        safe_items: list[dict[str, Any]] = []
+        items = result.get("items", [])
+        for item in items if isinstance(items, list) else []:
+            if isinstance(item, dict):
+                safe_items.append({key: item[key] for key in safe_item_keys if key in item})
+        return {
+            "ok": bool(result.get("ok", True)),
+            "read_only": True,
+            "state": clean_text(result.get("state"), 40) or "ready",
+            "degraded": bool(result.get("degraded", False)),
+            "pending": bool(result.get("pending", False)),
+            "profile": clean_text(result.get("profile") or profile, 80),
+            "items": safe_items,
+            "warnings": [clean_text(item, 160) for item in result.get("warnings", []) if clean_text(item, 160)][:8]
+            if isinstance(result.get("warnings"), list) else [],
+        }
+
+    async def read_profile(self, profile: str, query: str = "", **kwargs: Any) -> dict[str, Any]:
+        """Short alias for callers that use the generic Profile API name."""
+
+        return await self.read_bot_profile(profile, query=query, **kwargs)
+
     async def search(
         self,
         query: str,
@@ -430,13 +500,15 @@ class MemoryCompanionBridge:
             companion_available=companion_available,
         )
 
-    def probe_bot_personal_memory_capabilities(self) -> dict[str, Any]:
-        """Return a database-free capability snapshot for the bot-personal contract.
+    def probe_capability_snapshot(self) -> dict[str, Any]:
+        """Return the C4 capability snapshot without touching plugin state or storage.
 
         The probe is intentionally based only on the shared contract module. It
         must remain safe to call from ordinary chat paths even when the contract
         is stale or the local module is otherwise malformed.
         """
+        if self._capability_cache.snapshot().get("state") == "negative":
+            return self.capability_status()
         try:
             descriptor = bot_personal_contract.capability_descriptor(
                 available=True,
@@ -482,11 +554,57 @@ class MemoryCompanionBridge:
             )
 
         result["available"] = True
-        result["state"] = "ready"
+        result["state"] = "available"
         result["degraded"] = False
         self._add_personal_capability_contract_aliases(result)
+        c4_snapshot = build_capability_snapshot(
+            available=True,
+            state="available",
+            contract_module=bot_personal_contract,
+            methods=result.get("methods", []),
+            profiles=C4_PROFILE_NAMES,
+            warnings=result.get("warnings", []),
+        )
+        result.update(c4_snapshot)
+        result["memory_domain"] = bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN
+        result["domain"] = bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN
+        result["contract_revision"] = bot_personal_contract.CONTRACT_REVISION
+        result["capability_schema_version"] = bot_personal_contract.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION
+        result["payload_schema_version"] = bot_personal_contract.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION
+        result["capability_state"] = "available"
+        self._capability_cache.mark_available(c4_snapshot)
         result.setdefault("warnings", [])
         return result
+
+    def probe_bot_personal_memory_capabilities(self) -> dict[str, Any]:
+        """Backward-compatible C1 probe; C4 state is exposed as capability_state."""
+
+        result = dict(self.probe_capability_snapshot())
+        if result.get("capability_state") == "available":
+            result["state"] = "ready"
+        result["legacy_state"] = result.get("state", "degraded")
+        return result
+
+    def capability_status(self) -> dict[str, Any]:
+        """Return the bounded C4 cache state without probing storage."""
+
+        snapshot = self._capability_cache.snapshot()
+        snapshot["read_only"] = False
+        snapshot["contract_name"] = bot_personal_contract.CONTRACT_NAME
+        snapshot["max_payload_bytes"] = bot_personal_contract.BOT_PERSONAL_MAX_PAYLOAD_BYTES
+        snapshot["memory_domain"] = bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN
+        snapshot["domain"] = snapshot["memory_domain"]
+        snapshot["contract_revision"] = bot_personal_contract.CONTRACT_REVISION
+        snapshot["capability_schema_version"] = bot_personal_contract.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION
+        snapshot["payload_schema_version"] = bot_personal_contract.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION
+        snapshot["capability_state"] = snapshot.get("state", "unprobed")
+        return snapshot
+
+    def mark_capability_negative(self, reason: str) -> dict[str, Any]:
+        """Temporarily suppress repeated capability failures at the bridge edge."""
+
+        self._capability_cache.mark_negative(clean_text(reason, 120) or "capability_negative")
+        return self.capability_status()
 
     @staticmethod
     def _add_personal_capability_contract_aliases(result: dict[str, Any]) -> dict[str, Any]:
@@ -494,12 +612,17 @@ class MemoryCompanionBridge:
 
         result.setdefault("domain", result.get("memory_domain", ""))
         result.setdefault("domains", [result.get("memory_domain", "")])
-        result.setdefault("profiles", ["bot_personal_archive"])
+        result.setdefault("profiles", list(C4_PROFILE_NAMES))
+        result.setdefault("legacy_profiles", ["bot_personal_archive"])
         result.setdefault(
             "methods",
             [
                 "record_event",
                 "record_visible_turn",
+                "record_bot_personal_archive",
+                "record_bot_personal_memory",
+                "read_bot_personal_profile",
+                "search_bot_personal_profile",
                 "search",
                 "compose_injection",
                 "compose_context",
@@ -507,6 +630,9 @@ class MemoryCompanionBridge:
                 "recall",
                 "consume_person_projection",
                 "consume_context_projection",
+                "read_bot_profile",
+                "read_profile",
+                "probe_capability_snapshot",
                 "probe_bot_personal_memory_capabilities",
             ],
         )
@@ -548,7 +674,28 @@ class MemoryCompanionBridge:
                 "warnings": list(warnings or [reason]),
             }
         )
-        return MemoryCompanionBridge._add_personal_capability_contract_aliases(result)
+        MemoryCompanionBridge._add_personal_capability_contract_aliases(result)
+        c4_snapshot = build_capability_snapshot(
+            available=False,
+            state="degraded",
+            contract_module=bot_personal_contract,
+            methods=result.get("methods", []),
+            profiles=C4_PROFILE_NAMES,
+            warnings=result.get("warnings", []),
+            error_code=reason,
+        )
+        result.update(c4_snapshot)
+        result["memory_domain"] = getattr(bot_personal_contract, "BOT_PERSONAL_MEMORY_DOMAIN", "")
+        result["domain"] = result["memory_domain"]
+        result["contract_revision"] = getattr(bot_personal_contract, "CONTRACT_REVISION", 0)
+        result["capability_schema_version"] = getattr(
+            bot_personal_contract, "BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION", ""
+        )
+        result["payload_schema_version"] = getattr(
+            bot_personal_contract, "BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION", ""
+        )
+        result["capability_state"] = "degraded"
+        return result
 
     def get_token_usage_summary(self) -> dict[str, Any]:
         getter = getattr(self._plugin, "token_usage_summary", None)

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -916,6 +916,76 @@ class MemoryCompanionBridge:
             **({"error_code": clean_text(result.get("error_code"), 80)} if state != "ready" and clean_text(result.get("error_code"), 80) else {}),
         }
 
+    async def read_unified_profile_portrait(self, request: dict[str, Any], *, limit: int = 8) -> dict[str, Any]:
+        """Return only a pre-authorized low-sensitivity portrait summary."""
+        base = {
+            "ok": False,
+            "read_only": True,
+            "code": "bridge_unavailable",
+            "items": [],
+        }
+        getter = getattr(self._plugin, "read_unified_profile_portrait", None)
+        if not callable(getter):
+            return base
+        try:
+            result = await getter(request if isinstance(request, dict) else {}, limit=max(1, min(16, int(limit))))
+        except Exception:
+            return {**base, "code": "bridge_degraded"}
+        if not isinstance(result, dict):
+            return {**base, "code": "bridge_degraded"}
+        items: list[dict[str, Any]] = []
+        for item in result.get("items", []) if isinstance(result.get("items"), list) else []:
+            if not isinstance(item, dict):
+                continue
+            if clean_text(item.get("sensitivity"), 24) != "low":
+                continue
+            items.append(
+                {
+                    "dimension": clean_text(item.get("dimension"), 80),
+                    "summary": clean_text(item.get("summary"), 180),
+                    "portrait_tier": clean_text(item.get("portrait_tier"), 24),
+                    "epistemic_status": clean_text(item.get("epistemic_status"), 40),
+                    "confidence": float(item.get("confidence") or 0),
+                    "updated_at": clean_text(item.get("updated_at"), 80),
+                }
+            )
+        return {
+            "ok": bool(result.get("ok")),
+            "read_only": True,
+            "code": clean_text(result.get("code"), 80) or "bridge_degraded",
+            "items": items,
+            "portrait_revision": int(result.get("portrait_revision") or 0),
+        }
+
+    async def unified_profile_portrait_status(self, person_id: str) -> dict[str, Any]:
+        """Return only bridge synchronization metadata, never portrait text."""
+        getter = getattr(self._plugin, "unified_profile_portrait_status", None)
+        if not callable(getter):
+            return {"ok": False, "read_only": True, "code": "bridge_unavailable", "last_synced_at": "", "portrait_revision": 0}
+        try:
+            result = await getter(clean_text(person_id, 80))
+        except Exception:
+            return {"ok": False, "read_only": True, "code": "bridge_degraded", "last_synced_at": "", "portrait_revision": 0}
+        if not isinstance(result, dict):
+            return {"ok": False, "read_only": True, "code": "bridge_degraded", "last_synced_at": "", "portrait_revision": 0}
+        return {
+            "ok": bool(result.get("ok")),
+            "read_only": True,
+            "code": clean_text(result.get("code"), 80) or "bridge_degraded",
+            "last_synced_at": clean_text(result.get("last_synced_at"), 80),
+            "portrait_revision": int(result.get("portrait_revision") or 0),
+        }
+
+    async def run_unified_profile_portrait_batch(self, person_id: str, *, run_day: str = "") -> dict[str, Any]:
+        getter = getattr(self._plugin, "run_unified_profile_portrait_batch", None)
+        if not callable(getter):
+            return {"ok": False, "code": "bridge_unavailable"}
+        try:
+            result = await getter(clean_text(person_id, 80), run_day=clean_text(run_day, 16))
+        except Exception:
+            return {"ok": False, "code": "bridge_degraded"}
+        return dict(result) if isinstance(result, dict) else {"ok": False, "code": "bridge_degraded"}
+
     async def search_bot_personal_profile(self, query: str = "", *, limit: int = 10) -> dict[str, Any]:
         return await self.read_bot_personal_profile(query=query, limit=limit)
 
@@ -1312,6 +1382,9 @@ class MemoryCompanionBridge:
                 "consume_context_projection",
                 "read_bot_profile",
                 "read_profile",
+                "read_unified_profile_portrait",
+                "unified_profile_portrait_status",
+                "run_unified_profile_portrait_batch",
                 "p5_capability_status",
                 "provenance_snapshot",
                 "provenance_preview",

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from . import bot_personal_contract
 from .models import EntityRef, MemoryRecord, SessionContext, clean_text
 
 
@@ -291,10 +292,141 @@ class MemoryCompanionBridge:
         return await self._plugin.tool_note_delete(event, memory_id, title=title)
 
     def coordination_status(self) -> dict[str, Any]:
-        getter = getattr(self._plugin, "companion_coordination_status", None)
-        if callable(getter):
-            return getter()
-        return {"available": True}
+        try:
+            getter = getattr(self._plugin, "companion_coordination_status", None)
+        except Exception:
+            return {"available": False, "state": "degraded", "degraded": True, "reason": "bridge_exception"}
+        if not callable(getter):
+            return {"available": False, "state": "degraded", "degraded": True, "reason": "method_missing"}
+        try:
+            result = getter()
+        except Exception as exc:
+            return {"available": False, "state": "degraded", "degraded": True, "reason": "bridge_exception", "error": str(exc)[:160]}
+        if not isinstance(result, dict):
+            return {"available": False, "state": "degraded", "degraded": True, "reason": "invalid_status"}
+        result = dict(result)
+        result.setdefault("available", True)
+        result.setdefault("state", "ready")
+        result.setdefault("degraded", False)
+        return result
+
+    def probe_bot_personal_memory_capabilities(self) -> dict[str, Any]:
+        """Return a database-free capability snapshot for the bot-personal contract.
+
+        The probe is intentionally based only on the shared contract module. It
+        must remain safe to call from ordinary chat paths even when the contract
+        is stale or the local module is otherwise malformed.
+        """
+        try:
+            descriptor = bot_personal_contract.capability_descriptor(
+                available=True,
+                read_only=False,
+            )
+        except Exception:
+            return self._degraded_personal_capability_probe("contract_descriptor_exception")
+
+        if not isinstance(descriptor, dict):
+            return self._degraded_personal_capability_probe("contract_descriptor_invalid")
+
+        result = dict(descriptor)
+        try:
+            problems = bot_personal_contract.contract_self_check()
+        except Exception:
+            return self._degraded_personal_capability_probe(
+                "contract_self_check_exception",
+                base=result,
+            )
+
+        if not isinstance(problems, list):
+            return self._degraded_personal_capability_probe(
+                "contract_self_check_invalid",
+                base=result,
+            )
+        if problems:
+            warnings = ["contract_self_check_failed"]
+            known_codes = {
+                "contract_fingerprint_stale",
+                "duplicate_window_slug",
+                "type_contracts_out_of_sync",
+                "window_coverage_gap",
+                "alias_points_to_unknown_window",
+            }
+            for problem in problems:
+                code = str(problem).split(":", 1)[0]
+                if code in known_codes and code not in warnings:
+                    warnings.append(code)
+            return self._degraded_personal_capability_probe(
+                "contract_self_check_failed",
+                base=result,
+                warnings=warnings,
+            )
+
+        result["available"] = True
+        result["state"] = "ready"
+        result["degraded"] = False
+        self._add_personal_capability_contract_aliases(result)
+        result.setdefault("warnings", [])
+        return result
+
+    @staticmethod
+    def _add_personal_capability_contract_aliases(result: dict[str, Any]) -> dict[str, Any]:
+        """Expose stable C1 aliases without changing the shared contract copy."""
+
+        result.setdefault("domain", result.get("memory_domain", ""))
+        result.setdefault("domains", [result.get("memory_domain", "")])
+        result.setdefault("profiles", ["bot_personal_archive"])
+        result.setdefault(
+            "methods",
+            [
+                "record_event",
+                "record_visible_turn",
+                "search",
+                "compose_injection",
+                "compose_context",
+                "remember",
+                "recall",
+                "probe_bot_personal_memory_capabilities",
+            ],
+        )
+        result.setdefault("contract_version", str(result.get("contract_revision", "")))
+        result.setdefault("schema_version", str(result.get("capability_schema_version", "")))
+        return result
+
+    @staticmethod
+    def _degraded_personal_capability_probe(
+        reason: str,
+        *,
+        base: dict[str, Any] | None = None,
+        warnings: list[str] | None = None,
+    ) -> dict[str, Any]:
+        result = {
+            "available": False,
+            "read_only": False,
+            "memory_domain": getattr(bot_personal_contract, "BOT_PERSONAL_MEMORY_DOMAIN", ""),
+            "contract_name": getattr(bot_personal_contract, "CONTRACT_NAME", ""),
+            "contract_revision": getattr(bot_personal_contract, "CONTRACT_REVISION", 0),
+            "contract_fingerprint": getattr(bot_personal_contract, "CONTRACT_FINGERPRINT", ""),
+            "capability_schema_version": getattr(
+                bot_personal_contract, "BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION", ""
+            ),
+            "payload_schema_version": getattr(
+                bot_personal_contract, "BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION", ""
+            ),
+            "windows": list(getattr(bot_personal_contract, "WINDOW_SLUGS", ())),
+            "memory_types": list(getattr(bot_personal_contract, "BOT_PERSONAL_MEMORY_TYPES", ())),
+            "max_payload_bytes": getattr(bot_personal_contract, "BOT_PERSONAL_MAX_PAYLOAD_BYTES", 0),
+            "warnings": [],
+        }
+        result.update(base or {})
+        result.update(
+            {
+                "available": False,
+                "state": "degraded",
+                "degraded": True,
+                "warnings": list(warnings or [reason]),
+            }
+        )
+        return MemoryCompanionBridge._add_personal_capability_contract_aliases(result)
 
     def get_token_usage_summary(self) -> dict[str, Any]:
         getter = getattr(self._plugin, "token_usage_summary", None)

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -1178,6 +1178,44 @@ class MemoryCompanionBridge:
     async def get_emotion_trace(self, trace_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
         return await self._plugin.store.get_emotion_trace(trace_id, limit=limit)
 
+    async def get_emotion_trace_diagnostic(
+        self,
+        trace_id: str,
+        requester_context: dict[str, Any],
+        *,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        context = requester_context if type(requester_context) is dict else {}
+        if context.get("is_admin") is not True:
+            return {"state": "forbidden", "read_only": True, "items": [], "error_code": "admin_required"}
+        items = await self._plugin.store.get_emotion_trace_diagnostic(
+            trace_id,
+            bot_id=clean_text(context.get("bot_id"), 160),
+            scope=clean_text(context.get("scope"), 24),
+            session_id=clean_text(context.get("session_id"), 220),
+            limit=max(1, min(100, int(limit or 100))),
+        )
+        return {"state": "ready", "read_only": True, "items": items}
+
+    async def get_emotion_trace_summary(
+        self,
+        requester_context: dict[str, Any],
+        *,
+        cursor: str = "",
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        context = requester_context if type(requester_context) is dict else {}
+        if context.get("is_admin") is not True:
+            return {"state": "forbidden", "read_only": True, "items": [], "next_cursor": "", "error_code": "admin_required"}
+        result = await self._plugin.store.get_emotion_trace_summary(
+            bot_id=clean_text(context.get("bot_id"), 160),
+            scope=clean_text(context.get("scope"), 24),
+            session_id=clean_text(context.get("session_id"), 220),
+            cursor=clean_text(cursor, 20),
+            limit=max(1, min(100, int(limit or 20))),
+        )
+        return {"state": "ready", "read_only": True, **result}
+
     async def search_open_loops(self, *, session_id: str = "", limit: int = 3) -> list[dict[str, Any]]:
         """Search for unresolved open-loop / promise memories for proactive companionship."""
         return await self._plugin.bridge_search_open_loops(session_id=session_id, limit=limit)

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -67,6 +67,7 @@ _COMPANION_EXPRESSION_REASON_CODES = {
     "low_energy_expression_cap",
     "down_mood_expression_cap",
     "up_mood_expression_lift",
+    "affect_modulation_applied",
     "relationship_proactive_cap",
     "interaction_proactive_suppressed",
     "schedule_proactive_suppressed",

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -33,7 +33,13 @@ _COMPANION_INTERACTION_BANDS = {
     "close",
     "affectionate",
 }
-_COMPANION_EXPRESSION_CONTRACT = "companion_interaction_expression.v1"
+_COMPANION_EXPRESSION_CONTRACTS = {"companion_interaction_expression.v1", "companion_interaction_expression.v2"}
+_COMPANION_EXPRESSION_PACING = {"slow", "steady", "bright"}
+_COMPANION_EXPRESSION_DIRECTNESS = {"indirect", "natural", "direct"}
+_COMPANION_EXPRESSION_VALIDATION = {"none", "acknowledge", "support_first"}
+_COMPANION_EXPRESSION_DISCLOSURE = {"none", "light", "allowed"}
+_COMPANION_EXPRESSION_HUMOR = {"off", "light", "playful"}
+_COMPANION_EXPRESSION_TOPIC = {"reply_only", "followup", "shared_topic"}
 _COMPANION_EXPRESSION_BEHAVIORS = {
     "acknowledge",
     "brief_reply",
@@ -80,7 +86,7 @@ def sanitize_companion_expression_decision(value: Any) -> dict[str, Any]:
     """Accept only the bounded, request-scoped Companion expression contract."""
 
     fallback = {"status": "invalid", "read_only": True, "decision": {}}
-    if type(value) is not dict or value.get("contract") != _COMPANION_EXPRESSION_CONTRACT:
+    if type(value) is not dict or value.get("contract") not in _COMPANION_EXPRESSION_CONTRACTS:
         return fallback
     expression_band = value.get("expression_band")
     if type(expression_band) is not str or expression_band not in _COMPANION_INTERACTION_BANDS:
@@ -105,16 +111,33 @@ def sanitize_companion_expression_decision(value: Any) -> dict[str, Any]:
         return fallback
     if type(value.get("followup")) is not bool:
         return fallback
+    contract = value.get("contract")
+    dimensions: dict[str, str] = {}
+    if contract == "companion_interaction_expression.v2":
+        dimension_specs = {
+            "pacing": _COMPANION_EXPRESSION_PACING,
+            "directness": _COMPANION_EXPRESSION_DIRECTNESS,
+            "validation_style": _COMPANION_EXPRESSION_VALIDATION,
+            "self_disclosure": _COMPANION_EXPRESSION_DISCLOSURE,
+            "humor_mode": _COMPANION_EXPRESSION_HUMOR,
+            "topic_initiative": _COMPANION_EXPRESSION_TOPIC,
+        }
+        for key, allowed in dimension_specs.items():
+            item = value.get(key)
+            if type(item) is not str or item not in allowed:
+                return fallback
+            dimensions[key] = item
     return {
         "status": "accepted",
         "read_only": True,
         "decision": {
-            "contract": _COMPANION_EXPRESSION_CONTRACT,
+            "contract": contract,
             "expression_band": expression_band,
             "allowed_behaviors": list(allowed_behaviors),
             "safety_mode": safety_mode,
             "blocker": blocker,
             "reason_codes": list(reason_codes),
+            **dimensions,
         },
     }
 

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -5,7 +5,9 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from . import bot_personal_contract
+from .context_consumer import consume_context_projection
 from .models import EntityRef, MemoryRecord, SessionContext, clean_text
+from .person_projection import consume_person_projection
 
 
 LOCAL_TZ = ZoneInfo("Asia/Shanghai")
@@ -310,6 +312,38 @@ class MemoryCompanionBridge:
         result.setdefault("degraded", False)
         return result
 
+    def consume_person_projection(
+        self,
+        projection: Any,
+        expected_identity_key: str = "",
+        expected_person_id: str = "",
+        *,
+        companion_available: bool = True,
+    ) -> dict[str, Any]:
+        """Validate a companion-owned person projection without writing memory state."""
+        return consume_person_projection(
+            projection,
+            expected_identity_key=expected_identity_key,
+            expected_person_id=expected_person_id,
+            companion_available=companion_available,
+        )
+
+    def consume_context_projection(
+        self,
+        context: Any,
+        expected_person_id: str = "",
+        expected_scope: str = "",
+        *,
+        companion_available: bool = True,
+    ) -> dict[str, Any]:
+        """Validate a P3 projection without creating people or storing raw text."""
+        return consume_context_projection(
+            context,
+            expected_person_id=expected_person_id,
+            expected_scope=expected_scope,
+            companion_available=companion_available,
+        )
+
     def probe_bot_personal_memory_capabilities(self) -> dict[str, Any]:
         """Return a database-free capability snapshot for the bot-personal contract.
 
@@ -385,6 +419,8 @@ class MemoryCompanionBridge:
                 "compose_context",
                 "remember",
                 "recall",
+                "consume_person_projection",
+                "consume_context_projection",
                 "probe_bot_personal_memory_capabilities",
             ],
         )

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -1094,8 +1094,38 @@ class MemoryCompanionBridge:
         return await self._plugin.store.update_memory_visibility(memory_id, visibility)
 
     def get_emotional_events(self, *, session_id: str = "", limit: int = 5) -> list[dict[str, Any]]:
-        """Retrieve pending emotional drift events for the companion plugin."""
+        """Legacy read-and-remove compatibility path; new consumers use list/ack."""
         return self._plugin.bridge_get_emotional_events(session_id=session_id, limit=limit)
+
+    async def list_emotion_events(
+        self,
+        *,
+        consumer_id: str,
+        cursor: str = "",
+        session_id: str = "",
+        exclude_session_id: str = "",
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        """List redacted pending afterglow events without consuming them."""
+        return await self._plugin.store.list_emotion_event_deliveries(
+            consumer_id=consumer_id,
+            cursor=cursor,
+            session_id=session_id,
+            exclude_session_id=exclude_session_id,
+            limit=limit,
+        )
+
+    async def ack_emotion_events(
+        self,
+        event_refs: list[dict[str, Any]],
+        *,
+        consumer_id: str,
+    ) -> dict[str, Any]:
+        """Acknowledge only events durably applied by the named consumer."""
+        return await self._plugin.store.ack_emotion_event_deliveries(
+            consumer_id=consumer_id,
+            event_refs=event_refs,
+        )
 
     async def record_emotion_event(self, event: dict[str, Any]) -> dict[str, Any]:
         """Persist one redacted event revision outside normal memory retrieval."""
@@ -1198,7 +1228,13 @@ class MemoryCompanionBridge:
             projection["touch_count"] = touch_count
         return projection
 
-    def get_recent_emotional_state(self) -> dict[str, Any]:
+    def get_recent_emotional_state(
+        self,
+        *,
+        exclude_session_id: str = "",
+        window_seconds: float = 1800.0,
+        limit: int = 5,
+    ) -> dict[str, Any]:
         """Return a summary of recent emotional events across ALL sessions.
 
         This provides cross-window emotional continuity for the companion plugin:
@@ -1208,7 +1244,11 @@ class MemoryCompanionBridge:
         getter = getattr(self._plugin, "_get_cross_window_emotional_state", None)
         if not callable(getter):
             return {"total": 0, "scar_count": 0, "warm_count": 0, "vulnerable_count": 0}
-        return getter()
+        return getter(
+            exclude_session_id=exclude_session_id,
+            window_seconds=window_seconds,
+            limit=limit,
+        )
 
     def _entity(self, payload: dict[str, Any]) -> EntityRef:
         return EntityRef(

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -479,6 +479,86 @@ class MemoryCompanionBridge:
             "items": safe_items,
         }
 
+    async def read_user_memory_summary(
+        self,
+        user_id: str,
+        *,
+        session_id: str = "",
+        limit: int = 6,
+    ) -> dict[str, Any]:
+        """Read a strict, exact-user Memory summary without exposing memory text."""
+
+        identity = clean_text(user_id, 120)
+        safe_session = clean_text(session_id, 200)
+        base = {
+            "contract": "memory.user_memory_summary.v1",
+            "ok": False,
+            "read_only": True,
+            "state": "degraded",
+            "degraded": True,
+            "pending": True,
+            "user_id": identity,
+            "session_id": safe_session,
+            "counts": {"profile": 0, "preference": 0, "relationship": 0, "private_conversation": 0, "other": 0, "total": 0},
+            "summaries": [],
+            "workspace": {"kind": "memory_user_workspace", "route_hint": "user_memory", "user_id": identity},
+        }
+        if not identity:
+            return {**base, "error_code": "missing_user_id"}
+        try:
+            getter = getattr(self._plugin, "read_user_memory_summary", None)
+        except Exception:
+            getter = None
+        if not callable(getter):
+            return {**base, "error_code": "bridge_method_unavailable"}
+        try:
+            result = await getter(identity, session_id=safe_session, limit=limit)
+        except Exception:
+            return {**base, "error_code": "bridge_exception"}
+        if not isinstance(result, dict) or result.get("contract") != base["contract"]:
+            return {**base, "error_code": "invalid_bridge_response"}
+
+        counts = dict(base["counts"])
+        raw_counts = result.get("counts") if isinstance(result.get("counts"), dict) else {}
+        for key in counts:
+            try:
+                counts[key] = max(0, int(raw_counts.get(key, 0)))
+            except (TypeError, ValueError, OverflowError):
+                counts[key] = 0
+        summaries: list[dict[str, Any]] = []
+        for item in result.get("summaries", []) if isinstance(result.get("summaries"), list) else []:
+            if not isinstance(item, dict):
+                continue
+            category = clean_text(item.get("category"), 40)
+            if category not in {"profile", "preference", "relationship", "private_conversation", "other"}:
+                continue
+            summaries.append(
+                {
+                    "category": category,
+                    "memory_type": clean_text(item.get("memory_type"), 80),
+                    "occurred_at": clean_text(item.get("occurred_at"), 80),
+                    "summary": clean_text(item.get("summary"), 100),
+                    "content_redacted": True,
+                    "truncated": True,
+                }
+            )
+            if len(summaries) >= 8:
+                break
+        state = clean_text(result.get("state"), 40)
+        return {
+            **base,
+            "ok": bool(result.get("ok")) and state == "ready",
+            "state": "ready" if state == "ready" else "degraded",
+            "degraded": state != "ready" or bool(result.get("degraded", False)),
+            "pending": state != "ready" or bool(result.get("pending", False)),
+            "user_id": identity,
+            "session_id": safe_session,
+            "counts": counts,
+            "summaries": summaries,
+            "workspace": base["workspace"],
+            **({"error_code": clean_text(result.get("error_code"), 80)} if state != "ready" and clean_text(result.get("error_code"), 80) else {}),
+        }
+
     async def search_bot_personal_profile(self, query: str = "", *, limit: int = 10) -> dict[str, Any]:
         return await self.read_bot_personal_profile(query=query, limit=limit)
 

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -619,6 +619,66 @@ class MemoryCompanionBridge:
         ctx = normalizer(payload) if callable(normalizer) else SessionContext(**payload)
         return getter(ctx)
 
+    def peek_relationship_phase(
+        self,
+        *,
+        session_id: str = "",
+        scope: str = "private",
+        platform: str = "",
+        user_id: str = "",
+        group_id: str = "",
+        bot_id: str = "",
+    ) -> dict[str, Any]:
+        """Read an existing phase projection without creating default state."""
+        fallback = {"observed": False, "phase": "unknown", "momentum_band": "unknown"}
+        payload = {
+            "session_id": session_id,
+            "scope": scope,
+            "platform": platform,
+            "user_id": user_id,
+            "group_id": group_id,
+            "bot_id": bot_id,
+        }
+        if any(type(value) is not str for value in payload.values()):
+            return fallback
+        try:
+            getter = getattr(self._plugin, "_peek_relationship_phase", None)
+            if not callable(getter):
+                return fallback
+            normalizer = getattr(self._plugin, "session_context_from_bridge", None)
+            ctx = normalizer(payload) if callable(normalizer) else SessionContext(**payload)
+            result = getter(ctx)
+        except Exception:
+            return fallback
+        if type(result) is not dict:
+            return fallback
+        for key in result:
+            if type(key) is not str:
+                return fallback
+
+        observed = result.get("observed")
+        phase = result.get("phase")
+        momentum_band = result.get("momentum_band")
+        if type(observed) is not bool or type(phase) is not str or type(momentum_band) is not str:
+            return fallback
+        if phase not in {"acquaintance", "familiar", "close", "intimate", "deeply_bonded"}:
+            return fallback
+        if momentum_band not in {"rising", "cooling", "steady"}:
+            return fallback
+        if not observed:
+            return fallback
+        projection: dict[str, Any] = {
+            "observed": True,
+            "phase": phase,
+            "momentum_band": momentum_band,
+        }
+        touch_count = result.get("touch_count")
+        if touch_count is not None:
+            if type(touch_count) is not int or not 0 <= touch_count <= 256:
+                return fallback
+            projection["touch_count"] = touch_count
+        return projection
+
     def get_recent_emotional_state(self) -> dict[str, Any]:
         """Return a summary of recent emotional events across ALL sessions.
 

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -5,6 +5,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from . import bot_personal_contract
+from .bot_personal_dto import BotPersonalArchiveDTO, build_bot_personal_archive
 from .context_consumer import consume_context_projection
 from .models import EntityRef, MemoryRecord, SessionContext, clean_text
 from .person_projection import consume_person_projection
@@ -228,6 +229,91 @@ class MemoryCompanionBridge:
         kwargs.setdefault("tags", ["schedule", "persona_life"])
         kwargs.setdefault("importance", 0.45)
         return await self.record_event(content=content, **kwargs)
+
+    async def record_bot_personal_archive(self, envelope: BotPersonalArchiveDTO | dict[str, Any]) -> dict[str, Any]:
+        """Send one validated Bot Personal archive envelope without leaking failures."""
+        base = {
+            "ok": False,
+            "record_id": "",
+            "deduplicated": False,
+            "version": 0,
+            "error_code": None,
+            "state": "degraded",
+        }
+        try:
+            dto = build_bot_personal_archive(envelope)
+        except Exception as exc:
+            return {**base, "state": "invalid", "error_code": getattr(exc, "error_code", "invalid")}
+        try:
+            recorder = getattr(self._plugin, "record_bot_personal_archive", None)
+        except Exception:
+            recorder = None
+        if not callable(recorder):
+            return {**base, "error_code": "bridge_method_unavailable", "state": "degraded"}
+        try:
+            result = await recorder(dto)
+        except Exception:
+            return {**base, "error_code": "bridge_exception", "state": "degraded"}
+        if not isinstance(result, dict):
+            return {**base, "error_code": "invalid_bridge_response", "state": "degraded"}
+        normalized = dict(base)
+        for key in base:
+            if key in result:
+                normalized[key] = result[key]
+        normalized["ok"] = bool(result.get("ok"))
+        normalized["deduplicated"] = bool(result.get("deduplicated"))
+        normalized["version"] = int(result.get("version") or 0)
+        if normalized["ok"]:
+            normalized["state"] = "deduplicated" if normalized["deduplicated"] else "sent"
+        elif normalized["state"] == "ready":
+            normalized["state"] = "degraded"
+        return normalized
+
+    async def record_bot_personal_memory(self, *, memory_type: str, payload: dict[str, Any] | None = None, **kwargs: Any) -> dict[str, Any]:
+        """Compatibility alias that still crosses the structured archive boundary."""
+        try:
+            envelope = build_bot_personal_archive(memory_type=memory_type, payload=payload or {}, **kwargs)
+        except Exception as exc:
+            return {
+                "ok": False, "record_id": "", "deduplicated": False, "version": 0,
+                "error_code": getattr(exc, "error_code", "invalid"), "state": "invalid",
+            }
+        return await self.record_bot_personal_archive(envelope)
+
+    async def read_bot_personal_profile(self, query: str = "", *, limit: int = 10) -> dict[str, Any]:
+        """Read only safe Bot Personal summaries; never return archive payloads."""
+        base = {"ok": False, "read_only": True, "state": "degraded", "degraded": True, "pending": True, "items": []}
+        try:
+            getter = getattr(self._plugin, "read_bot_personal_profile", None)
+        except Exception:
+            getter = None
+        if not callable(getter):
+            return {**base, "error_code": "bridge_method_unavailable"}
+        try:
+            result = await getter(query=query, limit=limit)
+        except Exception:
+            return {**base, "error_code": "bridge_exception"}
+        if not isinstance(result, dict):
+            return {**base, "error_code": "invalid_bridge_response"}
+        safe_keys = {
+            "record_id", "memory_type", "memory_domain", "subject", "date", "window", "occurred_at",
+            "source_kind", "source_refs", "evidence_level", "status", "version", "summary", "reference",
+        }
+        items = result.get("items", result.get("memories", []))
+        safe_items: list[dict[str, Any]] = []
+        for item in items if isinstance(items, list) else []:
+            if not isinstance(item, dict):
+                continue
+            safe_items.append({key: item[key] for key in safe_keys if key in item and key not in {"payload", "content"}})
+        return {
+            "ok": bool(result.get("ok", True)), "read_only": True,
+            "state": "ready" if result.get("state") in (None, "ready") else result.get("state"),
+            "degraded": bool(result.get("degraded", False)), "pending": bool(result.get("pending", False)),
+            "items": safe_items,
+        }
+
+    async def search_bot_personal_profile(self, query: str = "", *, limit: int = 10) -> dict[str, Any]:
+        return await self.read_bot_personal_profile(query=query, limit=limit)
 
     async def search(
         self,

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -932,12 +932,9 @@ class MemoryCompanionBridge:
         result["capability_schema_version"] = bot_personal_contract.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION
         result["payload_schema_version"] = bot_personal_contract.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION
         result["capability_state"] = "available"
-        p5_status = getattr(self._plugin, "p5_capability_status", None)
-        if callable(p5_status):
-            try:
-                result["p5"] = dict(p5_status() or {})
-            except Exception:
-                result["p5"] = {"state": "degraded", "error_code": "p5_status_exception"}
+        # Capability discovery must remain static: callers use it before the
+        # plugin service is safe to query, and C1 guarantees no storage access.
+        result["p5"] = {"state": "unprobed", "error_code": "p5_status_not_probed"}
         self._capability_cache.mark_available(c4_snapshot)
         result.setdefault("warnings", [])
         return result

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -24,6 +24,98 @@ _COMPANION_RELATIONSHIP_PHASES = {
     "intimate",
     "deeply_bonded",
 }
+_COMPANION_INTERACTION_BANDS = {
+    "avoidant",
+    "hurt",
+    "relaxed",
+    "lively",
+    "warm",
+    "close",
+    "affectionate",
+}
+_COMPANION_EXPRESSION_CONTRACT = "companion_interaction_expression.v1"
+_COMPANION_EXPRESSION_BEHAVIORS = {
+    "acknowledge",
+    "brief_reply",
+    "give_space",
+    "reply",
+    "clarify",
+    "light_humor",
+    "followup",
+    "support",
+    "shared_ritual",
+    "affectionate_expression",
+}
+_COMPANION_EXPRESSION_SAFETY_MODES = {
+    "normal",
+    "contact_boundary_passive",
+    "contact_boundary",
+    "p4_blocked",
+}
+_COMPANION_EXPRESSION_BLOCKERS = {"contact_boundary", "p4_safety"}
+_COMPANION_EXPRESSION_REASON_CODES = {
+    "relationship_baseline_retained",
+    "interaction_band_applied",
+    "administrator_override_applied",
+    "owner_role_required",
+    "contact_boundary_passive_reengagement",
+    "p4_warmth_cap_applied",
+    "relationship_tone_applied",
+    "relationship_address_applied",
+    "relationship_followup_cap",
+    "intent_followup_suppressed",
+    "low_energy_expression_cap",
+    "down_mood_expression_cap",
+    "up_mood_expression_lift",
+    "relationship_proactive_cap",
+    "interaction_proactive_suppressed",
+    "schedule_proactive_suppressed",
+    "p4_blocked",
+    "contact_boundary",
+}
+
+
+def sanitize_companion_expression_decision(value: Any) -> dict[str, Any]:
+    """Accept only the bounded, request-scoped Companion expression contract."""
+
+    fallback = {"status": "invalid", "read_only": True, "decision": {}}
+    if type(value) is not dict or value.get("contract") != _COMPANION_EXPRESSION_CONTRACT:
+        return fallback
+    expression_band = value.get("expression_band")
+    if type(expression_band) is not str or expression_band not in _COMPANION_INTERACTION_BANDS:
+        return fallback
+    allowed_behaviors = value.get("allowed_behaviors")
+    if type(allowed_behaviors) not in {list, tuple} or len(allowed_behaviors) > 12:
+        return fallback
+    if any(type(item) is not str or item not in _COMPANION_EXPRESSION_BEHAVIORS for item in allowed_behaviors):
+        return fallback
+    if len(set(allowed_behaviors)) != len(allowed_behaviors):
+        return fallback
+    safety_mode = value.get("safety_mode")
+    if type(safety_mode) is not str or safety_mode not in _COMPANION_EXPRESSION_SAFETY_MODES:
+        return fallback
+    blocker = value.get("blocker")
+    if blocker is not None and (type(blocker) is not str or blocker not in _COMPANION_EXPRESSION_BLOCKERS):
+        return fallback
+    reason_codes = value.get("reason_codes")
+    if type(reason_codes) not in {list, tuple} or len(reason_codes) > 24:
+        return fallback
+    if any(type(item) is not str or item not in _COMPANION_EXPRESSION_REASON_CODES for item in reason_codes):
+        return fallback
+    if type(value.get("followup")) is not bool:
+        return fallback
+    return {
+        "status": "accepted",
+        "read_only": True,
+        "decision": {
+            "contract": _COMPANION_EXPRESSION_CONTRACT,
+            "expression_band": expression_band,
+            "allowed_behaviors": list(allowed_behaviors),
+            "safety_mode": safety_mode,
+            "blocker": blocker,
+            "reason_codes": list(reason_codes),
+        },
+    }
 
 
 def sanitize_companion_relationship_projection(value: Any) -> dict[str, Any]:
@@ -67,6 +159,20 @@ def sanitize_companion_relationship_projection(value: Any) -> dict[str, Any]:
             )
         },
     }
+    relationship_mode = value.get("relationship_mode")
+    if relationship_mode in {"normal", "owner_exclusive"}:
+        projection["relationship_mode"] = relationship_mode
+    current_interaction = value.get("current_interaction")
+    if type(current_interaction) is dict:
+        expression_band = current_interaction.get("expression_band")
+        if type(expression_band) is str and expression_band in _COMPANION_INTERACTION_BANDS:
+            projection["current_interaction"] = {
+                "expression_band": expression_band,
+                "label": clean_text(current_interaction.get("label"), 40),
+                "source": clean_text(current_interaction.get("source"), 40),
+                "reason": clean_text(current_interaction.get("reason"), 120),
+                "manual_override": current_interaction.get("manual_override") is True,
+            }
     return {"status": "accepted", "read_only": True, "projection": projection}
 
 

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -391,8 +391,16 @@ class MemoryCompanionBridge:
         *,
         session_context: SessionContext | dict[str, Any] | None = None,
         top_k: int | None = None,
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
     ) -> list[dict[str, Any]]:
-        return await self._plugin.bridge_search(query, session_context=session_context, top_k=top_k)
+        return await self._plugin.bridge_search(
+            query,
+            session_context=session_context,
+            top_k=top_k,
+            p5_attestation=p5_attestation,
+            p5_attestation_consumer=p5_attestation_consumer,
+        )
 
     async def compose_injection(
         self,
@@ -403,6 +411,8 @@ class MemoryCompanionBridge:
         max_chars: int | None = None,
         companion_bot_mood: str = "",
         companion_bot_energy: float = 0.0,
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
     ) -> str:
         return await self._plugin.bridge_compose_injection(
             query,
@@ -411,6 +421,8 @@ class MemoryCompanionBridge:
             max_chars=max_chars,
             companion_bot_mood=companion_bot_mood,
             companion_bot_energy=companion_bot_energy,
+            p5_attestation=p5_attestation,
+            p5_attestation_consumer=p5_attestation_consumer,
         )
 
     async def compose_context(
@@ -423,6 +435,8 @@ class MemoryCompanionBridge:
         companion_bot_mood: str = "",
         companion_bot_energy: float = 0.0,
         retrieval_profile: str = "",
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
     ) -> str:
         return await self._plugin.bridge_compose_context(
             query=query,
@@ -432,13 +446,74 @@ class MemoryCompanionBridge:
             companion_bot_mood=companion_bot_mood,
             companion_bot_energy=companion_bot_energy,
             retrieval_profile=retrieval_profile,
+            p5_attestation=p5_attestation,
+            p5_attestation_consumer=p5_attestation_consumer,
         )
 
     async def remember(self, *, event: Any, content: str, note_type: str = "memory") -> dict[str, Any]:
         return await self._plugin.tool_remember(event, content, note_type=note_type)
 
-    async def recall(self, *, event: Any, query: str, top_k: int = 5) -> dict[str, Any]:
-        return await self._plugin.tool_recall(event, query, top_k=top_k)
+    async def recall(
+        self,
+        *,
+        event: Any,
+        query: str,
+        top_k: int = 5,
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
+    ) -> dict[str, Any]:
+        return await self._plugin.tool_recall(
+            event,
+            query,
+            top_k=top_k,
+            p5_attestation=p5_attestation,
+            p5_attestation_consumer=p5_attestation_consumer,
+        )
+
+    def p5_capability_status(self) -> dict[str, Any]:
+        getter = getattr(self._plugin, "p5_capability_status", None)
+        if not callable(getter):
+            return {"state": "degraded", "error_code": "p5_status_unavailable"}
+        try:
+            result = getter()
+        except Exception:
+            return {"state": "degraded", "error_code": "p5_status_exception"}
+        return dict(result) if isinstance(result, dict) else {"state": "degraded", "error_code": "p5_status_invalid"}
+
+    def provenance_snapshot(self) -> dict[str, Any]:
+        getter = getattr(self._plugin, "provenance_snapshot", None)
+        if not callable(getter):
+            return {"records": {}, "operation_count": 0, "state": "degraded"}
+        result = getter()
+        return dict(result) if isinstance(result, dict) else {"records": {}, "operation_count": 0, "state": "degraded"}
+
+    def provenance_preview(self, candidates: list[dict[str, Any]], *, operation_ref_hash: str) -> dict[str, Any]:
+        getter = getattr(self._plugin, "provenance_preview", None)
+        if not callable(getter):
+            return {"mode": "preview", "readonly": True, "write_count": 0, "error_codes": ["unavailable"]}
+        result = getter(candidates, operation_ref_hash=operation_ref_hash)
+        return dict(result) if isinstance(result, dict) else {"mode": "preview", "readonly": True, "write_count": 0, "error_codes": ["invalid_result"]}
+
+    async def provenance_apply(self, operation: dict[str, Any]) -> dict[str, Any]:
+        getter = getattr(self._plugin, "provenance_apply", None)
+        if not callable(getter):
+            return {"ok": False, "state": "degraded", "error_code": "unavailable"}
+        result = await getter(operation)
+        return dict(result) if isinstance(result, dict) else {"ok": False, "state": "degraded", "error_code": "invalid_result"}
+
+    async def provenance_backup(self) -> dict[str, Any]:
+        getter = getattr(self._plugin, "provenance_backup", None)
+        if not callable(getter):
+            return {"ok": False, "state": "degraded", "error_code": "unavailable"}
+        result = await getter()
+        return dict(result) if isinstance(result, dict) else {"ok": False, "state": "degraded", "error_code": "invalid_result"}
+
+    async def provenance_rollback(self, operation: dict[str, Any]) -> dict[str, Any]:
+        getter = getattr(self._plugin, "provenance_rollback", None)
+        if not callable(getter):
+            return {"ok": False, "state": "degraded", "error_code": "unavailable"}
+        result = await getter(operation)
+        return dict(result) if isinstance(result, dict) else {"ok": False, "state": "degraded", "error_code": "invalid_result"}
 
     async def create_note(self, *, event: Any, title: str, content: str = "") -> dict[str, Any]:
         return await self._plugin.tool_note_create(event, title, content)
@@ -572,6 +647,12 @@ class MemoryCompanionBridge:
         result["capability_schema_version"] = bot_personal_contract.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION
         result["payload_schema_version"] = bot_personal_contract.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION
         result["capability_state"] = "available"
+        p5_status = getattr(self._plugin, "p5_capability_status", None)
+        if callable(p5_status):
+            try:
+                result["p5"] = dict(p5_status() or {})
+            except Exception:
+                result["p5"] = {"state": "degraded", "error_code": "p5_status_exception"}
         self._capability_cache.mark_available(c4_snapshot)
         result.setdefault("warnings", [])
         return result
@@ -632,6 +713,12 @@ class MemoryCompanionBridge:
                 "consume_context_projection",
                 "read_bot_profile",
                 "read_profile",
+                "p5_capability_status",
+                "provenance_snapshot",
+                "provenance_preview",
+                "provenance_apply",
+                "provenance_backup",
+                "provenance_rollback",
                 "probe_capability_snapshot",
                 "probe_bot_personal_memory_capabilities",
             ],
@@ -695,6 +782,7 @@ class MemoryCompanionBridge:
             bot_personal_contract, "BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION", ""
         )
         result["capability_state"] = "degraded"
+        result["p5"] = {"state": "degraded", "error_code": reason}
         return result
 
     def get_token_usage_summary(self) -> dict[str, Any]:

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -589,6 +589,17 @@ class MemoryCompanionBridge:
         """Retrieve pending emotional drift events for the companion plugin."""
         return self._plugin.bridge_get_emotional_events(session_id=session_id, limit=limit)
 
+    async def record_emotion_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        """Persist one redacted event revision outside normal memory retrieval."""
+        return await self._plugin.store.upsert_emotion_event(event)
+
+    async def revise_emotion_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        """Persist a later revision of an existing event."""
+        return await self._plugin.store.upsert_emotion_event(event)
+
+    async def get_emotion_trace(self, trace_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
+        return await self._plugin.store.get_emotion_trace(trace_id, limit=limit)
+
     async def search_open_loops(self, *, session_id: str = "", limit: int = 3) -> list[dict[str, Any]]:
         """Search for unresolved open-loop / promise memories for proactive companionship."""
         return await self._plugin.bridge_search_open_loops(session_id=session_id, limit=limit)

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -17,6 +17,7 @@ LOCAL_TZ = ZoneInfo("Asia/Shanghai")
 _PRIVATE_COMPANION_ROOT = "astrbot_plugin_private_companion"
 _PRIVATE_COMPANION_NAMES = {"PrivateCompanion", "private_companion"}
 _EMOTION_INGRESS_ORIGINS = {"interaction", "system_condition"}
+_EMOTION_DELIVERY_CONSUMER = "private_companion.daily_state"
 
 
 class _EmotionProducerCapability:
@@ -60,6 +61,45 @@ class _EmotionProducerContext:
         self._bridge = bridge
         self._capability = capability
         self.bot_id = bot_id
+        self.platform = platform
+        self.scope = scope
+        self.session_id = session_id
+        self.user_id = user_id
+
+
+class _EmotionDeliveryContext:
+    """Opaque, scoped authorization context for afterglow delivery and ack."""
+
+    __slots__ = (
+        "_bridge",
+        "_capability",
+        "allow_cross_window",
+        "bot_id",
+        "consumer_id",
+        "platform",
+        "scope",
+        "session_id",
+        "user_id",
+    )
+
+    def __init__(
+        self,
+        bridge: Any,
+        capability: _EmotionProducerCapability,
+        *,
+        allow_cross_window: bool,
+        bot_id: str,
+        consumer_id: str,
+        platform: str,
+        scope: str,
+        session_id: str,
+        user_id: str,
+    ) -> None:
+        self._bridge = bridge
+        self._capability = capability
+        self.allow_cross_window = allow_cross_window
+        self.bot_id = bot_id
+        self.consumer_id = consumer_id
         self.platform = platform
         self.scope = scope
         self.session_id = session_id
@@ -347,6 +387,43 @@ class MemoryCompanionBridge:
             return None
         return _EmotionProducerContext(self, capability, **normalized)
 
+    def create_emotion_delivery_context(
+        self,
+        capability: Any,
+        *,
+        bot_id: str,
+        scope: str,
+        platform: str,
+        user_id: str,
+        session_id: str,
+        consumer_id: str = _EMOTION_DELIVERY_CONSUMER,
+        allow_cross_window: bool = False,
+    ) -> Any | None:
+        """Bind Companion afterglow delivery to one trusted private identity domain."""
+
+        if not self._is_valid_emotion_producer_capability(capability):
+            return None
+        if clean_text(consumer_id, 80) != _EMOTION_DELIVERY_CONSUMER:
+            return None
+        if type(allow_cross_window) is not bool:
+            return None
+        normalized = self._normalize_emotion_domain(
+            bot_id=bot_id,
+            scope=scope,
+            platform=platform,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        if normalized is None:
+            return None
+        return _EmotionDeliveryContext(
+            self,
+            capability,
+            consumer_id=_EMOTION_DELIVERY_CONSUMER,
+            allow_cross_window=allow_cross_window,
+            **normalized,
+        )
+
     def bind_emotion_page_api(self, page_api: Any) -> Any | None:
         """Issue a private diagnostic capability to this Memory plugin's Page API."""
 
@@ -446,6 +523,22 @@ class MemoryCompanionBridge:
             type(context) is _EmotionProducerContext
             and context._bridge is self
             and self._is_valid_emotion_producer_capability(context._capability)
+            and self._normalize_emotion_domain(
+                bot_id=context.bot_id,
+                scope=context.scope,
+                platform=context.platform,
+                user_id=context.user_id,
+                session_id=context.session_id,
+            ) is not None
+        )
+
+    def _is_valid_emotion_delivery_context(self, context: Any) -> bool:
+        return (
+            type(context) is _EmotionDeliveryContext
+            and context._bridge is self
+            and self._is_valid_emotion_producer_capability(context._capability)
+            and context.consumer_id == _EMOTION_DELIVERY_CONSUMER
+            and type(context.allow_cross_window) is bool
             and self._normalize_emotion_domain(
                 bot_id=context.bot_id,
                 scope=context.scope,
@@ -1362,18 +1455,24 @@ class MemoryCompanionBridge:
     async def list_emotion_events(
         self,
         *,
-        consumer_id: str,
+        delivery_context: Any = None,
         cursor: str = "",
-        session_id: str = "",
-        exclude_session_id: str = "",
         limit: int = 10,
+        **_legacy: Any,
     ) -> dict[str, Any]:
-        """List redacted pending afterglow events without consuming them."""
+        """List afterglow events only for one opaque Companion delivery context."""
+
+        if not self._is_valid_emotion_delivery_context(delivery_context):
+            return self._emotion_delivery_forbidden_result("delivery_context_required")
         return await self._plugin.store.list_emotion_event_deliveries(
-            consumer_id=consumer_id,
+            consumer_id=delivery_context.consumer_id,
+            bot_id=delivery_context.bot_id,
+            scope=delivery_context.scope,
+            platform=delivery_context.platform,
+            user_id=delivery_context.user_id,
+            session_id=delivery_context.session_id,
+            allow_cross_window=delivery_context.allow_cross_window,
             cursor=cursor,
-            session_id=session_id,
-            exclude_session_id=exclude_session_id,
             limit=limit,
         )
 
@@ -1381,12 +1480,22 @@ class MemoryCompanionBridge:
         self,
         event_refs: list[dict[str, Any]],
         *,
-        consumer_id: str,
+        delivery_context: Any = None,
+        **_legacy: Any,
     ) -> dict[str, Any]:
-        """Acknowledge only events durably applied by the named consumer."""
+        """Acknowledge only events delivered inside one opaque identity domain."""
+
+        if not self._is_valid_emotion_delivery_context(delivery_context):
+            return self._emotion_ack_forbidden_result("delivery_context_required")
         return await self._plugin.store.ack_emotion_event_deliveries(
-            consumer_id=consumer_id,
+            consumer_id=delivery_context.consumer_id,
             event_refs=event_refs,
+            bot_id=delivery_context.bot_id,
+            scope=delivery_context.scope,
+            platform=delivery_context.platform,
+            user_id=delivery_context.user_id,
+            session_id=delivery_context.session_id,
+            allow_cross_window=delivery_context.allow_cross_window,
         )
 
     async def record_emotion_event(
@@ -1477,6 +1586,26 @@ class MemoryCompanionBridge:
             "state": "forbidden",
             "read_only": False,
             "event_id": "",
+            "error_code": error_code,
+        }
+
+    @staticmethod
+    def _emotion_delivery_forbidden_result(error_code: str) -> dict[str, Any]:
+        return {
+            "schema_version": "emotion_afterglow_delivery.v1",
+            "state": "forbidden",
+            "read_only": True,
+            "events": [],
+            "next_cursor": "",
+            "has_more": False,
+            "error_code": error_code,
+        }
+
+    @staticmethod
+    def _emotion_ack_forbidden_result(error_code: str) -> dict[str, Any]:
+        return {
+            "state": "forbidden",
+            "acked": 0,
             "error_code": error_code,
         }
 
@@ -1598,20 +1727,9 @@ class MemoryCompanionBridge:
         window_seconds: float = 1800.0,
         limit: int = 5,
     ) -> dict[str, Any]:
-        """Return a summary of recent emotional events across ALL sessions.
-
-        This provides cross-window emotional continuity for the companion plugin:
-        if the bot recently touched scar or warm memories in any session, the
-        companion plugin can factor this into its daily state calibration.
-        """
-        getter = getattr(self._plugin, "_get_cross_window_emotional_state", None)
-        if not callable(getter):
-            return {"total": 0, "scar_count": 0, "warm_count": 0, "vulnerable_count": 0}
-        return getter(
-            exclude_session_id=exclude_session_id,
-            window_seconds=window_seconds,
-            limit=limit,
-        )
+        """Deprecated unscoped aggregate; opaque delivery contexts are required."""
+        _ = (exclude_session_id, window_seconds, limit)
+        return {"total": 0, "scar_count": 0, "warm_count": 0, "vulnerable_count": 0}
 
     def _entity(self, payload: dict[str, Any]) -> EntityRef:
         return EntityRef(

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -590,22 +590,22 @@ class MemoryCompanionBridge:
                 read_only=False,
             )
         except Exception:
-            return self._degraded_personal_capability_probe("contract_descriptor_exception")
+            return self._negative_personal_capability_probe("contract_descriptor_exception")
 
         if not isinstance(descriptor, dict):
-            return self._degraded_personal_capability_probe("contract_descriptor_invalid")
+            return self._negative_personal_capability_probe("contract_descriptor_invalid")
 
         result = dict(descriptor)
         try:
             problems = bot_personal_contract.contract_self_check()
         except Exception:
-            return self._degraded_personal_capability_probe(
+            return self._negative_personal_capability_probe(
                 "contract_self_check_exception",
                 base=result,
             )
 
         if not isinstance(problems, list):
-            return self._degraded_personal_capability_probe(
+            return self._negative_personal_capability_probe(
                 "contract_self_check_invalid",
                 base=result,
             )
@@ -622,7 +622,7 @@ class MemoryCompanionBridge:
                 code = str(problem).split(":", 1)[0]
                 if code in known_codes and code not in warnings:
                     warnings.append(code)
-            return self._degraded_personal_capability_probe(
+            return self._negative_personal_capability_probe(
                 "contract_self_check_failed",
                 base=result,
                 warnings=warnings,
@@ -725,6 +725,34 @@ class MemoryCompanionBridge:
         )
         result.setdefault("contract_version", str(result.get("contract_revision", "")))
         result.setdefault("schema_version", str(result.get("capability_schema_version", "")))
+        return result
+
+    def _negative_personal_capability_probe(
+        self,
+        reason: str,
+        *,
+        base: dict[str, Any] | None = None,
+        warnings: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Return a bounded failure and suppress repeated probes for the TTL."""
+
+        safe_reason = clean_text(reason, 120) or "capability_negative"
+        result = self._degraded_personal_capability_probe(
+            safe_reason,
+            base=base,
+            warnings=warnings,
+        )
+        cached = self._capability_cache.mark_negative(safe_reason)
+        for key in ("available", "state", "degraded", "pending", "error_code"):
+            if key in cached:
+                result[key] = cached[key]
+        result["available"] = False
+        result["state"] = "negative"
+        result["capability_state"] = "negative"
+        result["degraded"] = True
+        result["pending"] = False
+        result["error_code"] = safe_reason
+        result["p5"] = {"state": "degraded", "error_code": safe_reason}
         return result
 
     @staticmethod

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -14,6 +14,78 @@ from .person_projection import consume_person_projection
 
 LOCAL_TZ = ZoneInfo("Asia/Shanghai")
 
+_PRIVATE_COMPANION_ROOT = "astrbot_plugin_private_companion"
+_PRIVATE_COMPANION_NAMES = {"PrivateCompanion", "private_companion"}
+_EMOTION_INGRESS_ORIGINS = {"interaction", "system_condition"}
+
+
+class _EmotionProducerCapability:
+    """Non-serializable capability bound to one live Companion plugin instance."""
+
+    __slots__ = ("_bridge", "_producer", "_token")
+
+    def __init__(self, bridge: Any, producer: Any, token: object) -> None:
+        self._bridge = bridge
+        self._producer = producer
+        self._token = token
+
+
+class _EmotionPageAdminCapability:
+    """Non-serializable capability bound to this bridge's Page API instance."""
+
+    __slots__ = ("_bridge", "_page_api", "_token")
+
+    def __init__(self, bridge: Any, page_api: Any, token: object) -> None:
+        self._bridge = bridge
+        self._page_api = page_api
+        self._token = token
+
+
+class _EmotionProducerContext:
+    """Opaque, scoped authorization context for Companion emotion ingress."""
+
+    __slots__ = ("_bridge", "_capability", "bot_id", "platform", "scope", "session_id", "user_id")
+
+    def __init__(
+        self,
+        bridge: Any,
+        capability: _EmotionProducerCapability,
+        *,
+        bot_id: str,
+        platform: str,
+        scope: str,
+        session_id: str,
+        user_id: str,
+    ) -> None:
+        self._bridge = bridge
+        self._capability = capability
+        self.bot_id = bot_id
+        self.platform = platform
+        self.scope = scope
+        self.session_id = session_id
+        self.user_id = user_id
+
+
+class _EmotionAdminContext:
+    """Opaque, scoped authorization context for redacted admin diagnostics."""
+
+    __slots__ = ("_bridge", "_capability", "bot_id", "scope", "session_id")
+
+    def __init__(
+        self,
+        bridge: Any,
+        capability: _EmotionPageAdminCapability,
+        *,
+        bot_id: str,
+        scope: str,
+        session_id: str,
+    ) -> None:
+        self._bridge = bridge
+        self._capability = capability
+        self.bot_id = bot_id
+        self.scope = scope
+        self.session_id = session_id
+
 _COMPANION_RELATIONSHIP_PHASES = {
     "deeply_distant",
     "strongly_distant",
@@ -240,6 +312,158 @@ class MemoryCompanionBridge:
     def __init__(self, plugin: Any):
         self._plugin = plugin
         self._capability_cache = CapabilityCache()
+        self._emotion_producer_token = object()
+        self._emotion_page_admin_token = object()
+
+    def register_emotion_producer(self, producer: Any) -> Any | None:
+        """Issue a private Companion capability only to a live registered plugin."""
+
+        if not self._is_registered_private_companion(producer):
+            return None
+        return _EmotionProducerCapability(self, producer, self._emotion_producer_token)
+
+    def create_emotion_producer_context(
+        self,
+        capability: Any,
+        *,
+        bot_id: str,
+        scope: str,
+        platform: str,
+        user_id: str,
+        session_id: str,
+    ) -> Any | None:
+        """Bind a Companion capability to one private user/Bot delivery domain."""
+
+        if not self._is_valid_emotion_producer_capability(capability):
+            return None
+        normalized = self._normalize_emotion_domain(
+            bot_id=bot_id,
+            scope=scope,
+            platform=platform,
+            user_id=user_id,
+            session_id=session_id,
+        )
+        if normalized is None:
+            return None
+        return _EmotionProducerContext(self, capability, **normalized)
+
+    def bind_emotion_page_api(self, page_api: Any) -> Any | None:
+        """Issue a private diagnostic capability to this Memory plugin's Page API."""
+
+        page_plugin = getattr(page_api, "plugin", None)
+        if page_plugin is not self._plugin and getattr(page_plugin, "service", None) is not self._plugin:
+            return None
+        return _EmotionPageAdminCapability(self, page_api, self._emotion_page_admin_token)
+
+    def create_emotion_admin_context(
+        self,
+        capability: Any,
+        *,
+        bot_id: str,
+        scope: str,
+        session_id: str,
+    ) -> Any | None:
+        """Create a scoped redacted-diagnostic context after page auth succeeds."""
+
+        if not self._is_valid_emotion_page_admin_capability(capability):
+            return None
+        normalized_bot_id = clean_text(bot_id, 160)
+        normalized_scope = clean_text(scope, 24).lower()
+        normalized_session_id = clean_text(session_id, 220)
+        if not normalized_bot_id or normalized_scope not in {"private", "group"} or not normalized_session_id:
+            return None
+        return _EmotionAdminContext(
+            self,
+            capability,
+            bot_id=normalized_bot_id,
+            scope=normalized_scope,
+            session_id=normalized_session_id,
+        )
+
+    def _is_registered_private_companion(self, producer: Any) -> bool:
+        context = getattr(self._plugin, "context", None)
+        getter = getattr(context, "get_all_stars", None)
+        if not callable(getter):
+            return False
+        try:
+            stars = getter()
+        except Exception:
+            return False
+        if not isinstance(stars, (list, tuple)):
+            return False
+        for metadata in stars:
+            if getattr(metadata, "star_cls", None) is not producer:
+                continue
+            if getattr(metadata, "activated", True) is not True:
+                continue
+            root = clean_text(getattr(metadata, "root_dir_name", ""), 120)
+            name = clean_text(getattr(metadata, "name", ""), 120)
+            if root == _PRIVATE_COMPANION_ROOT or name in _PRIVATE_COMPANION_NAMES:
+                return True
+        return False
+
+    def _is_valid_emotion_producer_capability(self, capability: Any) -> bool:
+        return (
+            type(capability) is _EmotionProducerCapability
+            and capability._bridge is self
+            and capability._token is self._emotion_producer_token
+            and self._is_registered_private_companion(capability._producer)
+        )
+
+    def _is_valid_emotion_page_admin_capability(self, capability: Any) -> bool:
+        return (
+            type(capability) is _EmotionPageAdminCapability
+            and capability._bridge is self
+            and capability._token is self._emotion_page_admin_token
+            and (
+                getattr(capability._page_api, "plugin", None) is self._plugin
+                or getattr(getattr(capability._page_api, "plugin", None), "service", None) is self._plugin
+            )
+        )
+
+    @staticmethod
+    def _normalize_emotion_domain(
+        *,
+        bot_id: Any,
+        scope: Any,
+        platform: Any,
+        user_id: Any,
+        session_id: Any,
+    ) -> dict[str, str] | None:
+        normalized = {
+            "bot_id": clean_text(bot_id, 160),
+            "scope": clean_text(scope, 24).lower(),
+            "platform": clean_text(platform, 80),
+            "user_id": clean_text(user_id, 160),
+            "session_id": clean_text(session_id, 220),
+        }
+        if not all(normalized.values()) or normalized["scope"] != "private":
+            return None
+        return normalized
+
+    def _is_valid_emotion_producer_context(self, context: Any) -> bool:
+        return (
+            type(context) is _EmotionProducerContext
+            and context._bridge is self
+            and self._is_valid_emotion_producer_capability(context._capability)
+            and self._normalize_emotion_domain(
+                bot_id=context.bot_id,
+                scope=context.scope,
+                platform=context.platform,
+                user_id=context.user_id,
+                session_id=context.session_id,
+            ) is not None
+        )
+
+    def _is_valid_emotion_admin_context(self, context: Any) -> bool:
+        return (
+            type(context) is _EmotionAdminContext
+            and context._bridge is self
+            and self._is_valid_emotion_page_admin_capability(context._capability)
+            and bool(clean_text(context.bot_id, 160))
+            and clean_text(context.scope, 24).lower() in {"private", "group"}
+            and bool(clean_text(context.session_id, 220))
+        )
 
     def consume_relationship_projection(self, projection: Any) -> dict[str, Any]:
         """Validate a read-only Companion relationship projection without persisting it."""
@@ -1131,8 +1355,9 @@ class MemoryCompanionBridge:
         return await self._plugin.store.update_memory_visibility(memory_id, visibility)
 
     def get_emotional_events(self, *, session_id: str = "", limit: int = 5) -> list[dict[str, Any]]:
-        """Legacy read-and-remove compatibility path; new consumers use list/ack."""
-        return self._plugin.bridge_get_emotional_events(session_id=session_id, limit=limit)
+        """Deprecated unscoped API; callers must migrate to a capability context."""
+        _ = (session_id, limit)
+        return []
 
     async def list_emotion_events(
         self,
@@ -1164,54 +1389,117 @@ class MemoryCompanionBridge:
             event_refs=event_refs,
         )
 
-    async def record_emotion_event(self, event: dict[str, Any]) -> dict[str, Any]:
-        """Persist one redacted event revision outside normal memory retrieval."""
-        return await self._plugin.store.upsert_emotion_event(event)
+    async def record_emotion_event(
+        self,
+        event: dict[str, Any],
+        *,
+        producer_context: Any = None,
+    ) -> dict[str, Any]:
+        """Persist a Companion event only inside an attested private user/Bot domain."""
 
-    async def revise_emotion_event(self, event: dict[str, Any]) -> dict[str, Any]:
-        """Persist a later revision of an existing event."""
-        return await self._plugin.store.upsert_emotion_event(event)
+        if not self._is_valid_emotion_producer_context(producer_context):
+            return self._emotion_forbidden_result("producer_context_required")
+        return await self._plugin.store.upsert_emotion_event(
+            self._attested_emotion_event(event, producer_context)
+        )
 
-    async def get_emotion_trace(self, trace_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
-        return await self._plugin.store.get_emotion_trace(trace_id, limit=limit)
+    async def revise_emotion_event(
+        self,
+        event: dict[str, Any],
+        *,
+        producer_context: Any = None,
+    ) -> dict[str, Any]:
+        """Persist a later Companion revision only inside its attested domain."""
+
+        if not self._is_valid_emotion_producer_context(producer_context):
+            return self._emotion_forbidden_result("producer_context_required")
+        return await self._plugin.store.upsert_emotion_event(
+            self._attested_emotion_event(event, producer_context)
+        )
+
+    async def get_emotion_trace(
+        self,
+        trace_id: str,
+        *,
+        requester_context: Any = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """Return only the scoped, redacted diagnostic projection for a trusted admin."""
+
+        return await self.get_emotion_trace_diagnostic(
+            trace_id,
+            requester_context,
+            limit=limit,
+        )
 
     async def get_emotion_trace_diagnostic(
         self,
         trace_id: str,
-        requester_context: dict[str, Any],
+        requester_context: Any,
         *,
         limit: int = 100,
     ) -> dict[str, Any]:
-        context = requester_context if type(requester_context) is dict else {}
-        if context.get("is_admin") is not True:
+        context = requester_context
+        if not self._is_valid_emotion_admin_context(context):
             return {"state": "forbidden", "read_only": True, "items": [], "error_code": "admin_required"}
         items = await self._plugin.store.get_emotion_trace_diagnostic(
             trace_id,
-            bot_id=clean_text(context.get("bot_id"), 160),
-            scope=clean_text(context.get("scope"), 24),
-            session_id=clean_text(context.get("session_id"), 220),
+            bot_id=context.bot_id,
+            scope=context.scope,
+            session_id=context.session_id,
             limit=max(1, min(100, int(limit or 100))),
         )
         return {"state": "ready", "read_only": True, "items": items}
 
     async def get_emotion_trace_summary(
         self,
-        requester_context: dict[str, Any],
+        requester_context: Any,
         *,
         cursor: str = "",
         limit: int = 20,
     ) -> dict[str, Any]:
-        context = requester_context if type(requester_context) is dict else {}
-        if context.get("is_admin") is not True:
+        context = requester_context
+        if not self._is_valid_emotion_admin_context(context):
             return {"state": "forbidden", "read_only": True, "items": [], "next_cursor": "", "error_code": "admin_required"}
         result = await self._plugin.store.get_emotion_trace_summary(
-            bot_id=clean_text(context.get("bot_id"), 160),
-            scope=clean_text(context.get("scope"), 24),
-            session_id=clean_text(context.get("session_id"), 220),
+            bot_id=context.bot_id,
+            scope=context.scope,
+            session_id=context.session_id,
             cursor=clean_text(cursor, 20),
             limit=max(1, min(100, int(limit or 20))),
         )
         return {"state": "ready", "read_only": True, **result}
+
+    @staticmethod
+    def _emotion_forbidden_result(error_code: str) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "state": "forbidden",
+            "read_only": False,
+            "event_id": "",
+            "error_code": error_code,
+        }
+
+    @staticmethod
+    def _attested_emotion_event(event: Any, context: _EmotionProducerContext) -> dict[str, Any]:
+        source = dict(event) if isinstance(event, dict) else {}
+        origin = clean_text(source.get("origin_kind"), 40).lower()
+        if origin not in _EMOTION_INGRESS_ORIGINS:
+            origin = "interaction"
+        source.update(
+            {
+                "producer_plugin": "private_companion",
+                "origin_kind": origin,
+                "bot_id": context.bot_id,
+                "scope": context.scope,
+                "platform": context.platform,
+                "session_id": context.session_id,
+                "actor_ref": {"kind": "user", "id": context.user_id, "role": "speaker"},
+                "target_ref": {"kind": "bot", "id": context.bot_id, "role": "bot_self"},
+                "quoted_target_ref": {},
+            }
+        )
+        return source
 
     async def search_open_loops(self, *, session_id: str = "", limit: int = 3) -> list[dict[str, Any]]:
         """Search for unresolved open-loop / promise memories for proactive companionship."""

--- a/core/capability_probe.py
+++ b/core/capability_probe.py
@@ -1,0 +1,242 @@
+"""Database-free capability state and negative-cache helpers for C4.
+
+This module deliberately knows only about the shared bot-personal contract.  It
+does not inspect plugin modules, touch storage, or perform capability probing
+itself; callers can use the cache to decide when a probe is worth attempting.
+"""
+
+from __future__ import annotations
+
+import copy
+import time
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+CAPABILITY_STATES = ("unprobed", "available", "degraded", "negative")
+
+# Stable C4 capability profiles.  Keep this tuple closed: callers may report
+# only profiles understood by both companion plugins.
+PROFILE_NAMES = (
+    "bot_schedule_current",
+    "bot_schedule_history",
+    "bot_creative",
+    "bot_subjective",
+    "locked_frame_personal",
+)
+
+_SNAPSHOT_KEYS = (
+    "available",
+    "state",
+    "degraded",
+    "pending",
+    "contract_fingerprint",
+    "contract_version",
+    "schema_version",
+    "windows",
+    "memory_types",
+    "domains",
+    "profiles",
+    "methods",
+    "warnings",
+    "error_code",
+)
+_MAX_ITEMS = 64
+_MAX_TEXT = 256
+
+
+def _text(value: object, *, limit: int = _MAX_TEXT) -> str:
+    try:
+        return str(value or "")[:limit]
+    except Exception:
+        return ""
+
+
+def _unique_texts(values: object, *, allowed: set[str] | None = None) -> list[str]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Iterable):
+        return []
+    result: list[str] = []
+    try:
+        for value in values:
+            item = _text(value)
+            if not item or (allowed is not None and item not in allowed) or item in result:
+                continue
+            result.append(item)
+            if len(result) >= _MAX_ITEMS:
+                break
+    except Exception:
+        return result
+    return result
+
+
+def _contract_value(module: object, name: str, default: object) -> object:
+    try:
+        return getattr(module, name)
+    except Exception:
+        return default
+
+
+def _safe_contract_data(contract_module: object | None) -> dict[str, object]:
+    if contract_module is None:
+        try:
+            from . import bot_personal_contract as contract_module
+        except Exception:
+            contract_module = None
+
+    windows = _unique_texts(_contract_value(contract_module, "WINDOW_SLUGS", ()))
+    memory_types = _unique_texts(_contract_value(contract_module, "BOT_PERSONAL_MEMORY_TYPES", ()))
+    domain = _text(_contract_value(contract_module, "BOT_PERSONAL_MEMORY_DOMAIN", ""))
+    domains = [domain] if domain else []
+    return {
+        "contract_fingerprint": _text(_contract_value(contract_module, "CONTRACT_FINGERPRINT", "")),
+        "contract_version": _text(_contract_value(contract_module, "CONTRACT_REVISION", "")),
+        "schema_version": _text(
+            _contract_value(contract_module, "BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION", "")
+        ),
+        "windows": windows,
+        "memory_types": memory_types,
+        "domains": domains,
+    }
+
+
+def _state(value: object) -> str:
+    candidate = _text(value).lower()
+    return candidate if candidate in CAPABILITY_STATES else "unprobed"
+
+
+def build_capability_snapshot(
+    *,
+    available: bool = False,
+    state: str = "unprobed",
+    contract_module: object | None = None,
+    methods: Iterable[object] = (),
+    domains: Iterable[object] = (),
+    profiles: Iterable[object] = PROFILE_NAMES,
+    warnings: Iterable[object] = (),
+    error_code: object = "",
+) -> dict[str, object]:
+    """Build a bounded, JSON-safe capability snapshot."""
+
+    contract = _safe_contract_data(contract_module)
+    resolved_state = _state(state)
+    if available:
+        resolved_state = "available"
+    elif resolved_state == "available":
+        resolved_state = "degraded"
+
+    supplied_domains = _unique_texts(domains)
+    if not supplied_domains:
+        supplied_domains = list(contract["domains"])
+
+    result: dict[str, object] = {
+        "available": resolved_state == "available",
+        "state": resolved_state,
+        "degraded": resolved_state in {"degraded", "negative"},
+        "pending": resolved_state == "unprobed",
+        "contract_fingerprint": contract["contract_fingerprint"],
+        "contract_version": contract["contract_version"],
+        "schema_version": contract["schema_version"],
+        "windows": list(contract["windows"]),
+        "memory_types": list(contract["memory_types"]),
+        "domains": supplied_domains,
+        "profiles": _unique_texts(profiles, allowed=set(PROFILE_NAMES)),
+        "methods": _unique_texts(methods),
+        "warnings": _unique_texts(warnings),
+        "error_code": _text(error_code),
+    }
+    return {key: result[key] for key in _SNAPSHOT_KEYS}
+
+
+class CapabilityCache:
+    """In-memory capability state with a TTL-limited negative result."""
+
+    def __init__(self, negative_ttl: float = 60.0, clock: object | None = None) -> None:
+        try:
+            self._negative_ttl = max(0.0, float(negative_ttl))
+        except (TypeError, ValueError):
+            self._negative_ttl = 60.0
+        self._clock = clock if callable(clock) else time.monotonic
+        self._snapshot = build_capability_snapshot()
+        self._negative_at: float | None = None
+
+    def _now(self) -> float:
+        try:
+            return float(self._clock())
+        except Exception:
+            return time.monotonic()
+
+    def snapshot(self) -> dict[str, object]:
+        if self._snapshot["state"] == "negative" and self._negative_at is not None:
+            if self._now() - self._negative_at >= self._negative_ttl:
+                self._snapshot = build_capability_snapshot()
+                self._negative_at = None
+        return copy.deepcopy(self._snapshot)
+
+    def mark_available(self, snapshot: Mapping[str, object]) -> dict[str, object]:
+        values = dict(snapshot) if isinstance(snapshot, Mapping) else {}
+        self._snapshot = build_capability_snapshot(
+            available=True,
+            state="available",
+            methods=values.get("methods", ()),
+            domains=values.get("domains", ()),
+            profiles=values.get("profiles", PROFILE_NAMES),
+            warnings=values.get("warnings", ()),
+            error_code=values.get("error_code", ""),
+            contract_module=_MappingContract(values),
+        )
+        self._negative_at = None
+        return self.snapshot()
+
+    def mark_degraded(self, reason: object) -> dict[str, object]:
+        current = self.snapshot()
+        self._snapshot = build_capability_snapshot(
+            state="degraded",
+            methods=current["methods"],
+            domains=current["domains"],
+            profiles=current["profiles"],
+            warnings=[*current["warnings"], _text(reason)] if _text(reason) else current["warnings"],
+            error_code=_text(reason),
+            contract_module=_MappingContract(current),
+        )
+        self._negative_at = None
+        return self.snapshot()
+
+    def mark_negative(self, reason: object) -> dict[str, object]:
+        current = self.snapshot()
+        self._snapshot = build_capability_snapshot(
+            state="negative",
+            methods=current["methods"],
+            domains=current["domains"],
+            profiles=current["profiles"],
+            warnings=[*current["warnings"], _text(reason)] if _text(reason) else current["warnings"],
+            error_code=_text(reason),
+            contract_module=_MappingContract(current),
+        )
+        self._negative_at = self._now()
+        return self.snapshot()
+
+    def clear(self) -> dict[str, object]:
+        self._snapshot = build_capability_snapshot()
+        self._negative_at = None
+        return self.snapshot()
+
+
+class _MappingContract:
+    """Attribute adapter used to preserve contract metadata across cache updates."""
+
+    def __init__(self, values: Mapping[str, object]) -> None:
+        self.CONTRACT_FINGERPRINT = values.get("contract_fingerprint", "")
+        self.CONTRACT_REVISION = values.get("contract_version", "")
+        self.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION = values.get("schema_version", "")
+        self.WINDOW_SLUGS = values.get("windows", ())
+        self.BOT_PERSONAL_MEMORY_TYPES = values.get("memory_types", ())
+        domains = values.get("domains", ())
+        self.BOT_PERSONAL_MEMORY_DOMAIN = domains[0] if isinstance(domains, list) and domains else ""
+
+
+__all__ = [
+    "CAPABILITY_STATES",
+    "PROFILE_NAMES",
+    "CapabilityCache",
+    "build_capability_snapshot",
+]

--- a/core/chat_import.py
+++ b/core/chat_import.py
@@ -638,6 +638,7 @@ class HistoricalChatImporter:
     IDENTITY_LINKS_VERSION = 2
     SUMMARY_PERSPECTIVE_VERSION = 1
     DETAIL_SCHEMA_VERSION = 1
+    STAGED_DATA_ERROR = "历史导入暂存数据损坏，请重新上传或清理该预览"
 
     def __init__(self, service: Any) -> None:
         self.service = service
@@ -1277,17 +1278,32 @@ class HistoricalChatImporter:
         manifest_path = self._upload_dir(upload_id) / "manifest.json"
         if not manifest_path.is_file():
             raise ValueError("上传预览不存在或已被清理")
-        return json.loads(manifest_path.read_text(encoding="utf-8"))
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError(self.STAGED_DATA_ERROR) from exc
+        if not isinstance(manifest, dict):
+            raise ValueError(self.STAGED_DATA_ERROR)
+        if clean_text(manifest.get("upload_id"), 120) != clean_text(upload_id, 120):
+            raise ValueError(self.STAGED_DATA_ERROR)
+        return manifest
 
     def _load_upload_messages(self, upload_id: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         manifest = self.preview_upload(upload_id)
         parsed_path = self._upload_dir(upload_id) / "parsed.jsonl"
         messages: list[dict[str, Any]] = []
-        for raw in parsed_path.read_text(encoding="utf-8").splitlines():
-            if raw.strip():
+        try:
+            for line_no, raw in enumerate(parsed_path.read_text(encoding="utf-8").splitlines(), 1):
+                if not raw.strip():
+                    continue
                 value = json.loads(raw)
-                if isinstance(value, dict):
-                    messages.append(value)
+                if not isinstance(value, dict):
+                    raise ValueError(f"line={line_no}")
+                messages.append(value)
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(self.STAGED_DATA_ERROR) from exc
+        if not messages:
+            raise ValueError(self.STAGED_DATA_ERROR)
         return manifest, messages
 
     def _private_api(self) -> Any | None:
@@ -2217,7 +2233,12 @@ class HistoricalChatImporter:
             batch["id"], statuses={"completed", "archived_only"}
         )
         memory_counts = await self.store.chat_import_memory_counts(batch["id"])
-        checkpoint = max((int(item.get("segment_index") or 0) + 1 for item in completed_segments), default=0)
+        current_checkpoint = max(0, int(batch.get("checkpoint_segment") or 0))
+        computed_checkpoint = max(
+            (int(item.get("segment_index") or 0) + 1 for item in completed_segments),
+            default=0,
+        )
+        checkpoint = max(current_checkpoint, computed_checkpoint)
         await self.store.update_chat_import_batch(
             batch["id"],
             checkpoint_segment=checkpoint,

--- a/core/classifier.py
+++ b/core/classifier.py
@@ -38,7 +38,12 @@ class MemoryClassifier:
             importance=importance,
             review_status="auto",
             tags=["user_message", ctx.scope],
-            metadata={"raw_text": text, "sender_name": ctx.user_name, "sender_id": ctx.user_id},
+            metadata={
+                "raw_text": text,
+                "sender_name": ctx.user_name,
+                "sender_id": ctx.user_id,
+                "owner_bot_id": clean_text(ctx.bot_id, 120),
+            },
         )
 
     def from_bot_response(self, ctx: SessionContext, response_text: str) -> MemoryRecord | None:
@@ -103,7 +108,11 @@ class MemoryClassifier:
                     content=fact["content"],
                     evidence=text,
                     tags=fact["tags"],
-                    metadata={"source_memory_id": source_memory_id, "extractor": "rule_v1"},
+                    metadata={
+                        "source_memory_id": source_memory_id,
+                        "extractor": "rule_v1",
+                        "owner_bot_id": clean_text(ctx.bot_id, 120),
+                    },
                     **base,
                 )
             )

--- a/core/config.py
+++ b/core/config.py
@@ -80,26 +80,6 @@ class ConfigView:
     def __init__(self, raw: Any):
         self.raw = raw or {}
 
-    def bridge_enabled(self) -> bool:
-        """Resolve the bridge switch without changing migration behavior."""
-        marker = object()
-        explicit = self._get_exact("enable_memory_companion_bridge", marker)
-        if explicit is not marker:
-            return self._coerce_bool(explicit, True)
-        return self.bool("private_companion_bridge.enabled", True)
-
-    @staticmethod
-    def _coerce_bool(value: Any, default: bool = False) -> bool:
-        if isinstance(value, str):
-            normalized = value.strip().lower()
-            if normalized in {"1", "true", "yes", "on", "enabled"}:
-                return True
-            if normalized in {"0", "false", "no", "off", "disabled"}:
-                return False
-        if value is None:
-            return default
-        return bool(value)
-
     def get(self, dotted: str, default: Any = None) -> Any:
         marker = object()
         value = self._get_exact(dotted, marker)

--- a/core/config.py
+++ b/core/config.py
@@ -80,6 +80,26 @@ class ConfigView:
     def __init__(self, raw: Any):
         self.raw = raw or {}
 
+    def bridge_enabled(self) -> bool:
+        """Resolve the bridge switch without changing migration behavior."""
+        marker = object()
+        explicit = self._get_exact("enable_memory_companion_bridge", marker)
+        if explicit is not marker:
+            return self._coerce_bool(explicit, True)
+        return self.bool("private_companion_bridge.enabled", True)
+
+    @staticmethod
+    def _coerce_bool(value: Any, default: bool = False) -> bool:
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on", "enabled"}:
+                return True
+            if normalized in {"0", "false", "no", "off", "disabled"}:
+                return False
+        if value is None:
+            return default
+        return bool(value)
+
     def get(self, dotted: str, default: Any = None) -> Any:
         marker = object()
         value = self._get_exact(dotted, marker)

--- a/core/context_consumer.py
+++ b/core/context_consumer.py
@@ -1,0 +1,155 @@
+"""Read-only consumer for the P3 context projection contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .person_context_contract import (
+    P3_SLOT_NAMES,
+    build_context_projection,
+    merge_context_slots,
+    validate_context_projection,
+    validate_context_slot,
+)
+
+
+_FORBIDDEN_KEYS = {
+    "raw_prompt",
+    "prompt",
+    "private_object",
+    "private_object_ref",
+    "object",
+    "chat_text",
+    "content",
+    "messages",
+    "transcript",
+    "database",
+}
+
+
+def _safe_value(value: Any, depth: int = 0) -> Any:
+    """Make a bounded metadata-only copy and drop text-bearing/private data."""
+
+    if depth > 2 or value is None or isinstance(value, bool):
+        return value if value is None or isinstance(value, bool) else None
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        return value[:240]
+    if isinstance(value, list):
+        return [_safe_value(item, depth + 1) for item in value[:12]]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in list(value.items())[:24]:
+            name = str(key).strip().lower()
+            if not name or name in _FORBIDDEN_KEYS:
+                continue
+            safe = _safe_value(item, depth + 1)
+            if safe is not None:
+                result[name[:80]] = safe
+        return result
+    return None
+
+
+def _slot_ref(slot: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "slot": slot["slot"],
+        "owner": slot["owner"],
+        "revision": slot["revision"],
+        "contract_fingerprint": slot["contract_fingerprint"],
+        "state": slot["state"],
+        "payload": _safe_value(slot.get("payload") or {}) or {},
+        "warnings": [str(item)[:120] for item in slot.get("warnings", [])[:8]],
+    }
+
+
+def consume_context_projection(
+    context: Any,
+    expected_person_id: str = "",
+    expected_scope: str = "",
+    *,
+    companion_available: bool = True,
+) -> dict[str, Any]:
+    """Validate and consume P3 slots, never persisting or mutating input.
+
+    Invalid slots are rejected individually.  Valid slots are merged using the
+    shared revision-aware contract helper, so an older duplicate cannot
+    replace a newer slot.  The returned context contains only safe metadata.
+    """
+
+    base = {"read_only": True, "source": "companion_context"}
+    if not companion_available:
+        return {**base, "state": "degraded", "degraded": True, "errors": ["companion_unavailable"]}
+    if context is None or (isinstance(context, dict) and "slots" not in context):
+        return {**base, "state": "legacy_local", "legacy_local": True, "warnings": ["context_missing"]}
+    if not isinstance(context, dict):
+        return {**base, "state": "invalid", "errors": ["context_invalid"]}
+
+    errors = list(validate_context_projection(context))
+    context_state = str(context.get("state") or "ready")
+    if context_state not in {"ready", "legacy_local", "invalid", "degraded", "pending"}:
+        errors.append("context_state_invalid")
+    if context_state == "invalid":
+        errors.append("context_invalid_state")
+    if expected_person_id:
+        context_person_id = context.get("person_id")
+        if context_person_id and context_person_id != expected_person_id:
+            errors.append("person_id_mismatch")
+    if expected_scope:
+        context_scope = context.get("scope")
+        if context_scope and context_scope != expected_scope:
+            errors.append("scope_mismatch")
+
+    incoming_slots = context.get("slots") if isinstance(context.get("slots"), dict) else {}
+    accepted: dict[str, dict[str, Any]] = {}
+    rejected: dict[str, list[str]] = {}
+    for name in P3_SLOT_NAMES:
+        candidate = incoming_slots.get(name)
+        slot_errors = validate_context_slot(candidate, name)
+        if slot_errors:
+            rejected[name] = slot_errors
+            continue
+        payload = candidate.get("payload") if isinstance(candidate.get("payload"), dict) else {}
+        if expected_person_id and payload.get("person_id") and payload.get("person_id") != expected_person_id:
+            rejected[name] = ["person_id_mismatch"]
+            continue
+        if expected_scope and payload.get("scope") and payload.get("scope") != expected_scope:
+            rejected[name] = ["scope_mismatch"]
+            continue
+        if candidate.get("state") == "invalid":
+            errors.append(f"{name}_state_invalid")
+            rejected[name] = ["slot_state_invalid"]
+            continue
+        accepted[name] = dict(candidate)
+
+    if errors:
+        return {**base, "state": "invalid", "errors": sorted(set(errors)), "rejected_slots": rejected}
+
+    safe_incoming = {"revision": context.get("revision", 1), "slots": accepted}
+    merged = merge_context_slots(build_context_projection(), safe_incoming)
+    safe_slots = {name: _slot_ref(merged["slots"][name]) for name in P3_SLOT_NAMES}
+    slot_states = {str(slot.get("state") or "ready") for slot in accepted.values()}
+    if context_state == "degraded" or "degraded" in slot_states:
+        state = "degraded"
+    elif context_state == "pending" or "pending" in slot_states:
+        state = "pending"
+    elif context_state == "legacy_local" or slot_states and slot_states.issubset({"legacy_local"}):
+        state = "legacy_local"
+    else:
+        state = "ready"
+    result: dict[str, Any] = {
+        **base,
+        "state": state,
+        "degraded": state == "degraded",
+        "context_ref": {
+            "revision": merged["revision"],
+            "contract_fingerprint": merged["contract_fingerprint"],
+            "slots": safe_slots,
+        },
+    }
+    if rejected:
+        result["rejected_slots"] = rejected
+    return result
+
+
+__all__ = ["consume_context_projection"]

--- a/core/coordination_status.py
+++ b/core/coordination_status.py
@@ -1,0 +1,221 @@
+"""Allowlist-only coordination status for the Memory page.
+
+This projection is observational. It never returns memory text, identity
+values, session identifiers, audit bodies, provider details, or handles.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+try:
+    from .p5c_guard import P5C_SINK_FLAGS
+except ImportError:
+    P5C_SINK_FLAGS = {}
+try:
+    from .p5d_security_events import P5D_OPERATION_FLAGS
+except ImportError:
+    P5D_OPERATION_FLAGS = {}
+
+from .p6_four_package_manifest import FOUR_PACKAGE_IDS, manifest_contract
+from .p6_readonly_projection import P6_READONLY_STATUS_FINGERPRINT, P6_READONLY_STATUS_SCHEMA
+
+
+COORDINATION_STATUS_SCHEMA = "ops.memory.coordination_status.v1"
+_HEALTH = frozenset({"ready", "degraded", "unverifiable"})
+_P5_B_FLAGS = (
+    "enable_p5_b1_recall_gate",
+    "enable_p5_b1_bridge_gate",
+    "enable_p5_b1_tool_recall_gate",
+    "enable_p5_b2_archive_read_gate",
+    "enable_p5_b2_cross_user_read_gate",
+)
+_P6_FIELDS = ("profiles", "identity_links", "audit_events", "operations")
+_P6_REASON_CODES = frozenset({"", "registry_status_unavailable", "invalid_reason_code"})
+_BRIDGE_REASON_CODES = frozenset({
+    "bridge_status_unavailable",
+    "bridge_config_unavailable",
+    "bridge_config_unreadable",
+    "bridge_config_invalid",
+    "bridge_disabled",
+    "companion_api_unavailable",
+    "companion_p6_producer_unavailable",
+    "companion_p6_producer_unreadable",
+    "companion_p6_unverifiable",
+    "companion_bridge_available",
+})
+
+
+def _has_exact_str_fields(value: dict[Any, Any], fields: frozenset[str]) -> bool:
+    if len(value) != len(fields):
+        return False
+    for key in value:
+        if type(key) is not str or key not in fields:
+            return False
+    return True
+
+
+def _fingerprint() -> str:
+    payload = {"schema_version": COORDINATION_STATUS_SCHEMA, "sections": ("page_api", "runtime", "bridge", "p5", "p6", "four_package")}
+    encoded = json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+COORDINATION_STATUS_FINGERPRINT = _fingerprint()
+
+
+def _status(health: str, reason_code: str) -> dict[str, str]:
+    return {
+        "health": health if type(health) is str and health in _HEALTH else "unverifiable",
+        "reason_code": reason_code if type(reason_code) is str and len(reason_code) <= 80 else "status_unavailable",
+    }
+
+
+def _project_bridge_status(raw: Any) -> dict[str, str]:
+    if type(raw) is not dict or not _has_exact_str_fields(raw, frozenset({"health", "reason_code"})):
+        return _status("unverifiable", "bridge_status_unavailable")
+    health = raw.get("health")
+    reason_code = raw.get("reason_code")
+    if type(health) is not str or health not in _HEALTH:
+        return _status("unverifiable", "bridge_status_unavailable")
+    if type(reason_code) is not str or reason_code not in _BRIDGE_REASON_CODES:
+        return _status("unverifiable", "bridge_status_unavailable")
+    return _status(health, reason_code)
+
+
+def _unavailable_group(total_count: int) -> dict[str, Any]:
+    return {"health": "unverifiable", "mode": "unavailable", "enabled_count": 0, "total_count": total_count, "reason_code": "contract_not_available"}
+
+
+def _config_group(config: Any, flags: tuple[str, ...], *, fallback_flags: tuple[str, ...] = ()) -> dict[str, Any]:
+    if not flags:
+        return _unavailable_group(0)
+    getter = getattr(config, "bool", None)
+    if not callable(getter):
+        return {"health": "unverifiable", "mode": "unverifiable", "enabled_count": 0, "total_count": len(flags), "reason_code": "config_unavailable"}
+    values: list[bool] = []
+    for index, flag in enumerate(flags):
+        try:
+            value = getter(flag, False)
+            if type(value) is not bool:
+                return {"health": "unverifiable", "mode": "unverifiable", "enabled_count": 0, "total_count": len(flags), "reason_code": "config_value_invalid"}
+            if value is False and fallback_flags:
+                fallback = getter(fallback_flags[index], False)
+                if type(fallback) is not bool:
+                    return {"health": "unverifiable", "mode": "unverifiable", "enabled_count": 0, "total_count": len(flags), "reason_code": "config_value_invalid"}
+                value = fallback
+        except Exception:
+            return {"health": "unverifiable", "mode": "unverifiable", "enabled_count": 0, "total_count": len(flags), "reason_code": "config_unreadable"}
+        values.append(value)
+    enabled_count = sum(values)
+    if enabled_count == 0:
+        return {"health": "ready", "mode": "default_off", "enabled_count": 0, "total_count": len(flags), "reason_code": "default_off"}
+    if enabled_count == len(flags):
+        return {"health": "ready", "mode": "enabled", "enabled_count": enabled_count, "total_count": len(flags), "reason_code": "configured"}
+    return {"health": "degraded", "mode": "partial", "enabled_count": enabled_count, "total_count": len(flags), "reason_code": "partial_coverage"}
+
+
+def build_p5_status(config: Any) -> dict[str, dict[str, Any]]:
+    return {
+        "attestation_read": _config_group(config, _P5_B_FLAGS),
+        "sink_boundary": _config_group(config, tuple(f"p5c_safety.{flag}" for flag in P5C_SINK_FLAGS.values()), fallback_flags=tuple(P5C_SINK_FLAGS.values())),
+        "security_recovery": _config_group(config, tuple(f"p5d_safety.{flag}" for flag in P5D_OPERATION_FLAGS.values()), fallback_flags=tuple(P5D_OPERATION_FLAGS.values())),
+    }
+
+
+def project_runtime_health(runtime: Any) -> dict[str, str]:
+    try:
+        if type(runtime) is dict:
+            for key in runtime:
+                if type(key) is not str:
+                    return _status("unverifiable", "runtime_unsupported")
+            if len(runtime) != 1 or "compatibility_level" not in runtime:
+                return _status("unverifiable", "runtime_unsupported")
+            level = runtime.get("compatibility_level")
+        else:
+            level = getattr(runtime, "compatibility_level", None)
+    except Exception:
+        return _status("unverifiable", "runtime_status_unavailable")
+    if type(level) is not str:
+        return _status("unverifiable", "runtime_unsupported")
+    if level == "full":
+        return _status("ready", "runtime_compatible")
+    if level == "degraded":
+        return _status("degraded", "runtime_degraded")
+    return _status("unverifiable", "runtime_unsupported")
+
+
+def project_p6_status(raw: Any) -> dict[str, Any]:
+    fallback = {
+        "schema_version": P6_READONLY_STATUS_SCHEMA,
+        "contract_fingerprint": P6_READONLY_STATUS_FINGERPRINT,
+        "health": "unverifiable",
+        "reason_code": "p6_status_unavailable",
+        "counts": {field: 0 for field in _P6_FIELDS},
+    }
+    if type(raw) is not dict or not _has_exact_str_fields(raw, frozenset({"schema_version", "source_plugin", "contract_fingerprint", "health", "reason_code", "counts"})):
+        return fallback
+    schema_version = raw.get("schema_version")
+    source_plugin = raw.get("source_plugin")
+    contract_fingerprint = raw.get("contract_fingerprint")
+    if (
+        type(schema_version) is not str
+        or type(source_plugin) is not str
+        or type(contract_fingerprint) is not str
+        or schema_version != P6_READONLY_STATUS_SCHEMA
+        or source_plugin != "private_companion"
+        or contract_fingerprint != P6_READONLY_STATUS_FINGERPRINT
+    ):
+        return fallback
+    health, reason_code, counts = raw.get("health"), raw.get("reason_code"), raw.get("counts")
+    if type(health) is not str or health not in _HEALTH:
+        return fallback
+    if type(reason_code) is not str or reason_code not in _P6_REASON_CODES:
+        return fallback
+    if type(counts) is not dict or not _has_exact_str_fields(counts, frozenset(_P6_FIELDS)):
+        return fallback
+    if any(type(counts[field]) is not int or not 0 <= counts[field] <= 10_000_000 for field in _P6_FIELDS):
+        return fallback
+    return {
+        "schema_version": P6_READONLY_STATUS_SCHEMA,
+        "contract_fingerprint": P6_READONLY_STATUS_FINGERPRINT,
+        "health": health,
+        "reason_code": reason_code,
+        "counts": {field: counts[field] for field in _P6_FIELDS},
+    }
+
+
+def build_coordination_status(*, config: Any, runtime: Any, bridge: dict[str, str], p6_raw: Any) -> dict[str, Any]:
+    p5 = build_p5_status(config)
+    p6 = project_p6_status(p6_raw)
+    manifest = manifest_contract()
+    bridge_status = _project_bridge_status(bridge)
+    components = [project_runtime_health(runtime), bridge_status, {"health": p6["health"], "reason_code": p6["reason_code"]}]
+    if any(item["health"] == "unverifiable" for item in components):
+        health, reason_code = "unverifiable", "coordination_input_unverifiable"
+    elif any(item["health"] == "degraded" for item in components):
+        health, reason_code = "degraded", "coordination_degraded"
+    else:
+        health, reason_code = "ready", "coordination_ready"
+    return {
+        "schema_version": COORDINATION_STATUS_SCHEMA,
+        "contract_fingerprint": COORDINATION_STATUS_FINGERPRINT,
+        "health": health,
+        "reason_code": reason_code,
+        "page_api": _status("ready", "page_api_registered"),
+        "runtime": project_runtime_health(runtime),
+        "bridge": bridge_status,
+        "p5": p5,
+        "p6": p6,
+        "four_package": {
+            "schema_version": manifest["schema"],
+            "contract_fingerprint": manifest["contract_fingerprint"],
+            "health": "unverifiable",
+            "reason_code": "manifest_registry_unavailable",
+            "expected_package_count": len(FOUR_PACKAGE_IDS),
+        },
+    }
+
+
+__all__ = ["COORDINATION_STATUS_FINGERPRINT", "COORDINATION_STATUS_SCHEMA", "build_coordination_status", "build_p5_status", "project_p6_status", "project_runtime_health"]

--- a/core/emotion_event_contract.py
+++ b/core/emotion_event_contract.py
@@ -1,4 +1,4 @@
-"""Versioned, redacted emotion-event contract shared with Companion."""
+"""Versioned, redacted emotion-event contract shared across companion plugins."""
 from __future__ import annotations
 
 from datetime import datetime, timezone

--- a/core/emotion_event_contract.py
+++ b/core/emotion_event_contract.py
@@ -1,0 +1,162 @@
+"""Versioned, redacted emotion-event contract shared with Companion."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import math
+import re
+from typing import Any, Mapping
+
+
+EMOTION_EVENT_SCHEMA_VERSION = "companion_emotion_event.v1"
+EMOTION_EVENT_TYPES = frozenset({
+    "neutral", "hurt", "apology", "comfort", "praise", "comfort_need",
+    "external_negative", "scar_touched", "warm_memory", "vulnerable_resonance",
+    "play", "intimacy", "boundary",
+})
+EMOTION_EVENT_ORIGINS = frozenset({"interaction", "memory_recall", "system_condition"})
+EMOTION_EVENT_STATUSES = frozenset({"observed", "revised", "applied", "ignored", "expired"})
+EMOTION_EVENT_CONTRACT_FIELDS = (
+    "schema_version", "event_id", "trace_id", "revision", "producer_plugin",
+    "origin_kind", "platform", "bot_id", "scope", "session_id", "actor_ref",
+    "target_ref", "quoted_target_ref", "event_type", "intensity", "confidence",
+    "valence_hint", "arousal_hint", "vulnerability_hint", "source_rule",
+    "occurred_at", "expires_at", "dedupe_key", "payload_hash", "privacy_level",
+    "applied_interaction", "applied_energy_delta", "correction_of", "status",
+    "reason_codes",
+)
+EMOTION_EVENT_CONTRACT_FINGERPRINT = hashlib.sha256(
+    "|".join(EMOTION_EVENT_CONTRACT_FIELDS).encode("ascii")
+).hexdigest()[:20]
+
+
+def _text(value: Any, limit: int) -> str:
+    text = re.sub(r"\s+", " ", str(value or "").replace("\u3000", " ")).strip()
+    return text[:limit]
+
+
+def _number(value: Any, default: float, low: float, high: float) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(number):
+        return default
+    return round(max(low, min(high, number)), 4)
+
+
+def _integer(value: Any, default: int = 1) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return max(1, min(1_000_000, int(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _entity(value: Any) -> dict[str, str]:
+    source = value if isinstance(value, Mapping) else {}
+    return {
+        "kind": _text(source.get("kind"), 24) or "unknown",
+        "id": _text(source.get("id"), 160),
+        "role": _text(source.get("role"), 40),
+    }
+
+
+def _timestamp(value: Any) -> str:
+    text = _text(value, 48)
+    if text:
+        return text
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _stable_hash(*parts: Any) -> str:
+    raw = "|".join(_text(part, 500) for part in parts)
+    return hashlib.sha256(raw.encode("utf-8", errors="ignore")).hexdigest()
+
+
+def normalize_emotion_event(value: Any, *, producer_plugin: str = "") -> dict[str, Any]:
+    """Return a bounded JSON-safe event without retaining raw message content."""
+    source = dict(value) if isinstance(value, Mapping) else {}
+    producer = _text(source.get("producer_plugin") or producer_plugin, 80) or "unknown"
+    origin = _text(source.get("origin_kind"), 40)
+    if origin not in EMOTION_EVENT_ORIGINS:
+        origin = "interaction"
+    event_type = _text(source.get("event_type"), 48).lower()
+    if event_type not in EMOTION_EVENT_TYPES:
+        event_type = "neutral"
+    status = _text(source.get("status"), 24).lower()
+    if status not in EMOTION_EVENT_STATUSES:
+        status = "observed"
+    session_id = _text(source.get("session_id"), 220)
+    dedupe_key = _text(source.get("dedupe_key"), 160)
+    payload_hash = _text(source.get("payload_hash"), 80)
+    if not payload_hash:
+        payload_hash = _stable_hash(
+            producer, origin, session_id, event_type, dedupe_key,
+            source.get("message_fingerprint"), source.get("source_rule"),
+        )
+    event_id = _text(source.get("event_id"), 96)
+    if not event_id:
+        event_id = "emo_" + _stable_hash(producer, origin, session_id, event_type, dedupe_key, payload_hash)[:24]
+    trace_id = _text(source.get("trace_id"), 96)
+    if not trace_id:
+        trace_id = "etr_" + _stable_hash(session_id, dedupe_key or event_id)[:24]
+    reason_codes = source.get("reason_codes")
+    if not isinstance(reason_codes, (list, tuple)):
+        reason_codes = []
+    clean_reasons: list[str] = []
+    for item in reason_codes[:12]:
+        reason = _text(item, 64)
+        if reason and reason not in clean_reasons:
+            clean_reasons.append(reason)
+    return {
+        "schema_version": EMOTION_EVENT_SCHEMA_VERSION,
+        "event_id": event_id,
+        "trace_id": trace_id,
+        "revision": _integer(source.get("revision"), 1),
+        "producer_plugin": producer,
+        "origin_kind": origin,
+        "platform": _text(source.get("platform"), 80),
+        "bot_id": _text(source.get("bot_id"), 160),
+        "scope": _text(source.get("scope"), 24) or "private",
+        "session_id": session_id,
+        "actor_ref": _entity(source.get("actor_ref")),
+        "target_ref": _entity(source.get("target_ref")),
+        "quoted_target_ref": _entity(source.get("quoted_target_ref")),
+        "event_type": event_type,
+        "intensity": _number(source.get("intensity"), 0.0, 0.0, 100.0),
+        "confidence": _number(source.get("confidence"), 0.0, 0.0, 1.0),
+        "valence_hint": _number(source.get("valence_hint"), 0.0, -1.0, 1.0),
+        "arousal_hint": _number(source.get("arousal_hint"), 0.0, 0.0, 1.0),
+        "vulnerability_hint": _number(source.get("vulnerability_hint"), 0.0, 0.0, 1.0),
+        "source_rule": _text(source.get("source_rule"), 80),
+        "occurred_at": _timestamp(source.get("occurred_at")),
+        "expires_at": _text(source.get("expires_at"), 48),
+        "dedupe_key": dedupe_key or payload_hash[:32],
+        "payload_hash": payload_hash,
+        "privacy_level": _text(source.get("privacy_level"), 24) or "redacted",
+        "applied_interaction": _text(source.get("applied_interaction"), 32),
+        "applied_energy_delta": _number(source.get("applied_energy_delta"), 0.0, -100.0, 100.0),
+        "correction_of": _text(source.get("correction_of"), 96),
+        "status": status,
+        "reason_codes": clean_reasons,
+    }
+
+
+def emotion_event_json(value: Any, *, producer_plugin: str = "") -> str:
+    return json.dumps(normalize_emotion_event(value, producer_plugin=producer_plugin), ensure_ascii=False, separators=(",", ":"))
+
+
+__all__ = [
+    "EMOTION_EVENT_CONTRACT_FIELDS",
+    "EMOTION_EVENT_CONTRACT_FINGERPRINT",
+    "EMOTION_EVENT_SCHEMA_VERSION",
+    "EMOTION_EVENT_STATUSES",
+    "EMOTION_EVENT_TYPES",
+    "emotion_event_json",
+    "normalize_emotion_event",
+]

--- a/core/emotion_targeting.py
+++ b/core/emotion_targeting.py
@@ -10,19 +10,45 @@ from .models import clean_text
 def memory_emotion_refs(memory: Any, ctx: Any) -> dict[str, dict[str, str]] | None:
     memory_session = clean_text(getattr(memory, "session_id", ""), 220)
     current_session = clean_text(getattr(ctx, "session_id", ""), 220)
-    if memory_session and current_session and memory_session != current_session:
+    memory_scope = clean_text(getattr(memory, "scope", ""), 24).lower()
+    current_scope = clean_text(getattr(ctx, "scope", ""), 24).lower()
+    memory_platform = clean_text(getattr(memory, "platform", ""), 80)
+    current_platform = clean_text(getattr(ctx, "platform", ""), 80)
+    user_id = clean_text(getattr(ctx, "user_id", ""), 160)
+    bot_id = clean_text(getattr(ctx, "bot_id", ""), 160)
+    if (
+        not all((memory_session, current_session, memory_platform, current_platform, user_id, bot_id))
+        or memory_session != current_session
+        or memory_scope != "private"
+        or current_scope != "private"
+        or memory_platform != current_platform
+    ):
         return None
     subject = getattr(memory, "subject", None)
     subject_kind = clean_text(getattr(subject, "kind", ""), 24)
     subject_id = clean_text(getattr(subject, "id", ""), 160)
-    user_id = clean_text(getattr(ctx, "user_id", ""), 160)
-    bot_id = clean_text(getattr(ctx, "bot_id", ""), 160) or "self"
-    if subject_kind == "user" and user_id and subject_id != user_id:
+    if subject_kind != "user" or subject_id != user_id:
         return None
-    if subject_kind not in {"user", "bot"} or not subject_id:
+    metadata = getattr(memory, "metadata", {})
+    metadata = metadata if isinstance(metadata, dict) else {}
+    owner_bot_id = clean_text(metadata.get("owner_bot_id"), 160)
+    target = getattr(memory, "object", None)
+    target_kind = clean_text(getattr(target, "kind", ""), 24)
+    target_id = clean_text(getattr(target, "id", ""), 160)
+    if owner_bot_id:
+        if owner_bot_id != bot_id:
+            return None
+    elif target_kind != "bot" or target_id != bot_id:
+        # A legacy record without an explicit owner must at least name this Bot.
+        return None
+    if target_id and (
+        (target_kind == "bot" and target_id != bot_id)
+        or (target_kind == "user" and target_id != user_id)
+        or target_kind not in {"bot", "user"}
+    ):
         return None
     return {
-        "actor_ref": {"kind": subject_kind, "id": subject_id, "role": clean_text(getattr(subject, "role", ""), 40)},
+        "actor_ref": {"kind": "user", "id": subject_id, "role": clean_text(getattr(subject, "role", ""), 40)},
         "target_ref": {"kind": "bot", "id": bot_id, "role": "bot_self"},
         "quoted_target_ref": {"kind": "unknown", "id": "", "role": ""},
     }

--- a/core/emotion_targeting.py
+++ b/core/emotion_targeting.py
@@ -1,0 +1,31 @@
+"""Validate memory-event attribution against the active visibility domain."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .models import clean_text
+
+
+def memory_emotion_refs(memory: Any, ctx: Any) -> dict[str, dict[str, str]] | None:
+    memory_session = clean_text(getattr(memory, "session_id", ""), 220)
+    current_session = clean_text(getattr(ctx, "session_id", ""), 220)
+    if memory_session and current_session and memory_session != current_session:
+        return None
+    subject = getattr(memory, "subject", None)
+    subject_kind = clean_text(getattr(subject, "kind", ""), 24)
+    subject_id = clean_text(getattr(subject, "id", ""), 160)
+    user_id = clean_text(getattr(ctx, "user_id", ""), 160)
+    bot_id = clean_text(getattr(ctx, "bot_id", ""), 160) or "self"
+    if subject_kind == "user" and user_id and subject_id != user_id:
+        return None
+    if subject_kind not in {"user", "bot"} or not subject_id:
+        return None
+    return {
+        "actor_ref": {"kind": subject_kind, "id": subject_id, "role": clean_text(getattr(subject, "role", ""), 40)},
+        "target_ref": {"kind": "bot", "id": bot_id, "role": "bot_self"},
+        "quoted_target_ref": {"kind": "unknown", "id": "", "role": ""},
+    }
+
+
+__all__ = ["memory_emotion_refs"]

--- a/core/injection.py
+++ b/core/injection.py
@@ -665,7 +665,7 @@ class InjectionComposer:
             scar = 0.0
         hints: list[str] = []
         if phase and phase != "neutral":
-            hints.append(f"关系阶段={phase}")
+            hints.append(f"当时关系情境={phase}")
         if scar >= 0.45:
             hints.append("伤痕感=高")
         try:

--- a/core/models.py
+++ b/core/models.py
@@ -84,6 +84,11 @@ class SessionContext:
     companion_relationship_phase_label: str = ""
     companion_relationship_tone: str = ""
     companion_relationship_address_level: str = ""
+    companion_interaction_dynamics_version: str = ""
+    companion_interaction_band: str = ""
+    companion_interaction_recovery_band: str = ""
+    companion_interaction_expires_at: float = 0.0
+    companion_interaction_projection_revision: int = 0
     companion_expression_contract: str = ""
     companion_expression_band: str = ""
     companion_expression_allowed_behaviors: tuple[str, ...] = ()

--- a/core/models.py
+++ b/core/models.py
@@ -95,6 +95,12 @@ class SessionContext:
     companion_expression_safety_mode: str = ""
     companion_expression_blocker: str = ""
     companion_expression_reason_codes: tuple[str, ...] = ()
+    companion_expression_pacing: str = ""
+    companion_expression_directness: str = ""
+    companion_expression_validation_style: str = ""
+    companion_expression_self_disclosure: str = ""
+    companion_expression_humor_mode: str = ""
+    companion_expression_topic_initiative: str = ""
 
     @property
     def current_target_id(self) -> str:

--- a/core/models.py
+++ b/core/models.py
@@ -78,6 +78,12 @@ class SessionContext:
     strict_session_only: bool = False
     preferred_address: str = ""
     preferred_address_locked: bool = False
+    relationship_authority_source: str = ""
+    companion_relationship_score: int = 0
+    companion_relationship_phase_key: str = ""
+    companion_relationship_phase_label: str = ""
+    companion_relationship_tone: str = ""
+    companion_relationship_address_level: str = ""
 
     @property
     def current_target_id(self) -> str:

--- a/core/models.py
+++ b/core/models.py
@@ -84,6 +84,12 @@ class SessionContext:
     companion_relationship_phase_label: str = ""
     companion_relationship_tone: str = ""
     companion_relationship_address_level: str = ""
+    companion_expression_contract: str = ""
+    companion_expression_band: str = ""
+    companion_expression_allowed_behaviors: tuple[str, ...] = ()
+    companion_expression_safety_mode: str = ""
+    companion_expression_blocker: str = ""
+    companion_expression_reason_codes: tuple[str, ...] = ()
 
     @property
     def current_target_id(self) -> str:

--- a/core/operations.py
+++ b/core/operations.py
@@ -15,6 +15,7 @@ from .models import EntityRef, MemoryRecord, clean_text, json_loads
 PORTABLE_FORMAT = "astrbot-memory-jsonl"
 PORTABLE_VERSION = 1
 MAX_PORTABLE_BYTES = 64 * 1024 * 1024
+PORTABLE_EXPORT_PAGE_SIZE = 500
 
 
 PRESETS: dict[str, dict[str, Any]] = {
@@ -302,17 +303,14 @@ class PortableMemoryArchive:
         self.export_dir = self.data_dir / "exports"
 
     async def export(self) -> dict[str, Any]:
-        memories = await self.store.list_memories(limit=1_000_000)
-        identities = await self.store.list_identities(limit=1_000_000)
-        relationships = await self.store.list_relationships(limit=1_000_000)
-        timeline = await self.store.recent_timeline(limit=1_000_000)
+        stats = await self.store.stats()
         acl_rules = await self.store.list_acl_rules()
         acl_policies = await self.store.list_acl_policies()
         counts = {
-            "memory": len(memories),
-            "identity": len(identities),
-            "relationship": len(relationships),
-            "timeline": len(timeline),
+            "memory": int(stats.get("total_memories") or 0),
+            "identity": int(stats.get("identities") or 0),
+            "relationship": int(stats.get("relationships") or 0),
+            "timeline": int(stats.get("timeline_events") or 0),
             "acl_rule": len(acl_rules),
             "acl_policy": len(acl_policies),
         }
@@ -333,15 +331,26 @@ class PortableMemoryArchive:
         try:
             with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
                 self._write_line(handle, header)
-                for memory in memories:
-                    self._write_line(handle, {"record_type": "memory", "data": self._memory_payload(memory)})
-                for kind, rows in (
-                    ("identity", identities),
-                    ("relationship", relationships),
-                    ("timeline", timeline),
-                    ("acl_rule", acl_rules),
-                    ("acl_policy", acl_policies),
+                for record_type, loader, normalizer in (
+                    ("memory", self.store.list_memories, self._memory_payload),
+                    ("identity", self.store.list_identities, self._normalized_row),
+                    ("relationship", self.store.list_relationships, self._normalized_row),
+                    ("timeline", self.store.recent_timeline, self._normalized_row),
                 ):
+                    offset = 0
+                    while True:
+                        rows = await loader(limit=PORTABLE_EXPORT_PAGE_SIZE, offset=offset)
+                        if not rows:
+                            break
+                        for row in rows:
+                            self._write_line(
+                                handle,
+                                {"record_type": record_type, "data": normalizer(row)},
+                            )
+                        offset += len(rows)
+                        if len(rows) < PORTABLE_EXPORT_PAGE_SIZE:
+                            break
+                for kind, rows in (("acl_rule", acl_rules), ("acl_policy", acl_policies)):
                     for row in rows:
                         self._write_line(handle, {"record_type": kind, "data": self._normalized_row(row)})
             os.replace(temp_name, path)

--- a/core/p6_four_package_manifest.py
+++ b/core/p6_four_package_manifest.py
@@ -1,0 +1,106 @@
+"""Pure validation for the shared P6 four-package manifest contract."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+
+FOUR_PACKAGE_MANIFEST_SCHEMA = "ops.p6.four_package_manifest.v1"
+FOUR_PACKAGE_MANIFEST_REPORT_SCHEMA = "ops.p6.four_package_manifest_report.v1"
+FOUR_PACKAGE_IDS = ("companion", "memory", "ops_archive", "peiban")
+
+_REQUIRED_MANIFEST_FIELDS = (
+    "schema",
+    "package_id",
+    "manifest_version",
+    "package_fingerprint",
+    "compatibility_fingerprint",
+)
+_MANIFEST_VERSION_PATTERN = re.compile(r"^[1-9]\d*\.[0-9]+$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _contract_payload() -> dict[str, object]:
+    return {
+        "schema": FOUR_PACKAGE_MANIFEST_SCHEMA,
+        "report_schema": FOUR_PACKAGE_MANIFEST_REPORT_SCHEMA,
+        "package_ids": list(FOUR_PACKAGE_IDS),
+        "required_manifest_fields": list(_REQUIRED_MANIFEST_FIELDS),
+    }
+
+
+def manifest_contract() -> dict[str, object]:
+    descriptor = _contract_payload()
+    canonical = json.dumps(descriptor, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    descriptor["contract_fingerprint"] = hashlib.sha256(canonical).hexdigest()
+    return descriptor
+
+
+def _unverifiable_report(reason_code: str) -> dict[str, object]:
+    return {
+        "schema": FOUR_PACKAGE_MANIFEST_REPORT_SCHEMA,
+        "status": "unverifiable",
+        "reason_code": reason_code,
+        "expected_package_ids": list(FOUR_PACKAGE_IDS),
+    }
+
+
+def _verified_report() -> dict[str, object]:
+    return {
+        "schema": FOUR_PACKAGE_MANIFEST_REPORT_SCHEMA,
+        "status": "verified",
+        "reason_code": "four_package_manifest_verified",
+        "expected_package_ids": list(FOUR_PACKAGE_IDS),
+    }
+
+
+def verify_four_package_manifests(manifests: object) -> dict[str, object]:
+    """Verify values only; no package object or runtime is inspected."""
+    if type(manifests) is not dict:
+        return _unverifiable_report("manifest_collection_not_exact_dict")
+    for package_id in manifests:
+        if type(package_id) is not str or package_id not in FOUR_PACKAGE_IDS:
+            return _unverifiable_report("unexpected_package_manifest")
+    for package_id in FOUR_PACKAGE_IDS:
+        if package_id not in manifests:
+            return _unverifiable_report("missing_package_manifest")
+
+    common_compatibility_fingerprint = None
+    for package_id in FOUR_PACKAGE_IDS:
+        package_manifest = manifests[package_id]
+        if type(package_manifest) is not dict:
+            return _unverifiable_report("package_manifest_not_exact_dict")
+        for field_name in package_manifest:
+            if type(field_name) is not str or field_name not in _REQUIRED_MANIFEST_FIELDS:
+                return _unverifiable_report("unexpected_manifest_field")
+        for field_name in _REQUIRED_MANIFEST_FIELDS:
+            if field_name not in package_manifest:
+                return _unverifiable_report("missing_manifest_field")
+        if type(package_manifest["schema"]) is not str or package_manifest["schema"] != FOUR_PACKAGE_MANIFEST_SCHEMA:
+            return _unverifiable_report("manifest_schema_mismatch")
+        if type(package_manifest["package_id"]) is not str or package_manifest["package_id"] != package_id:
+            return _unverifiable_report("manifest_package_id_mismatch")
+        version = package_manifest["manifest_version"]
+        if type(version) is not str or _MANIFEST_VERSION_PATTERN.fullmatch(version) is None:
+            return _unverifiable_report("manifest_version_invalid")
+        package_fingerprint = package_manifest["package_fingerprint"]
+        if type(package_fingerprint) is not str or _SHA256_PATTERN.fullmatch(package_fingerprint) is None:
+            return _unverifiable_report("package_fingerprint_invalid")
+        compatibility_fingerprint = package_manifest["compatibility_fingerprint"]
+        if type(compatibility_fingerprint) is not str or _SHA256_PATTERN.fullmatch(compatibility_fingerprint) is None:
+            return _unverifiable_report("compatibility_fingerprint_invalid")
+        if common_compatibility_fingerprint is None:
+            common_compatibility_fingerprint = compatibility_fingerprint
+        elif compatibility_fingerprint != common_compatibility_fingerprint:
+            return _unverifiable_report("compatibility_fingerprint_mismatch")
+    return _verified_report()
+
+
+__all__ = [
+    "FOUR_PACKAGE_IDS",
+    "FOUR_PACKAGE_MANIFEST_REPORT_SCHEMA",
+    "FOUR_PACKAGE_MANIFEST_SCHEMA",
+    "manifest_contract",
+    "verify_four_package_manifests",
+]

--- a/core/p6_readonly_projection.py
+++ b/core/p6_readonly_projection.py
@@ -1,0 +1,51 @@
+"""P6 minimal read-only status projection."""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+P6_READONLY_STATUS_SCHEMA = "ops.p6.read_only_status.v1"
+_STATUS_FIELDS = ("profiles", "identity_links", "audit_events", "operations")
+_HEALTH = frozenset({"ready", "degraded", "unverifiable"})
+
+
+def _fingerprint() -> str:
+    payload = {"schema_version": P6_READONLY_STATUS_SCHEMA, "count_fields": _STATUS_FIELDS}
+    encoded = json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+P6_READONLY_STATUS_FINGERPRINT = _fingerprint()
+
+
+def _count(value: Any) -> int:
+    return value if type(value) is int and 0 <= value <= 10_000_000 else 0
+
+
+def build_p6_readonly_status(status: Any, *, health: str = "ready", reason_code: str = "") -> dict[str, Any]:
+    """Return bounded counts only; P4 and identity authority never crosses this boundary."""
+    status_available = type(status) is dict
+    if status_available:
+        for key in status:
+            if type(key) is not str:
+                status_available = False
+                break
+    source = status if status_available else {}
+    normalized_health = health if type(health) is str and health in _HEALTH else "unverifiable"
+    normalized_reason = reason_code if type(reason_code) is str and len(reason_code) <= 80 else "invalid_reason_code"
+    if not status_available:
+        normalized_health = "unverifiable"
+        normalized_reason = "registry_status_unavailable"
+    return {
+        "schema_version": P6_READONLY_STATUS_SCHEMA,
+        "source_plugin": "memory_companion",
+        "contract_fingerprint": P6_READONLY_STATUS_FINGERPRINT,
+        "health": normalized_health,
+        "reason_code": normalized_reason,
+        "counts": {field: _count(source.get(field)) for field in _STATUS_FIELDS},
+    }
+
+
+__all__ = ["P6_READONLY_STATUS_SCHEMA", "P6_READONLY_STATUS_FINGERPRINT", "build_p6_readonly_status"]

--- a/core/person_context_contract.py
+++ b/core/person_context_contract.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+import unicodedata
+from typing import Any
+
+
+CONTRACT_NAME = "chat.unified_person.v1"
+CONTRACT_VERSION = "1.0"
+PROJECTION_SCHEMA_VERSION = "1.0"
+P3_CONTRACT_NAME = "chat.p3.context.v1"
+P3_CONTRACT_VERSION = "1.0"
+P3_SLOT_NAMES = ("persona", "runtime", "person", "scene")
+P3_SLOT_OWNERS = {
+    "persona": "companion",
+    "runtime": "companion",
+    "person": "memory_projection",
+    "scene": "companion",
+}
+P3_SLOT_STATES = frozenset({"ready", "legacy_local", "invalid", "degraded", "pending"})
+IDENTITY_FIELDS = (
+    "companion_instance_id",
+    "bot_account_id",
+    "adapter_instance_id",
+    "subject_namespace",
+    "platform_subject_id",
+)
+PROJECTION_FIELDS = (
+    "contract_name",
+    "contract_version",
+    "contract_fingerprint",
+    "projection_schema_version",
+    "projection_revision",
+    "person_id",
+    "resolved_identity_key",
+    "identity_assurance",
+    "profile_status",
+    "display_name",
+    "aliases",
+    "relation_policy_id",
+    "relation_label",
+    "owner_mode",
+    "affinity_score",
+    "affinity_band",
+    "relationship_capabilities",
+    "group_overlay_ref",
+    "updated_at",
+)
+IDENTITY_ASSURANCE_VALUES = frozenset({"unverified", "observed", "verified", "explicit_linked"})
+PROFILE_STATUS_VALUES = frozenset({"active", "suspended", "quarantined", "deleted"})
+OWNER_MODE_VALUES = frozenset({"none", "owner", "not_owner"})
+AFFINITY_BAND_VALUES = frozenset({"critical", "guarded", "neutral", "positive"})
+RELATIONSHIP_CAPABILITIES = frozenset(
+    {
+        "comfort",
+        "proactive_care",
+        "joking",
+        "affectionate_address",
+        "missing_you",
+        "romantic_expression",
+    }
+)
+CONTEXT_FORBIDDEN_KEYS = frozenset(
+    {
+        "raw_prompt",
+        "prompt",
+        "private_object",
+        "private_object_ref",
+        "object",
+        "chat_text",
+        "content",
+        "messages",
+        "transcript",
+        "database",
+    }
+)
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _text(value: Any, field: str, limit: int = 160) -> str:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        raise ValueError(f"{field}_invalid")
+    text = unicodedata.normalize("NFC", str(value)).strip()
+    if not text or "\x00" in text or len(text) > limit:
+        raise ValueError(f"{field}_invalid")
+    return text
+
+
+def canonical_identity(identity: dict[str, Any]) -> dict[str, str]:
+    if not isinstance(identity, dict):
+        raise ValueError("identity_invalid")
+    result = {field: _text(identity.get(field), field) for field in IDENTITY_FIELDS}
+    result["subject_namespace"] = result["subject_namespace"].lower()
+    return result
+
+
+def build_identity_key(identity: dict[str, Any]) -> str:
+    digest = hashlib.sha256(_canonical(canonical_identity(identity)).encode("utf-8")).hexdigest()
+    return f"chat-origin-v1:{digest}"
+
+
+def person_id_for_identity(identity: dict[str, Any]) -> str:
+    return f"person_{hashlib.sha256(build_identity_key(identity).encode('utf-8')).hexdigest()[:24]}"
+
+
+def affinity_band(score: Any) -> str:
+    try:
+        value = int(score)
+    except (TypeError, ValueError):
+        value = 0
+    if value <= -800:
+        return "critical"
+    if value < 0:
+        return "guarded"
+    if value == 0:
+        return "neutral"
+    return "positive"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def empty_person_store() -> dict[str, Any]:
+    return {
+        "version": 1,
+        "profiles": {},
+        "identity_links": {},
+        "group_overlays": {},
+        "relation_policies": {
+            "default_friend": {
+                "label": "friend",
+                "capabilities": [],
+                "active": True,
+            }
+        },
+        "audit_events": [],
+    }
+
+
+def ensure_person_store(data: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    if not isinstance(data, dict):
+        raise ValueError("store_invalid")
+    changed = False
+    root = data.get("unified_person")
+    if not isinstance(root, dict):
+        data["unified_person"] = empty_person_store()
+        return data, True
+    defaults = empty_person_store()
+    for key, value in defaults.items():
+        if key not in root or not isinstance(root.get(key), type(value)):
+            root[key] = value.copy() if isinstance(value, dict) else list(value) if isinstance(value, list) else value
+            changed = True
+    root["version"] = max(1, int(root.get("version") or 0))
+    return data, changed
+
+
+def _list_text(value: Any, limit: int = 120, count: int = 12) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    result: list[str] = []
+    for item in value:
+        try:
+            text = _text(item, "list_item", limit)
+        except ValueError:
+            continue
+        if text not in result:
+            result.append(text)
+        if len(result) >= count:
+            break
+    return result
+
+
+def build_person_projection(store: dict[str, Any], person_id: str) -> dict[str, Any] | None:
+    root = store.get("unified_person") if isinstance(store, dict) else None
+    profiles = root.get("profiles") if isinstance(root, dict) and isinstance(root.get("profiles"), dict) else {}
+    profile = profiles.get(str(person_id or ""))
+    if not isinstance(profile, dict):
+        return None
+    identity_key = profile.get("resolved_identity_key")
+    policy_id = str(profile.get("relation_policy_id") or "default_friend")
+    policies = root.get("relation_policies") if isinstance(root.get("relation_policies"), dict) else {}
+    policy = policies.get(policy_id) if isinstance(policies.get(policy_id), dict) else {}
+    projection = {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "contract_fingerprint": CONTRACT_FINGERPRINT,
+        "projection_schema_version": PROJECTION_SCHEMA_VERSION,
+        "projection_revision": max(1, int(profile.get("projection_revision") or 1)),
+        "person_id": str(profile.get("person_id") or ""),
+        "resolved_identity_key": str(identity_key or ""),
+        "identity_assurance": str(profile.get("identity_assurance") or "unverified"),
+        "profile_status": str(profile.get("profile_status") or "active"),
+        "display_name": str(profile.get("display_name") or ""),
+        "aliases": _list_text(profile.get("aliases")),
+        "relation_policy_id": policy_id,
+        "relation_label": str(policy.get("label") or "friend"),
+        "owner_mode": str(profile.get("owner_mode") or "not_owner"),
+        "affinity_score": max(-1200, min(1200, int(profile.get("affinity_score") or 0))),
+        "affinity_band": affinity_band(profile.get("affinity_score") or 0),
+        "relationship_capabilities": [
+            item for item in _list_text(policy.get("capabilities"), 60) if item in RELATIONSHIP_CAPABILITIES
+        ],
+        "group_overlay_ref": str(profile.get("group_overlay_ref") or ""),
+        "updated_at": str(profile.get("updated_at") or ""),
+    }
+    return projection if not validate_projection(projection) else None
+
+
+def validate_projection(projection: Any) -> list[str]:
+    if not isinstance(projection, dict):
+        return ["projection_invalid"]
+    errors = [f"missing_{field}" for field in PROJECTION_FIELDS if field not in projection]
+    if errors:
+        return errors
+    if projection.get("contract_name") != CONTRACT_NAME:
+        errors.append("contract_name_mismatch")
+    if projection.get("contract_version") != CONTRACT_VERSION:
+        errors.append("contract_version_mismatch")
+    if projection.get("contract_fingerprint") != CONTRACT_FINGERPRINT:
+        errors.append("contract_fingerprint_mismatch")
+    if projection.get("projection_schema_version") != PROJECTION_SCHEMA_VERSION:
+        errors.append("projection_schema_version_mismatch")
+    for field in ("person_id", "resolved_identity_key", "display_name", "relation_policy_id", "relation_label", "updated_at"):
+        value = projection.get(field)
+        if not isinstance(value, str) or not value or "\x00" in value or len(value) > 240:
+            errors.append(f"{field}_invalid")
+    if not re.fullmatch(r"chat-origin-v1:[0-9a-f]{64}", str(projection.get("resolved_identity_key") or "")):
+        errors.append("resolved_identity_key_invalid")
+    if not re.fullmatch(r"person_[0-9a-f]{24}", str(projection.get("person_id") or "")):
+        errors.append("person_id_invalid")
+    if not isinstance(projection.get("projection_revision"), int) or projection["projection_revision"] < 1:
+        errors.append("projection_revision_invalid")
+    if projection.get("identity_assurance") not in IDENTITY_ASSURANCE_VALUES:
+        errors.append("identity_assurance_invalid")
+    if projection.get("profile_status") not in PROFILE_STATUS_VALUES:
+        errors.append("profile_status_invalid")
+    if projection.get("owner_mode") not in OWNER_MODE_VALUES:
+        errors.append("owner_mode_invalid")
+    if not isinstance(projection.get("aliases"), list) or any(not isinstance(item, str) for item in projection["aliases"]):
+        errors.append("aliases_invalid")
+    if not isinstance(projection.get("relationship_capabilities"), list) or not set(projection["relationship_capabilities"]).issubset(RELATIONSHIP_CAPABILITIES):
+        errors.append("relationship_capabilities_invalid")
+    score = projection.get("affinity_score")
+    if not isinstance(score, int) or not -1200 <= score <= 1200:
+        errors.append("affinity_score_invalid")
+    elif projection.get("affinity_band") != affinity_band(score):
+        errors.append("affinity_band_inconsistent")
+    if projection.get("group_overlay_ref") is not None and not isinstance(projection.get("group_overlay_ref"), str):
+        errors.append("group_overlay_ref_invalid")
+    return errors
+
+
+def resolve_identity(store: dict[str, Any], identity: dict[str, Any]) -> dict[str, Any]:
+    try:
+        identity_key = build_identity_key(identity)
+    except ValueError:
+        return {"state": "invalid", "identity_key": "", "person_id": "", "errors": ["identity_invalid"]}
+    root = store.get("unified_person") if isinstance(store, dict) else None
+    links = root.get("identity_links") if isinstance(root, dict) and isinstance(root.get("identity_links"), dict) else {}
+    link = links.get(identity_key)
+    if not isinstance(link, dict):
+        return {"state": "pending", "identity_key": identity_key, "person_id": ""}
+    person_id = str(link.get("person_id") or "")
+    projection = build_person_projection(store, person_id)
+    if projection is None:
+        return {"state": "invalid", "identity_key": identity_key, "person_id": person_id, "errors": ["projection_invalid"]}
+    return {"state": "resolved", "identity_key": identity_key, "person_id": person_id, "projection": projection}
+
+
+def _safe_context_value(value: Any, depth: int = 0) -> Any:
+    if depth > 2:
+        return None
+    if isinstance(value, bool) or value is None or isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        return value[:240]
+    if isinstance(value, (list, tuple)):
+        return [_safe_context_value(item, depth + 1) for item in list(value)[:12]]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in list(value.items())[:24]:
+            name = str(key).strip().lower()
+            if not name or name in CONTEXT_FORBIDDEN_KEYS:
+                continue
+            safe = _safe_context_value(item, depth + 1)
+            if safe is not None:
+                result[name[:80]] = safe
+        return result
+    return None
+
+
+def make_context_slot(slot: str, payload: dict[str, Any] | None, *, owner: str = "", revision: int = 1, state: str = "ready", warnings: list[str] | None = None) -> dict[str, Any]:
+    slot_name = str(slot or "")
+    actual_owner = owner or P3_SLOT_OWNERS.get(slot_name, "unknown")
+    return {
+        "slot": slot_name,
+        "owner": actual_owner,
+        "revision": max(1, int(revision or 1)),
+        "contract_name": P3_CONTRACT_NAME,
+        "contract_version": P3_CONTRACT_VERSION,
+        "contract_fingerprint": P3_CONTRACT_FINGERPRINT,
+        "state": state if state in P3_SLOT_STATES else "invalid",
+        "payload": _safe_context_value(payload or {}) or {},
+        "warnings": [str(item)[:120] for item in (warnings or [])[:8]],
+    }
+
+
+def validate_context_slot(slot: Any, expected_name: str = "") -> list[str]:
+    if not isinstance(slot, dict):
+        return ["slot_invalid"]
+    errors: list[str] = []
+    name = str(slot.get("slot") or "")
+    if name not in P3_SLOT_NAMES or (expected_name and name != expected_name):
+        errors.append("slot_name_invalid")
+    if slot.get("owner") != P3_SLOT_OWNERS.get(name):
+        errors.append("slot_owner_mismatch")
+    if slot.get("contract_name") != P3_CONTRACT_NAME or slot.get("contract_version") != P3_CONTRACT_VERSION:
+        errors.append("slot_contract_mismatch")
+    if slot.get("contract_fingerprint") != P3_CONTRACT_FINGERPRINT:
+        errors.append("slot_fingerprint_mismatch")
+    if not isinstance(slot.get("revision"), int) or slot["revision"] < 1:
+        errors.append("slot_revision_invalid")
+    if slot.get("state") not in P3_SLOT_STATES:
+        errors.append("slot_state_invalid")
+    if not isinstance(slot.get("payload"), dict):
+        errors.append("slot_payload_invalid")
+    return errors
+
+
+def build_context_projection(slots: dict[str, dict[str, Any]] | None = None, *, state: str = "ready", revision: int = 1, warnings: list[str] | None = None) -> dict[str, Any]:
+    incoming = slots if isinstance(slots, dict) else {}
+    return {
+        "contract_name": P3_CONTRACT_NAME,
+        "contract_version": P3_CONTRACT_VERSION,
+        "contract_fingerprint": P3_CONTRACT_FINGERPRINT,
+        "revision": max(1, int(revision or 1)),
+        "state": state if state in P3_SLOT_STATES else "invalid",
+        "slots": {name: incoming.get(name, make_context_slot(name, {}, state="pending")) for name in P3_SLOT_NAMES},
+        "warnings": [str(item)[:120] for item in (warnings or [])[:8]],
+    }
+
+
+def validate_context_projection(context: Any) -> list[str]:
+    if not isinstance(context, dict):
+        return ["context_invalid"]
+    errors: list[str] = []
+    if context.get("contract_name") != P3_CONTRACT_NAME or context.get("contract_version") != P3_CONTRACT_VERSION:
+        errors.append("context_contract_mismatch")
+    if context.get("contract_fingerprint") != P3_CONTRACT_FINGERPRINT:
+        errors.append("context_fingerprint_mismatch")
+    slots = context.get("slots")
+    if not isinstance(slots, dict):
+        return errors + ["context_slots_invalid"]
+    for name in P3_SLOT_NAMES:
+        errors.extend(validate_context_slot(slots.get(name), name))
+    return errors
+
+
+def merge_context_slots(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    result = dict(existing) if isinstance(existing, dict) else build_context_projection()
+    old_slots = result.get("slots") if isinstance(result.get("slots"), dict) else {}
+    new_slots = incoming.get("slots") if isinstance(incoming, dict) and isinstance(incoming.get("slots"), dict) else {}
+    merged = dict(old_slots)
+    for name in P3_SLOT_NAMES:
+        candidate = new_slots.get(name)
+        if not isinstance(candidate, dict) or validate_context_slot(candidate, name):
+            continue
+        previous = merged.get(name)
+        if not isinstance(previous, dict) or int(candidate.get("revision") or 0) >= int(previous.get("revision") or 0):
+            merged[name] = candidate
+    result["slots"] = merged
+    result["revision"] = max(int(result.get("revision") or 1), int(incoming.get("revision") or 1) if isinstance(incoming, dict) else 1)
+    return result
+
+
+def _contract_shape() -> dict[str, Any]:
+    return {
+        "name": CONTRACT_NAME,
+        "version": CONTRACT_VERSION,
+        "projection_schema_version": PROJECTION_SCHEMA_VERSION,
+        "identity_fields": list(IDENTITY_FIELDS),
+        "projection_fields": list(PROJECTION_FIELDS),
+        "p3_name": P3_CONTRACT_NAME,
+        "p3_version": P3_CONTRACT_VERSION,
+        "p3_slots": list(P3_SLOT_NAMES),
+        "p3_owners": dict(P3_SLOT_OWNERS),
+    }
+
+
+CONTRACT_FINGERPRINT = hashlib.sha256(_canonical(_contract_shape()).encode("utf-8")).hexdigest()[:16]
+P3_CONTRACT_FINGERPRINT = hashlib.sha256(
+    _canonical({"name": P3_CONTRACT_NAME, "version": P3_CONTRACT_VERSION, "slots": list(P3_SLOT_NAMES), "owners": P3_SLOT_OWNERS}).encode("utf-8")
+).hexdigest()[:16]
+
+
+def contract_self_check() -> list[str]:
+    errors: list[str] = []
+    if CONTRACT_FINGERPRINT != hashlib.sha256(_canonical(_contract_shape()).encode("utf-8")).hexdigest()[:16]:
+        errors.append("contract_fingerprint_stale")
+    if P3_CONTRACT_FINGERPRINT != hashlib.sha256(
+        _canonical({"name": P3_CONTRACT_NAME, "version": P3_CONTRACT_VERSION, "slots": list(P3_SLOT_NAMES), "owners": P3_SLOT_OWNERS}).encode("utf-8")
+    ).hexdigest()[:16]:
+        errors.append("p3_contract_fingerprint_stale")
+    if set(P3_SLOT_NAMES) != set(P3_SLOT_OWNERS):
+        errors.append("p3_slot_owner_mismatch")
+    return errors
+
+
+__all__ = [name for name in globals() if name.isupper() or name in {
+    "affinity_band", "build_context_projection", "build_identity_key", "build_person_projection",
+    "canonical_identity", "contract_self_check", "empty_person_store", "ensure_person_store",
+    "make_context_slot", "merge_context_slots", "person_id_for_identity", "resolve_identity",
+    "validate_context_projection", "validate_context_slot", "validate_projection",
+}]

--- a/core/person_projection.py
+++ b/core/person_projection.py
@@ -1,0 +1,142 @@
+"""Read-only consumer for the companion-owned Unified Person projection.
+
+The memory plugin is deliberately not an authority for person creation or
+identity linking.  This module accepts a projection produced by the companion
+plugin, validates it against the shared contract, and returns only a small
+safe reference suitable for memory retrieval/context decisions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .person_context_contract import (
+    PROJECTION_SCHEMA_VERSION,
+    CONTRACT_FINGERPRINT,
+    resolve_identity,
+    validate_projection,
+)
+
+
+_SAFE_REFERENCE_FIELDS = (
+    "person_id",
+    "resolved_identity_key",
+    "projection_revision",
+    "projection_schema_version",
+    "contract_fingerprint",
+    "identity_assurance",
+    "profile_status",
+    "owner_mode",
+    "relation_policy_id",
+    "relation_label",
+    "affinity_band",
+    "relationship_capabilities",
+    "group_overlay_ref",
+    "updated_at",
+)
+
+
+def _reference(projection: dict[str, Any]) -> dict[str, Any]:
+    """Copy only contract-approved metadata; never return caller objects."""
+
+    result: dict[str, Any] = {}
+    for field in _SAFE_REFERENCE_FIELDS:
+        value = projection.get(field)
+        if field == "relationship_capabilities":
+            result[field] = list(value) if isinstance(value, list) else []
+        else:
+            result[field] = value
+    return result
+
+
+def consume_person_projection(
+    projection: Any,
+    expected_identity_key: str = "",
+    expected_person_id: str = "",
+    *,
+    companion_available: bool = True,
+    identity_store: dict[str, Any] | None = None,
+    identity: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Consume a companion projection without creating or mutating anything.
+
+    ``identity_store`` and ``identity`` are optional read-only verification
+    inputs.  When both are supplied, the shared ``resolve_identity`` contract
+    function is used and the resolved person/key must agree with the incoming
+    projection.  Normal bridge calls only need the three positional arguments.
+    """
+
+    base = {"read_only": True, "source": "companion_projection"}
+    if not companion_available:
+        return {
+            **base,
+            "state": "degraded",
+            "degraded": True,
+            "errors": ["companion_unavailable"],
+        }
+    if not isinstance(projection, dict):
+        return {**base, "state": "invalid", "errors": ["projection_invalid"]}
+
+    errors = list(validate_projection(projection))
+    if errors:
+        return {**base, "state": "invalid", "errors": errors}
+
+    person_id = str(projection.get("person_id") or "")
+    identity_key = str(projection.get("resolved_identity_key") or "")
+    if expected_person_id and person_id != expected_person_id:
+        errors.append("person_id_mismatch")
+    if expected_identity_key and identity_key != expected_identity_key:
+        errors.append("identity_key_mismatch")
+
+    if identity_store is not None or identity is not None:
+        if not isinstance(identity_store, dict) or not isinstance(identity, dict):
+            errors.append("identity_resolution_input_invalid")
+        else:
+            resolved = resolve_identity(identity_store, identity)
+            if resolved.get("state") != "resolved":
+                errors.append(f"identity_{resolved.get('state', 'invalid')}")
+            else:
+                if resolved.get("identity_key") != identity_key:
+                    errors.append("identity_key_unresolved")
+                if resolved.get("person_id") != person_id:
+                    errors.append("person_id_unresolved")
+
+    if errors:
+        return {
+            **base,
+            "state": "invalid",
+            "errors": errors,
+            "projection_ref": {"person_id": person_id, "resolved_identity_key": identity_key},
+        }
+
+    return {
+        **base,
+        "state": "resolved",
+        "degraded": False,
+        "projection_ref": _reference(projection),
+    }
+
+
+def projection_capability(*, companion_available: bool = True) -> dict[str, Any]:
+    """Return a database-free, read-only capability descriptor."""
+
+    if not companion_available:
+        return {
+            "available": False,
+            "state": "degraded",
+            "degraded": True,
+            "read_only": True,
+            "reason": "companion_unavailable",
+        }
+    return {
+        "available": True,
+        "state": "ready",
+        "degraded": False,
+        "read_only": True,
+        "projection_schema_version": PROJECTION_SCHEMA_VERSION,
+        "contract_fingerprint": CONTRACT_FINGERPRINT,
+        "methods": ["consume_person_projection"],
+    }
+
+
+__all__ = ["consume_person_projection", "projection_capability"]

--- a/core/portrait.py
+++ b/core/portrait.py
@@ -1,0 +1,259 @@
+"""REQ-036 portrait facts, evidence normalization, and pre-retrieval policy."""
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+try:
+    from ..unified_profile_contract import (
+        LOW_SENSITIVITY,
+        build_person_ref,
+        validate_person_ref,
+        validate_portrait_request,
+    )
+except ImportError:  # Existing standalone core.* test/import compatibility.
+    from unified_profile_contract import (  # type: ignore[no-redef]
+        LOW_SENSITIVITY,
+        build_person_ref,
+        validate_person_ref,
+        validate_portrait_request,
+    )
+from .models import clean_text
+
+
+PORTRAIT_TIERS = frozenset({"base", "intelligent"})
+SENSITIVITY_LEVELS = frozenset({"low", "sensitive", "high"})
+SUPPRESSION_STATUSES = frozenset({"active", "reconfirmation_pending", "revoked", "superseded", "expired"})
+PURPOSE_RESULT_CODES = {
+    "adapt_for_subject": "profile_exact",
+    "summarize_to_subject": "profile_exact",
+    "disclose_to_third_party": "portrait_third_party_forbidden",
+}
+
+_SENSITIVE_TOKENS = (
+    "疾病", "病", "过敏", "治疗", "药", "医院", "政治", "宗教", "信仰", "性", "住址", "地址",
+    "定位", "行程", "财务", "工资", "密码", "账号", "身份证", "创伤", "自杀",
+)
+_EXPLICIT_PATTERNS = (
+    (r"(?:我|咱|俺)(?:很|最|超|特别|有点|真的|超级)?喜欢(.{1,40})", "preference", "like"),
+    (r"(?:我|咱|俺)(?:不喜欢|不爱|不太喜欢|讨厌)(.{1,40})", "preference", "dislike"),
+    (r"(?:以后|之后)?(?:叫我|喊我)(.{1,20})", "preferred_address", "address"),
+    (r"(?:我|咱|俺)(?:通常|一般|习惯|经常)(.{2,40})", "communication_preference", "habit"),
+    (r"(?:别问我|不要问我|不想聊)(.{0,30})", "boundary", "avoid"),
+)
+_CROSS_SCENE_PREFERENCE_MARKERS = (
+    "吃", "喝", "食物", "料理", "烤肉", "火锅", "甜品", "咖啡", "茶",
+    "音乐", "歌曲", "乐队", "电影", "影视", "剧", "动漫", "游戏", "桌游",
+    "画画", "阅读", "摄影", "跑步", "运动",
+)
+_CROSS_SCENE_COMMUNICATION_MARKERS = (
+    "简短", "详细", "直接", "委婉", "表情", "emoji", "中文", "英文", "日文",
+    "语言", "语气", "称呼", "沟通", "回复",
+)
+_CROSS_SCENE_DENY_MARKERS = (
+    "工作", "上班", "学习", "学校", "凌晨", "早上", "晚上", "睡", "作息",
+    "地点", "住", "城市", "家", "朋友", "恋人", "健康",
+)
+
+
+def _text(value: Any, limit: int = 240) -> str:
+    return clean_text(value, limit) if value is not None else ""
+
+
+def normalized_claim_hash(dimension: Any, claim: Any) -> str:
+    normalized = re.sub(r"\s+", "", _text(claim, 160).lower())
+    raw = f"{_text(dimension, 80).lower()}:{normalized}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def evidence_hash(*, person_id: Any, scope: Any, session_id: Any, message_id: Any, text: Any) -> str:
+    raw = "|".join(
+        (
+            _text(person_id, 80),
+            _text(scope, 80),
+            _text(session_id, 200),
+            _text(message_id, 120),
+            _text(text, 1800),
+        )
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def statement_fingerprint(text: Any) -> str:
+    """Hash a normalized source statement without retaining its body.
+
+    Message IDs keep event evidence auditable.  This separate fingerprint keeps
+    mechanically repeated statements from becoming artificial independent
+    evidence for one portrait claim.
+    """
+    normalized = re.sub(r"\s+", "", _text(text, 1800).lower())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest() if normalized else ""
+
+
+def classify_sensitivity(claim: Any) -> str:
+    text = _text(claim, 160).lower()
+    if any(token.lower() in text for token in _SENSITIVE_TOKENS):
+        return "high"
+    return LOW_SENSITIVITY
+
+
+def cross_scene_whitelisted_fact(
+    *,
+    dimension: Any,
+    claim_summary: Any,
+    sensitivity: Any,
+    source_scope: Any,
+) -> bool:
+    """Return whether a fact may leave its source scope for its own subject.
+
+    The first REQ-036 release is deliberately allowlist-only.  Low sensitivity
+    alone is insufficient because work, schedule, location, and relationship
+    details can be low-labelled yet still violate the frozen cross-scene policy.
+    """
+    if _text(sensitivity, 24) != LOW_SENSITIVITY or _text(source_scope, 80) != "private":
+        return False
+    normalized_dimension = _text(dimension, 80).lower()
+    summary = _text(claim_summary, 180).lower()
+    if not summary or any(marker in summary for marker in _CROSS_SCENE_DENY_MARKERS):
+        return False
+    if normalized_dimension == "preferred_address":
+        return True
+    if normalized_dimension == "communication_preference":
+        return any(marker in summary for marker in _CROSS_SCENE_COMMUNICATION_MARKERS)
+    if normalized_dimension == "preference":
+        return any(marker in summary for marker in _CROSS_SCENE_PREFERENCE_MARKERS)
+    return False
+
+
+def extract_explicit_candidates(text: Any) -> list[dict[str, str]]:
+    """Extract only self-contained first-person statements without context text."""
+    source = _text(text, 1800)
+    if not source:
+        return []
+    results: list[dict[str, str]] = []
+    for pattern, dimension, kind in _EXPLICIT_PATTERNS:
+        match = re.search(pattern, source)
+        if not match:
+            continue
+        claim = _text(match.group(1).strip(" ，。！？!?.：:"), 80)
+        if not claim:
+            continue
+        summary = {
+            "like": f"喜欢 {claim}",
+            "dislike": f"不喜欢 {claim}",
+            "address": f"希望被称为 {claim}",
+            "habit": f"沟通习惯：{claim}",
+            "avoid": f"不希望聊 {claim}" if claim else "有明确不想聊的内容",
+        }[kind]
+        item = {
+            "dimension": dimension,
+            "normalized_claim_hash": normalized_claim_hash(dimension, f"{kind}:{claim}"),
+            "claim_summary": _text(summary, 180),
+            "sensitivity": classify_sensitivity(claim),
+            "producer_kind": "rule_explicit",
+            "producer_version": "req036.rule.v1",
+            "derivation_kind": "explicit_statement",
+            "epistemic_status": "explicit",
+        }
+        if item not in results:
+            results.append(item)
+    return results
+
+
+def build_evidence(
+    *,
+    person_ref: Any,
+    scope: Any,
+    session_id: Any,
+    message_id: Any,
+    source_identity_key: Any,
+    text: Any,
+    context_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    ref = build_person_ref(person_ref)
+    return {
+        "person_id": ref["person_id"],
+        "origin_identity_key": _text(source_identity_key, 96) or ref["resolved_identity_key"],
+        "scope": _text(scope, 80),
+        "session_id": _text(session_id, 200),
+        "message_id": _text(message_id, 120),
+        "evidence_hash": evidence_hash(
+            person_id=ref["person_id"],
+            scope=scope,
+            session_id=session_id,
+            message_id=message_id,
+            text=text,
+        ),
+        "statement_fingerprint": statement_fingerprint(text),
+        "context_refs": [_text(item, 160) for item in (context_refs or []) if _text(item, 160)][:8],
+    }
+
+
+def portrait_access_decision(request: Any) -> dict[str, Any]:
+    """Return before candidate retrieval; callers must obey candidates_allowed."""
+    errors = validate_portrait_request(request)
+    if errors:
+        return {
+            "allowed": False,
+            "candidates_allowed": False,
+            "code": "bridge_contract_mismatch",
+            "errors": errors,
+            "max_sensitivity": "",
+        }
+    payload = request if isinstance(request, dict) else {}
+    person_ref = payload.get("person_ref") if isinstance(payload.get("person_ref"), dict) else {}
+    ref_errors = validate_person_ref(person_ref)
+    if ref_errors:
+        return {
+            "allowed": False,
+            "candidates_allowed": False,
+            "code": "bridge_person_mismatch",
+            "errors": ref_errors,
+            "max_sensitivity": "",
+        }
+    requester = _text(payload.get("requester_person_id"), 80)
+    target = _text(payload.get("target_person_id"), 80)
+    purpose = _text(payload.get("purpose"), 80)
+    if purpose == "disclose_to_third_party" or not requester or requester != target:
+        return {
+            "allowed": False,
+            "candidates_allowed": False,
+            "code": "portrait_third_party_forbidden",
+            "errors": [],
+            "max_sensitivity": "",
+        }
+    if person_ref.get("person_id") != target or person_ref.get("profile_status") != "active":
+        return {
+            "allowed": False,
+            "candidates_allowed": False,
+            "code": "bridge_person_mismatch",
+            "errors": [],
+            "max_sensitivity": "",
+        }
+    if person_ref.get("identity_assurance") not in {"observed", "verified", "explicit_linked"}:
+        return {
+            "allowed": False,
+            "candidates_allowed": False,
+            "code": "bridge_person_mismatch",
+            "errors": [],
+            "max_sensitivity": "",
+        }
+    return {
+        "allowed": True,
+        "candidates_allowed": True,
+        "code": PURPOSE_RESULT_CODES.get(purpose, "bridge_contract_mismatch"),
+        "errors": [],
+        "max_sensitivity": LOW_SENSITIVITY,
+    }
+
+
+def suppression_key(person_id: Any, dimension: Any, claim_hash: Any, scope: Any) -> str:
+    raw = "|".join((_text(person_id, 80), _text(dimension, 80), _text(claim_hash, 80), _text(scope, 80)))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [name for name in globals() if name.isupper() or name in {
+    "build_evidence", "classify_sensitivity", "evidence_hash", "extract_explicit_candidates",
+    "cross_scene_whitelisted_fact", "normalized_claim_hash", "portrait_access_decision", "statement_fingerprint", "suppression_key",
+}]

--- a/core/portrait_service.py
+++ b/core/portrait_service.py
@@ -1,0 +1,189 @@
+"""Memory-owned REQ-036 portrait capture, governance, and read boundary."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    from ..unified_profile_contract import build_person_ref, validate_profile_dto
+except ImportError:  # Existing standalone core.* test/import compatibility.
+    from unified_profile_contract import build_person_ref, validate_profile_dto  # type: ignore[no-redef]
+from .models import SessionContext, clean_text
+from .portrait import (
+    build_evidence,
+    cross_scene_whitelisted_fact,
+    extract_explicit_candidates,
+    portrait_access_decision,
+)
+
+
+class PortraitService:
+    def __init__(self, store: Any, config: Any) -> None:
+        self.store = store
+        self.config = config
+
+    @staticmethod
+    def _profile_context(event: Any = None, req: Any = None) -> dict[str, Any] | None:
+        for source in (event, req):
+            value = getattr(source, "private_companion_unified_profile_context", None) if source is not None else None
+            if isinstance(value, dict):
+                return value
+        return None
+
+    async def sync_profile_context(self, *, event: Any = None, req: Any = None) -> dict[str, Any]:
+        dto = self._profile_context(event, req)
+        errors = validate_profile_dto(dto)
+        if errors:
+            return {"ok": False, "code": "bridge_contract_mismatch", "errors": errors, "dto": None}
+        assert isinstance(dto, dict)
+        person_ref = build_person_ref(dto["person_ref"])
+        if person_ref["profile_status"] != "active" or person_ref["identity_assurance"] not in {"observed", "verified", "explicit_linked"}:
+            return {"ok": False, "code": "bridge_person_mismatch", "errors": [], "dto": dto}
+        result = await self.store.upsert_portrait_person_projection(person_ref, dto["capability_summary"])
+        if not result.get("ok"):
+            return {"ok": False, "code": result.get("code", "bridge_degraded"), "errors": [], "dto": dto}
+        return {"ok": True, "code": "profile_exact", "errors": [], "dto": dto, "person_ref": person_ref}
+
+    async def capture_user_message(self, ctx: SessionContext, *, event: Any = None, req: Any = None) -> dict[str, Any]:
+        """Capture only a sender's own message as portrait evidence.
+
+        The raw message is used transiently to derive a hash and deterministic
+        explicit candidate.  It is never copied to the portrait tables.
+        """
+        synced = await self.sync_profile_context(event=event, req=req)
+        if not synced.get("ok"):
+            return {"ok": False, "code": synced.get("code", "bridge_degraded"), "facts": 0}
+        person_ref = synced["person_ref"]
+        scope = self._scope_for_context(ctx)
+        if not scope:
+            return {"ok": False, "code": "bridge_person_mismatch", "facts": 0}
+        evidence = build_evidence(
+            person_ref=person_ref,
+            scope=scope,
+            session_id=ctx.session_id,
+            message_id=ctx.message_id,
+            source_identity_key=person_ref["resolved_identity_key"],
+            text=ctx.message_text,
+        )
+        evidence_result = await self.store.add_portrait_evidence(evidence)
+        if not evidence_result.get("ok") or not evidence_result.get("created"):
+            return {"ok": bool(evidence_result.get("ok")), "code": evidence_result.get("code", "portrait_evidence_recorded"), "facts": 0}
+        created = 0
+        for candidate in extract_explicit_candidates(ctx.message_text):
+            fact = {
+                **candidate,
+                "person_id": person_ref["person_id"],
+                "portrait_tier": "base",
+                "source_scope": scope,
+                "usable_scope": "self_low_global" if cross_scene_whitelisted_fact(
+                    dimension=candidate["dimension"],
+                    claim_summary=candidate["claim_summary"],
+                    sensitivity=candidate["sensitivity"],
+                    source_scope=scope,
+                ) else "source_only",
+                "confidence": 0.9,
+                "status": "active",
+                "evidence_hashes": [evidence["evidence_hash"]],
+                "context_refs": evidence["context_refs"],
+                "operation_id": f"portrait.explicit:{evidence['evidence_hash'][:24]}",
+            }
+            result = await self.store.upsert_portrait_fact(fact)
+            if result.get("ok"):
+                created += 1
+                await self.store.enqueue_portrait_learning(
+                    person_id=person_ref["person_id"],
+                    fact_id=result["fact_id"],
+                    evidence_hash=evidence["evidence_hash"],
+                )
+        return {"ok": True, "code": "portrait_evidence_recorded", "facts": created, "person_id": person_ref["person_id"]}
+
+    async def read_summary(self, request: dict[str, Any], *, limit: int = 8) -> dict[str, Any]:
+        decision = portrait_access_decision(request)
+        if not decision["candidates_allowed"]:
+            return {"ok": False, "code": decision["code"], "items": [], "decision": decision}
+        person_ref = request.get("person_ref") if isinstance(request.get("person_ref"), dict) else {}
+        projection = await self.store.portrait_projection_decision(person_ref)
+        if not projection.get("ok"):
+            return {
+                "ok": False,
+                "code": clean_text(projection.get("code"), 80) or "bridge_degraded",
+                "items": [],
+                "decision": decision,
+            }
+        target = clean_text(request.get("target_person_id"), 80)
+        result = await self.store.portrait_summary(
+            target,
+            scope=clean_text(request.get("scope"), 80),
+            limit=max(1, min(16, int(limit))),
+            low_only=True,
+            usage_min_confidence=self.config.float("portrait.usage_min_confidence", 0.75),
+            inferred_freshness_days=self.config.int("portrait.inferred_freshness_days", 90),
+        )
+        return {**result, "decision": decision}
+
+    @staticmethod
+    def _scope_for_context(ctx: SessionContext) -> str:
+        if ctx.scope == "private":
+            return "private"
+        if ctx.scope != "group":
+            return ""
+        platform = clean_text(ctx.platform, 40).lower()
+        group_id = clean_text(ctx.group_id, 120)
+        if not platform or not group_id:
+            return ""
+        return f"group:{platform}:{group_id}"
+
+    async def run_daily_batch(self, person_id: str, *, run_day: str = "") -> dict[str, Any]:
+        day = clean_text(run_day, 16)
+        if not day:
+            day = datetime.now(timezone.utc).astimezone().date().isoformat()
+        return await self.store.run_portrait_daily_batch(
+            person_id=person_id,
+            run_day=day,
+            min_independent_evidence=self.config.int("portrait.min_independent_evidence", 3),
+            success_limit=self.config.int("portrait.daily_success_limit_per_person", 1),
+            attempt_limit=self.config.int("portrait.daily_attempt_limit_per_person", 2),
+        )
+
+    async def list_governance_profiles(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        return await self.store.list_portrait_people(limit=limit)
+
+    async def status(self, person_id: str) -> dict[str, Any]:
+        return await self.store.portrait_status(clean_text(person_id, 80))
+
+    async def governance_detail(self, person_id: str) -> dict[str, Any]:
+        return await self.store.portrait_governance_detail(clean_text(person_id, 80))
+
+    async def govern_fact(
+        self,
+        *,
+        person_id: str,
+        fact_id: str,
+        action: str,
+        actor: str = "page_administrator",
+        operation_id: str,
+        expires_at: str = "",
+    ) -> dict[str, Any]:
+        """Apply only non-reopening administrator governance actions.
+
+        A user denial is never silently reopened here.  Any later replacement
+        needs an authorized self-confirmation flow or a separate reviewed
+        operation that creates a new fact.
+        """
+        return await self.store.govern_portrait_fact(
+            person_id=clean_text(person_id, 80),
+            fact_id=clean_text(fact_id, 120),
+            action=clean_text(action, 40),
+            actor=clean_text(actor, 80) or "page_administrator",
+            operation_id=clean_text(operation_id, 120),
+            expires_at=clean_text(expires_at, 80),
+        )
+
+    async def migrate_legacy(self, *, operation_id: str, dry_run: bool = True) -> dict[str, Any]:
+        return await self.store.portrait_migration(
+            operation_id=clean_text(operation_id, 120),
+            dry_run=bool(dry_run),
+        )
+
+    async def rollback_legacy_migration(self, *, operation_id: str) -> dict[str, Any]:
+        return await self.store.rollback_portrait_migration(operation_id=clean_text(operation_id, 120))

--- a/core/profile_api.py
+++ b/core/profile_api.py
@@ -1,0 +1,332 @@
+"""Read-only, privacy-limited C4 Bot Profile projection.
+
+This module deliberately operates on already-loaded records and never exposes
+record content, evidence, or payload data.  It is suitable as a small boundary
+for later service/bridge integration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import re
+from typing import Any
+
+
+PROFILE_NAMES = (
+    "bot_schedule_current",
+    "bot_schedule_history",
+    "bot_creative",
+    "bot_subjective",
+    "locked_frame_personal",
+)
+
+_PROFILE_TYPES = {
+    "bot_schedule_current": frozenset(
+        {
+            "bot_schedule_plan",
+            "bot_observed_activity",
+            "bot_schedule_reconciliation",
+            "bot_window_snapshot",
+            "bot_shared_activity",
+            "bot_detail_fragment",
+            "bot_calendar_event",
+            "bot_proactive_message",
+        }
+    ),
+    "bot_schedule_history": frozenset(
+        {
+            "bot_schedule_plan",
+            "bot_observed_activity",
+            "bot_schedule_reconciliation",
+            "bot_window_snapshot",
+            "bot_daily_diary",
+            "bot_shared_activity",
+            "bot_detail_fragment",
+            "bot_calendar_event",
+            "bot_proactive_message",
+        }
+    ),
+    "bot_creative": frozenset({"bot_creative_work", "bot_media_memory"}),
+    "bot_subjective": frozenset({"bot_daily_diary", "bot_subjective_memory"}),
+    "locked_frame_personal": frozenset(
+        {
+            "bot_schedule_plan",
+            "bot_observed_activity",
+            "bot_schedule_reconciliation",
+            "bot_window_snapshot",
+            "bot_daily_diary",
+            "bot_creative_work",
+            "bot_media_memory",
+            "bot_subjective_memory",
+            "bot_shared_activity",
+            "bot_detail_fragment",
+            "bot_calendar_event",
+            "bot_proactive_message",
+        }
+    ),
+}
+
+# Public lookup is intentionally keyed by the C3 memory type.  A type may be
+# visible in more than one profile, while the private profile index above
+# keeps selection logic straightforward.
+PROFILE_MEMORY_TYPES = {
+    memory_type: frozenset(
+        profile for profile, memory_types in _PROFILE_TYPES.items() if memory_type in memory_types
+    )
+    for memory_type in sorted({item for values in _PROFILE_TYPES.values() for item in values})
+}
+
+_BOT_DOMAIN = "bot_self_schedule"
+_FORBIDDEN_SCOPE_OR_VISIBILITY = {"group", "user_memory"}
+_SAFE_TEXT = re.compile(r"^[^\x00-\x1f\x7f]{0,240}$")
+_SENSITIVE = re.compile(
+    r"(?i)(?:bearer\s+|password\s*[:=]|passwd\s*[:=]|secret\s*[:=]|"
+    r"token\s*[:=]|api[_-]?key\s*[:=]|authorization\s*[:=]|base64,|"
+    r"(?:[a-z]:[\\/]|/home/|/root/|/tmp/|/var/))"
+)
+
+_SUMMARY_BY_TYPE = {
+    "bot_schedule_plan": "Bot schedule plan record.",
+    "bot_observed_activity": "Bot observed activity record.",
+    "bot_schedule_reconciliation": "Bot schedule reconciliation record.",
+    "bot_window_snapshot": "Bot window snapshot record.",
+    "bot_daily_diary": "Bot daily diary record.",
+    "bot_creative_work": "Bot creative work record.",
+    "bot_media_memory": "Bot media memory record.",
+    "bot_subjective_memory": "Bot subjective memory record.",
+    "bot_shared_activity": "Bot shared activity record.",
+    "bot_detail_fragment": "Bot schedule detail record.",
+    "bot_calendar_event": "Bot calendar event record.",
+    "bot_proactive_message": "Bot proactive message record.",
+}
+
+
+def profile_names() -> tuple[str, ...]:
+    """Return the stable profile names without exposing mutable state."""
+
+    return PROFILE_NAMES
+
+
+def profile_descriptor(profile: Any) -> dict[str, Any]:
+    """Return a small, non-record descriptor for a profile name."""
+
+    name = _text(profile, 80)
+    return {
+        "profile": name,
+        "known": name in PROFILE_NAMES,
+        "memory_types": sorted(_PROFILE_TYPES.get(name, ())),
+        "read_only": True,
+    }
+
+
+def _text(value: Any, limit: int = 240) -> str:
+    if value is None:
+        return ""
+    try:
+        text = str(value).strip().replace("\u3000", " ")
+    except Exception:
+        return ""
+    if not text or not _SAFE_TEXT.fullmatch(text[:limit]) or _SENSITIVE.search(text):
+        return ""
+    return text[:limit]
+
+
+def _metadata(record: Any) -> Mapping[str, Any]:
+    value = getattr(record, "metadata", {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _record_value(record: Any, metadata: Mapping[str, Any], key: str, default: Any = "") -> Any:
+    value = metadata.get(key, default)
+    if value in (None, ""):
+        value = getattr(record, key, default)
+    return value
+
+
+def _is_allowed_record(record: Any, metadata: Mapping[str, Any]) -> bool:
+    domain = _text(metadata.get("memory_domain"), 80)
+    bot_personal = metadata.get("bot_personal") is True
+    scope = _text(getattr(record, "scope", ""), 40).lower()
+    visibility = _text(getattr(record, "visibility", ""), 40).lower()
+    metadata_scope = _text(metadata.get("scope"), 40).lower()
+    metadata_visibility = _text(metadata.get("visibility"), 40).lower()
+    if domain and domain != _BOT_DOMAIN:
+        return False
+    if not domain and not bot_personal:
+        return False
+    if scope in _FORBIDDEN_SCOPE_OR_VISIBILITY or visibility in _FORBIDDEN_SCOPE_OR_VISIBILITY:
+        return False
+    if metadata_scope in _FORBIDDEN_SCOPE_OR_VISIBILITY or metadata_visibility in _FORBIDDEN_SCOPE_OR_VISIBILITY:
+        return False
+    if domain == "user_memory" or metadata_visibility == "user_memory":
+        return False
+    return True
+
+
+def _source_refs(value: Any) -> list[str]:
+    if isinstance(value, (str, bytes, bytearray)):
+        values = [value]
+    elif isinstance(value, Iterable):
+        try:
+            values = list(value)
+        except Exception:
+            values = []
+    else:
+        values = []
+    result: list[str] = []
+    for item in values[:16]:
+        safe = _text(item, 240)
+        if safe:
+            result.append(safe)
+    return result
+
+
+def _version(value: Any) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 1
+    return max(1, min(2**31 - 1, number))
+
+
+def _item(record: Any, metadata: Mapping[str, Any], memory_type: str) -> dict[str, Any]:
+    record_id = _text(_record_value(record, metadata, "record_id", getattr(record, "id", "")), 160)
+    # A bot_personal marker is an admission signal, not permission to echo an
+    # arbitrary caller-supplied domain into the public projection.
+    domain = _BOT_DOMAIN
+    date = _text(_record_value(record, metadata, "date"), 20)
+    window = _text(_record_value(record, metadata, "window"), 40)
+    occurred_at = _text(_record_value(record, metadata, "occurred_at"), 80)
+    source_kind = _text(_record_value(record, metadata, "source_kind"), 80)
+    evidence_level = _text(_record_value(record, metadata, "evidence_level"), 40)
+    status = _text(_record_value(record, metadata, "status"), 80)
+    return {
+        "record_id": record_id,
+        "memory_domain": domain,
+        "memory_type": memory_type,
+        "subject": "bot_self",
+        "date": date,
+        "window": window,
+        "occurred_at": occurred_at,
+        "source_kind": source_kind,
+        "source_refs": _source_refs(_record_value(record, metadata, "source_refs")),
+        "evidence_level": evidence_level,
+        "status": status,
+        "version": _version(_record_value(record, metadata, "version", 1)),
+        "summary": _SUMMARY_BY_TYPE.get(memory_type, "Bot personal memory record."),
+        "reference": f"profile:{record_id}" if record_id else "profile:unknown",
+    }
+
+
+def _matches_query(item: Mapping[str, Any], query: str) -> bool:
+    needle = _text(query, 240).casefold()
+    if not needle:
+        return True
+    safe_fields = (
+        "record_id", "memory_domain", "memory_type", "subject", "date", "window",
+        "occurred_at", "source_kind", "evidence_level", "status", "version", "summary",
+        "reference",
+    )
+    haystack = " ".join(str(item.get(key, "")) for key in safe_fields)
+    haystack += " " + " ".join(item.get("source_refs", []))
+    return needle in haystack.casefold()
+
+
+def _limit(value: Any) -> int:
+    try:
+        return max(1, min(100, int(value)))
+    except (TypeError, ValueError, OverflowError):
+        return 10
+
+
+def build_profile_result(
+    records: Iterable[Any],
+    profile: Any,
+    query: str = "",
+    limit: int = 10,
+    *,
+    current_date: str = "",
+    current_window: str = "",
+    authorized: bool = False,
+) -> dict[str, Any]:
+    """Build a fixed-shape, read-only profile result without raw memory data."""
+
+    name = _text(profile, 80)
+    result: dict[str, Any] = {
+        "ok": True,
+        "read_only": True,
+        "state": "ready",
+        "degraded": False,
+        "pending": False,
+        "profile": name,
+        "items": [],
+        "warnings": [],
+    }
+    if name not in PROFILE_NAMES:
+        result.update(ok=False, state="invalid", warnings=["unknown_profile"])
+        return result
+    if name == "locked_frame_personal" and authorized is not True:
+        result.update(ok=False, state="forbidden", warnings=["authorization_required"])
+        return result
+
+    safe_date = _text(current_date, 20)
+    safe_window = _text(current_window, 40)
+    raw_query = str(query or "").strip()
+    safe_query = _text(query, 240)
+    if current_date and not safe_date:
+        result["warnings"].append("invalid_current_date")
+    if current_window and not safe_window:
+        result["warnings"].append("invalid_current_window")
+    if raw_query and not safe_query:
+        result["warnings"].append("unsafe_query_rejected")
+        return result
+
+    try:
+        iterable = () if records is None or isinstance(records, (str, bytes, bytearray)) else records
+        iterator = iter(iterable)
+    except Exception:
+        result.update(state="degraded", degraded=True, warnings=[*result["warnings"], "invalid_records"])
+        return result
+
+    selected: list[dict[str, Any]] = []
+    type_filter = _PROFILE_TYPES[name]
+    try:
+        for record in iterator:
+            try:
+                metadata = _metadata(record)
+                memory_type = _text(getattr(record, "memory_type", metadata.get("memory_type", "")), 80)
+                if not _is_allowed_record(record, metadata) or memory_type not in type_filter:
+                    continue
+                date = _text(_record_value(record, metadata, "date"), 20)
+                window = _text(_record_value(record, metadata, "window"), 40)
+                if name == "bot_schedule_current":
+                    if safe_date and date != safe_date:
+                        continue
+                    if safe_window and window != safe_window:
+                        continue
+                elif name == "bot_schedule_history":
+                    if safe_date and safe_window and date == safe_date and window == safe_window:
+                        continue
+                item = _item(record, metadata, memory_type)
+                if _matches_query(item, safe_query):
+                    selected.append(item)
+            except Exception:
+                result["warnings"].append("malformed_record_skipped")
+    except Exception:
+        result.update(state="degraded", degraded=True)
+        result["warnings"].append("records_iteration_failed")
+
+    selected.sort(key=lambda item: (item.get("occurred_at", ""), item.get("record_id", "")), reverse=True)
+    result["items"] = selected[: _limit(limit)]
+    if len(result["warnings"]) > 8:
+        result["warnings"] = result["warnings"][:8]
+    return result
+
+
+__all__ = [
+    "PROFILE_NAMES",
+    "PROFILE_MEMORY_TYPES",
+    "build_profile_result",
+    "profile_descriptor",
+    "profile_names",
+]

--- a/core/provenance.py
+++ b/core/provenance.py
@@ -1,0 +1,530 @@
+"""Pure chat-side provenance contract and in-memory migration projection.
+
+The module accepts metadata only.  It never reads or stores prompt text,
+conversation content, media, credentials, paths, or arbitrary source prose,
+and it performs no I/O.  A later SQLite adapter may use the plans and CAS
+results, but this module deliberately has no knowledge of that adapter.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from dataclasses import asdict, is_dataclass
+import hashlib
+import json
+import re
+from typing import Any
+
+
+PROVENANCE_CONTRACT_NAME = "ops.p5.provenance.v1"
+PROVENANCE_CONTRACT_VERSION = "1.0"
+P3_CONTRACT_NAME = "ops.context_orchestration.v1"
+P3_CONTRACT_VERSION = "1.0"
+P3_CONTRACT_FINGERPRINT = "3bb7a12af05bb4d9a47cef9f31e78752cec512b90b1d50ae49feef54470974f8"
+COMPANION_ATTESTATION_ISSUER = "private_companion"
+ATTESTATION_SCHEMA_VERSION = "ops.p5.attestation.v1"
+
+TRUST_LEVELS = ("T0", "T1", "T2", "T3", "T4")
+PROVENANCE_STATES = ("observed", "legacy_unresolved", "owner_recovered", "invalid")
+SOURCE_KINDS = (
+    "policy_config", "verified_authorization", "current_user_intent",
+    "forwarded_text", "quoted_text", "vision_summary", "tool_output",
+    "web_extract", "memory_recall", "derived_summary", "legacy_memory", "unknown",
+)
+FIREWALL_STATUSES = (
+    "allowed", "sanitized", "blocked", "rejected", "quarantined", "unavailable", "unknown",
+)
+DISPOSITIONS = ("allow", "shadow_quarantine", "deny_high_risk")
+HASH_FORMAT = "sha256_hex_lower"
+
+RECORD_FIELDS = (
+    "contract_name", "contract_version", "contract_fingerprint", "memory_id",
+    "source_kind", "source_trust", "firewall_status", "source_event_ref_hash",
+    "authority_attestation_ref_hash", "provenance_state", "migration_operation_ref",
+    "recovery_operation_ref", "record_revision",
+)
+OPERATION_FIELDS = (
+    "contract_name", "contract_version", "contract_fingerprint", "operation_kind",
+    "operation_ref_hash", "memory_id", "expected_revision", "before_record_digest",
+    "after_record_digest", "before_record", "after_record",
+)
+
+_SOURCE_KIND_SET = frozenset(SOURCE_KINDS)
+_TRUST_SET = frozenset(TRUST_LEVELS)
+_FIREWALL_SET = frozenset(FIREWALL_STATUSES)
+_DISPOSITION_SET = frozenset(DISPOSITIONS)
+_SINKS = frozenset({
+    "prompt_forward_quote", "prompt_vision_summary", "memory_recall",
+    "bridge_serialization", "tool_retrieval", "external_export", "cross_user_read",
+})
+_MEMORY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$")
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_TOKEN_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_FORBIDDEN_RAW_FIELDS = frozenset({
+    "body", "content", "text", "message", "prompt", "conversation", "media",
+    "raw_id", "source_id", "source_event_id", "event_id", "attestation_id",
+    "authority_attestation_id", "request_id", "session_id", "credential",
+    "credentials", "password", "secret", "token", "path", "absolute_path", "url",
+})
+_SNAPSHOT_FIELDS = frozenset({
+    "schema_version", "contract_name", "contract_version", "contract_fingerprint",
+    "issuer", "issuer_epoch", "p3_contract_name", "p3_contract_version",
+    "p3_contract_fingerprint", "source_kind", "source_trust", "trust", "firewall_status",
+    "source_event_ref_hash", "source_hash", "authority_attestation_ref_hash",
+    "attestation_ref_hash", "disposition", "reason_codes", "request_hash", "session_hash",
+    "derived_hash", "derived_from_ref_hash", "provenance_state", "sink",
+})
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def contract_descriptor() -> dict[str, Any]:
+    """Return a fresh, closed, JSON-safe descriptor."""
+
+    return {
+        "contract_name": PROVENANCE_CONTRACT_NAME,
+        "contract_version": PROVENANCE_CONTRACT_VERSION,
+        "record_fields": list(RECORD_FIELDS),
+        "provenance_states": list(PROVENANCE_STATES),
+        "trust_levels": list(TRUST_LEVELS),
+        "source_kinds": list(SOURCE_KINDS),
+        "firewall_statuses": list(FIREWALL_STATUSES),
+        "dispositions": list(DISPOSITIONS),
+        "hash_format": HASH_FORMAT,
+        "attestation_issuer": COMPANION_ATTESTATION_ISSUER,
+        "p3_contract_name": P3_CONTRACT_NAME,
+        "p3_contract_version": P3_CONTRACT_VERSION,
+    }
+
+
+def contract_fingerprint() -> str:
+    """Return the canonical descriptor SHA-256 fingerprint."""
+
+    return _digest(contract_descriptor())
+
+
+provenance_contract_descriptor = contract_descriptor
+provenance_contract_fingerprint = contract_fingerprint
+
+
+def _safe_memory_id(value: Any) -> str:
+    return value if isinstance(value, str) and _MEMORY_ID_RE.fullmatch(value) else ""
+
+
+def _safe_hash(value: Any) -> str:
+    return value if isinstance(value, str) and _SHA256_RE.fullmatch(value) and value == value.lower() else ""
+
+
+def _normalize_hash(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    raw = value[7:] if value.startswith("sha256:") else value
+    return raw.lower() if _SHA256_RE.fullmatch(raw) else ""
+
+
+def _safe_revision(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+
+
+def _known(value: Any, allowed: frozenset[str] | tuple[str, ...]) -> bool:
+    return isinstance(value, str) and value in allowed
+
+
+def _forbidden(value: Mapping[str, Any]) -> bool:
+    return any(key in value for key in _FORBIDDEN_RAW_FIELDS)
+
+
+def _error_result(*codes: str) -> dict[str, Any]:
+    return {"ok": False, "error_codes": sorted(set(codes))}
+
+
+def _blank_record(memory_id: Any = "", *, revision: int = 0, state: str = "invalid") -> dict[str, Any]:
+    return {
+        "contract_name": PROVENANCE_CONTRACT_NAME,
+        "contract_version": PROVENANCE_CONTRACT_VERSION,
+        "contract_fingerprint": contract_fingerprint(),
+        "memory_id": _safe_memory_id(memory_id),
+        "source_kind": "unknown",
+        "source_trust": "T4",
+        "firewall_status": "unknown",
+        "source_event_ref_hash": "",
+        "authority_attestation_ref_hash": "",
+        "provenance_state": state,
+        "migration_operation_ref": "",
+        "recovery_operation_ref": "",
+        "record_revision": revision if _safe_revision(revision) is not None else 0,
+    }
+
+
+def validate_provenance_record(record: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return static validation errors or a deep-copied safe record.
+
+    Invalid input values are never returned, so a caller can safely serialize
+    the result without leaking hostile identifiers or source prose.
+    """
+
+    if not isinstance(record, Mapping):
+        return _error_result("record_not_mapping")
+    errors: list[str] = []
+    if _forbidden(record):
+        errors.append("forbidden_raw_field")
+    if set(record) != set(RECORD_FIELDS):
+        errors.append("record_fields_mismatch")
+    if record.get("contract_name") != PROVENANCE_CONTRACT_NAME:
+        errors.append("contract_name_mismatch")
+    if record.get("contract_version") != PROVENANCE_CONTRACT_VERSION:
+        errors.append("contract_version_mismatch")
+    if record.get("contract_fingerprint") != contract_fingerprint():
+        errors.append("contract_fingerprint_mismatch")
+    if not _safe_memory_id(record.get("memory_id")):
+        errors.append("memory_id_invalid")
+    if not _known(record.get("source_kind"), _SOURCE_KIND_SET):
+        errors.append("source_kind_invalid")
+    if not _known(record.get("source_trust"), _TRUST_SET):
+        errors.append("source_trust_invalid")
+    if not _known(record.get("firewall_status"), _FIREWALL_SET):
+        errors.append("firewall_status_invalid")
+    if not _known(record.get("provenance_state"), PROVENANCE_STATES):
+        errors.append("provenance_state_invalid")
+    if _safe_revision(record.get("record_revision")) is None:
+        errors.append("record_revision_invalid")
+
+    source = record.get("source_event_ref_hash")
+    authority = record.get("authority_attestation_ref_hash")
+    source_hash = _safe_hash(source)
+    authority_hash = _safe_hash(authority)
+    if source != "" and not source_hash:
+        errors.append("source_event_ref_hash_invalid")
+    if authority != "" and not authority_hash:
+        errors.append("authority_attestation_ref_hash_invalid")
+    migration = record.get("migration_operation_ref")
+    recovery = record.get("recovery_operation_ref")
+    if migration != "" and not _safe_hash(migration):
+        errors.append("migration_operation_ref_invalid")
+    if recovery != "" and not _safe_hash(recovery):
+        errors.append("recovery_operation_ref_invalid")
+
+    state = record.get("provenance_state")
+    if state == "legacy_unresolved":
+        if (record.get("source_kind"), record.get("source_trust"), record.get("firewall_status")) != ("unknown", "T4", "unknown"):
+            errors.append("legacy_defaults_required")
+        if source != "" or authority != "":
+            errors.append("legacy_hashes_forbidden")
+    elif state in {"observed", "owner_recovered"}:
+        if record.get("source_kind") == "unknown":
+            errors.append("observed_source_kind_required")
+        if not source_hash or not authority_hash:
+            errors.append("attestation_hashes_required")
+        if source_hash and source_hash == authority_hash:
+            errors.append("attestation_hashes_conflict")
+        if state == "owner_recovered" and not _safe_hash(recovery):
+            errors.append("recovery_operation_ref_required")
+    elif state == "invalid" and (source_hash or authority_hash):
+        errors.append("invalid_hashes_forbidden")
+    if errors:
+        return _error_result(*errors)
+    return {"ok": True, "record": deepcopy(dict(record))}
+
+
+def legacy_unresolved(memory_id: str, *, record_revision: int = 0) -> dict[str, Any]:
+    """Represent a historical record without guessing its provenance."""
+
+    result = _blank_record(memory_id, revision=record_revision, state="legacy_unresolved")
+    return result if result["memory_id"] and validate_provenance_record(result)["ok"] else _blank_record(state="invalid")
+
+
+def _snapshot_mapping(snapshot: Any) -> Mapping[str, Any] | None:
+    if isinstance(snapshot, Mapping):
+        return snapshot
+    if is_dataclass(snapshot):
+        value = asdict(snapshot)
+        return value if isinstance(value, Mapping) else None
+    return None
+
+
+def _paired_hash(snapshot: Mapping[str, Any], *keys: str) -> tuple[str, str]:
+    values = [_normalize_hash(snapshot[key]) for key in keys if key in snapshot]
+    if not values:
+        return "missing", ""
+    if not all(values):
+        return "invalid", ""
+    return ("present", values[0]) if len(set(values)) == 1 else ("conflict", "")
+
+
+def _paired_label(snapshot: Mapping[str, Any], allowed: frozenset[str], *keys: str) -> tuple[str, str]:
+    values = [snapshot[key] for key in keys if key in snapshot]
+    if not values:
+        return "missing", ""
+    if not all(_known(value, allowed) for value in values):
+        return "invalid", ""
+    return ("present", values[0]) if len(set(values)) == 1 else ("conflict", "")
+
+
+def _snapshot_safe(snapshot: Mapping[str, Any]) -> bool:
+    if set(snapshot) - _SNAPSHOT_FIELDS or _forbidden(snapshot):
+        return False
+    if not _known(snapshot.get("disposition"), _DISPOSITION_SET):
+        return False
+    codes = snapshot.get("reason_codes", ())
+    if not isinstance(codes, (list, tuple)) or len(codes) > 16:
+        return False
+    if not all(isinstance(code, str) and _TOKEN_RE.fullmatch(code) for code in codes):
+        return False
+    for key in ("request_hash", "session_hash", "issuer_epoch"):
+        if not _normalize_hash(snapshot.get(key)):
+            return False
+    derived = [snapshot[key] for key in ("derived_hash", "derived_from_ref_hash") if key in snapshot and snapshot[key] != ""]
+    if derived and (any(not _normalize_hash(value) for value in derived) or len({_normalize_hash(value) for value in derived}) != 1):
+        return False
+    return snapshot.get("provenance_state") == "observed" and _known(snapshot.get("sink"), _SINKS)
+
+
+def observed_from_companion_snapshot(memory_id: str, snapshot: Any, *, record_revision: int = 0) -> dict[str, Any]:
+    """Create ``observed`` only from a complete, attested Companion snapshot."""
+
+    safe_id = _safe_memory_id(memory_id)
+    revision = _safe_revision(record_revision)
+    data = _snapshot_mapping(snapshot)
+    if not safe_id or revision is None or data is None or not _snapshot_safe(data):
+        return _blank_record(safe_id, revision=revision or 0)
+    expected = {
+        "schema_version": ATTESTATION_SCHEMA_VERSION,
+        "issuer": COMPANION_ATTESTATION_ISSUER,
+        "contract_name": PROVENANCE_CONTRACT_NAME,
+        "contract_version": PROVENANCE_CONTRACT_VERSION,
+        "contract_fingerprint": contract_fingerprint(),
+        "p3_contract_name": P3_CONTRACT_NAME,
+        "p3_contract_version": P3_CONTRACT_VERSION,
+        "p3_contract_fingerprint": P3_CONTRACT_FINGERPRINT,
+    }
+    if any(data.get(key) != value for key, value in expected.items()):
+        return _blank_record(safe_id, revision=revision)
+    source_status, source_hash = _paired_hash(data, "source_event_ref_hash", "source_hash")
+    authority_status, authority_hash = _paired_hash(data, "authority_attestation_ref_hash", "attestation_ref_hash")
+    trust_status, trust = _paired_label(data, _TRUST_SET, "source_trust", "trust")
+    source_kind = data.get("source_kind")
+    firewall = data.get("firewall_status")
+    if (
+        source_status != "present" or authority_status != "present" or trust_status != "present"
+        or source_hash == authority_hash or not _known(source_kind, _SOURCE_KIND_SET - {"unknown"})
+        or not _known(firewall, _FIREWALL_SET)
+    ):
+        return _blank_record(safe_id, revision=revision)
+    record = _blank_record(safe_id, revision=revision, state="observed")
+    record.update({
+        "source_kind": source_kind, "source_trust": trust, "firewall_status": firewall,
+        "source_event_ref_hash": source_hash, "authority_attestation_ref_hash": authority_hash,
+    })
+    return record if validate_provenance_record(record)["ok"] else _blank_record(safe_id, revision=revision)
+
+
+def provenance_record_digest(record: Mapping[str, Any] | None) -> str:
+    checked = validate_provenance_record(record)
+    return _digest(checked["record"]) if checked["ok"] else ""
+
+
+def _record_or_none(value: Any) -> dict[str, Any] | None:
+    checked = validate_provenance_record(value if isinstance(value, Mapping) else None)
+    return deepcopy(checked["record"]) if checked["ok"] else None
+
+
+def _operation(*, operation_kind: str, operation_ref_hash: str, before_record: Mapping[str, Any] | None, after_record: Mapping[str, Any]) -> dict[str, Any] | None:
+    before = _record_or_none(before_record)
+    after = _record_or_none(after_record)
+    reference = _safe_hash(operation_ref_hash)
+    if operation_kind not in {"migration", "recovery"} or not reference or after is None:
+        return None
+    if before is not None and before["memory_id"] != after["memory_id"]:
+        return None
+    expected = before["record_revision"] if before is not None else after["record_revision"] - 1
+    if expected < 0 or after["record_revision"] != expected + 1:
+        return None
+    operation = {
+        "contract_name": PROVENANCE_CONTRACT_NAME, "contract_version": PROVENANCE_CONTRACT_VERSION,
+        "contract_fingerprint": contract_fingerprint(), "operation_kind": operation_kind,
+        "operation_ref_hash": reference, "memory_id": after["memory_id"], "expected_revision": expected,
+        "before_record_digest": _digest(before) if before is not None else "",
+        "after_record_digest": _digest(after), "before_record": before, "after_record": after,
+    }
+    return operation if validate_operation(operation)["ok"] else None
+
+
+def validate_operation(operation: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(operation, Mapping):
+        return _error_result("operation_not_mapping")
+    errors: list[str] = []
+    if _forbidden(operation):
+        errors.append("forbidden_raw_field")
+    if set(operation) != set(OPERATION_FIELDS):
+        errors.append("operation_fields_mismatch")
+    if operation.get("contract_name") != PROVENANCE_CONTRACT_NAME:
+        errors.append("contract_name_mismatch")
+    if operation.get("contract_version") != PROVENANCE_CONTRACT_VERSION:
+        errors.append("contract_version_mismatch")
+    if operation.get("contract_fingerprint") != contract_fingerprint():
+        errors.append("contract_fingerprint_mismatch")
+    if operation.get("operation_kind") not in {"migration", "recovery"}:
+        errors.append("operation_kind_invalid")
+    if not _safe_hash(operation.get("operation_ref_hash")):
+        errors.append("operation_ref_invalid")
+    if not _safe_memory_id(operation.get("memory_id")):
+        errors.append("memory_id_invalid")
+    expected = _safe_revision(operation.get("expected_revision"))
+    if expected is None:
+        errors.append("expected_revision_invalid")
+    before = _record_or_none(operation.get("before_record"))
+    after = _record_or_none(operation.get("after_record"))
+    if operation.get("before_record") is not None and before is None:
+        errors.append("before_record_invalid")
+    if after is None:
+        errors.append("after_record_invalid")
+    if before is None and operation.get("before_record_digest") != "":
+        errors.append("before_digest_required_empty")
+    if before is not None and operation.get("before_record_digest") != _digest(before):
+        errors.append("before_digest_mismatch")
+    if after is not None and operation.get("after_record_digest") != _digest(after):
+        errors.append("after_digest_mismatch")
+    if after is not None:
+        if operation.get("memory_id") != after["memory_id"]:
+            errors.append("memory_id_mismatch")
+        if expected is not None and after["record_revision"] != expected + 1:
+            errors.append("revision_progression_invalid")
+        ref_field = "migration_operation_ref" if operation.get("operation_kind") == "migration" else "recovery_operation_ref"
+        if after.get(ref_field) != operation.get("operation_ref_hash"):
+            errors.append("operation_ref_not_bound")
+    if before is not None and after is not None:
+        if before["memory_id"] != after["memory_id"]:
+            errors.append("before_after_memory_mismatch")
+        if expected is not None and before["record_revision"] != expected:
+            errors.append("before_revision_mismatch")
+    return _error_result(*errors) if errors else {"ok": True, "operation": deepcopy(dict(operation))}
+
+
+def plan_legacy_migration(records: Iterable[Mapping[str, Any]], *, operation_ref_hash: str) -> dict[str, Any]:
+    """Return a non-mutating preview for unresolved legacy records."""
+
+    reference = _safe_hash(operation_ref_hash)
+    result: dict[str, Any] = {
+        "mode": "preview", "readonly": True, "write_count": 0,
+        "operation_ref_hash": reference, "operations": [], "skipped": [], "error_codes": [],
+    }
+    if not reference:
+        result["error_codes"].append("operation_ref_invalid")
+        return result
+    if isinstance(records, (str, bytes)) or not isinstance(records, Iterable):
+        result["error_codes"].append("records_not_iterable")
+        return result
+    for candidate in records:
+        if not isinstance(candidate, Mapping) or _forbidden(candidate):
+            result["error_codes"].append("candidate_invalid")
+            continue
+        existing = _record_or_none(candidate)
+        if existing is not None:
+            result["skipped"].append({"memory_id": existing["memory_id"], "reason_code": "already_provenanced"})
+            continue
+        if set(candidate) != {"memory_id", "record_revision"}:
+            result["error_codes"].append("candidate_fields_mismatch")
+            continue
+        memory_id = _safe_memory_id(candidate.get("memory_id"))
+        revision = _safe_revision(candidate.get("record_revision"))
+        if not memory_id or revision is None:
+            result["error_codes"].append("candidate_invalid")
+            continue
+        after = legacy_unresolved(memory_id, record_revision=revision + 1)
+        after["migration_operation_ref"] = reference
+        operation = _operation(operation_kind="migration", operation_ref_hash=reference, before_record=None, after_record=after)
+        if operation is None:
+            result["error_codes"].append("operation_invalid")
+        else:
+            result["operations"].append(operation)
+    result["error_codes"] = sorted(set(result["error_codes"]))
+    return result
+
+
+def _minimal_current(current: Mapping[str, Any] | None) -> tuple[str, int | None, dict[str, Any] | None, str]:
+    if not isinstance(current, Mapping) or _forbidden(current):
+        return "", None, None, "current_invalid"
+    record = _record_or_none(current)
+    if record is not None:
+        return record["memory_id"], record["record_revision"], record, ""
+    if set(current) != {"memory_id", "record_revision"}:
+        return "", None, None, "current_fields_mismatch"
+    return _safe_memory_id(current.get("memory_id")), _safe_revision(current.get("record_revision")), None, ""
+
+
+def apply_planned_operation(current: Mapping[str, Any] | None, operation: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Apply a plan to an in-memory mapping with exact revision CAS."""
+
+    checked = validate_operation(operation)
+    if not checked["ok"]:
+        return {"ok": False, "mode": "apply", "status": "invalid_operation", "error_codes": checked["error_codes"]}
+    op = checked["operation"]
+    memory_id, revision, current_record, error = _minimal_current(current)
+    if error or not memory_id or revision is None:
+        return {"ok": False, "mode": "apply", "status": "invalid_current", "error_codes": [error or "current_invalid"]}
+    if current_record is not None and _digest(current_record) == op["after_record_digest"]:
+        return {"ok": True, "mode": "apply", "status": "idempotent", "record": deepcopy(op["after_record"]), "changed": False}
+    if memory_id != op["memory_id"] or revision != op["expected_revision"]:
+        return {"ok": False, "mode": "apply", "status": "revision_conflict", "error_codes": ["revision_or_memory_mismatch"]}
+    before = op["before_record"]
+    if before is None:
+        if current_record is not None:
+            return {"ok": False, "mode": "apply", "status": "revision_conflict", "error_codes": ["unexpected_existing_provenance"]}
+    elif current_record is None or _digest(current_record) != op["before_record_digest"]:
+        return {"ok": False, "mode": "apply", "status": "revision_conflict", "error_codes": ["before_record_mismatch"]}
+    return {"ok": True, "mode": "apply", "status": "applied", "record": deepcopy(op["after_record"]), "changed": True}
+
+
+def rollback_planned_operation(current: Mapping[str, Any] | None, operation: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Rollback only when the current record still matches the plan's CAS."""
+
+    checked = validate_operation(operation)
+    if not checked["ok"]:
+        return {"ok": False, "mode": "rollback", "status": "invalid_operation", "error_codes": checked["error_codes"]}
+    op = checked["operation"]
+    memory_id, revision, current_record, error = _minimal_current(current)
+    if error or current_record is None or revision is None:
+        return {"ok": False, "mode": "rollback", "status": "invalid_current", "error_codes": [error or "current_invalid"]}
+    if memory_id != op["memory_id"] or revision != op["after_record"]["record_revision"] or _digest(current_record) != op["after_record_digest"]:
+        return {"ok": False, "mode": "rollback", "status": "revision_conflict", "error_codes": ["concurrent_update_protected"]}
+    before = op["before_record"]
+    return {"ok": True, "mode": "rollback", "status": "rolled_back", "record": deepcopy(before) if before is not None else None, "removed": before is None, "changed": True}
+
+
+def plan_owner_recovery(current: Mapping[str, Any], snapshot: Mapping[str, Any], *, recovery_operation_ref_hash: str) -> dict[str, Any]:
+    """Plan attested owner recovery for one legacy-unresolved record."""
+
+    existing = _record_or_none(current)
+    reference = _safe_hash(recovery_operation_ref_hash)
+    if existing is None or existing["provenance_state"] != "legacy_unresolved" or not reference:
+        return {"ok": False, "mode": "preview", "error_codes": ["recovery_precondition_failed"]}
+    after = observed_from_companion_snapshot(existing["memory_id"], snapshot, record_revision=existing["record_revision"] + 1)
+    if after["provenance_state"] != "observed":
+        return {"ok": False, "mode": "preview", "error_codes": ["companion_snapshot_invalid"]}
+    after["provenance_state"] = "owner_recovered"
+    after["migration_operation_ref"] = existing["migration_operation_ref"]
+    after["recovery_operation_ref"] = reference
+    operation = _operation(operation_kind="recovery", operation_ref_hash=reference, before_record=existing, after_record=after)
+    if operation is None:
+        return {"ok": False, "mode": "preview", "error_codes": ["operation_invalid"]}
+    return {"ok": True, "mode": "preview", "readonly": True, "write_count": 0, "operation": operation}
+
+
+__all__ = [
+    "ATTESTATION_SCHEMA_VERSION", "COMPANION_ATTESTATION_ISSUER", "DISPOSITIONS",
+    "FIREWALL_STATUSES", "HASH_FORMAT", "OPERATION_FIELDS", "P3_CONTRACT_FINGERPRINT",
+    "P3_CONTRACT_NAME", "P3_CONTRACT_VERSION", "PROVENANCE_CONTRACT_NAME",
+    "PROVENANCE_CONTRACT_VERSION", "PROVENANCE_STATES", "RECORD_FIELDS", "SOURCE_KINDS",
+    "TRUST_LEVELS", "apply_planned_operation", "contract_descriptor", "contract_fingerprint",
+    "legacy_unresolved", "observed_from_companion_snapshot", "plan_legacy_migration",
+    "plan_owner_recovery", "provenance_contract_descriptor", "provenance_contract_fingerprint",
+    "provenance_record_digest", "rollback_planned_operation", "validate_operation",
+    "validate_provenance_record",
+]

--- a/core/provenance_store.py
+++ b/core/provenance_store.py
@@ -1,0 +1,280 @@
+"""Small append-only provenance ledger for the chat-side memory plugin.
+
+The ledger stores only validated provenance records and migration audit
+metadata.  It never accepts prompt text, conversation content, media,
+credentials, or arbitrary source prose.  Writes are atomic and every mutation
+creates a backup before the current projection changes.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+import shutil
+import threading
+import time
+from typing import Any, Mapping
+
+from .provenance import (
+    apply_planned_operation,
+    plan_legacy_migration,
+    provenance_record_digest,
+    rollback_planned_operation,
+    validate_operation,
+    validate_provenance_record,
+)
+
+
+LEDGER_SCHEMA_VERSION = "ops.p5.provenance.ledger.v1"
+
+
+class ProvenanceLedger:
+    """Persist validated provenance projections with CAS-protected writes."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self._lock = threading.RLock()
+
+    def _empty(self) -> dict[str, Any]:
+        return {"schema_version": LEDGER_SCHEMA_VERSION, "records": {}, "operations": [], "observations": []}
+
+    def _load_locked(self) -> dict[str, Any]:
+        if not self.path.is_file():
+            return self._empty()
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return self._empty()
+        if not isinstance(raw, dict) or raw.get("schema_version") != LEDGER_SCHEMA_VERSION:
+            return self._empty()
+        records: dict[str, dict[str, Any]] = {}
+        raw_records = raw.get("records")
+        if isinstance(raw_records, dict):
+            for memory_id, value in raw_records.items():
+                checked = validate_provenance_record(value if isinstance(value, Mapping) else None)
+                if checked.get("ok") and checked.get("record", {}).get("memory_id") == memory_id:
+                    records[memory_id] = deepcopy(checked["record"])
+        operations: list[dict[str, Any]] = []
+        raw_operations = raw.get("operations")
+        if isinstance(raw_operations, list):
+            for value in raw_operations:
+                checked = validate_operation(value if isinstance(value, Mapping) else None)
+                if checked.get("ok"):
+                    operations.append(deepcopy(checked["operation"]))
+                elif isinstance(value, dict) and value.get("kind") == "rollback":
+                    safe = self._safe_rollback_audit(value)
+                    if safe is not None:
+                        operations.append(safe)
+        observations: list[dict[str, Any]] = []
+        raw_observations = raw.get("observations")
+        if isinstance(raw_observations, list):
+            for value in raw_observations:
+                safe = self._safe_observation(value)
+                if safe is not None:
+                    observations.append(safe)
+        return {
+            "schema_version": LEDGER_SCHEMA_VERSION,
+            "records": records,
+            "operations": operations,
+            "observations": observations,
+        }
+
+    @staticmethod
+    def _safe_observation(value: Any) -> dict[str, Any] | None:
+        if not isinstance(value, Mapping) or set(value) != {
+            "memory_id", "record_digest", "record_revision", "source_event_ref_hash",
+            "authority_attestation_ref_hash", "provenance_state",
+        }:
+            return None
+        if (
+            not isinstance(value.get("memory_id"), str)
+            or not value["memory_id"]
+            or not isinstance(value.get("record_digest"), str)
+            or len(value["record_digest"]) != 64
+            or not isinstance(value.get("source_event_ref_hash"), str)
+            or len(value["source_event_ref_hash"]) != 64
+            or not isinstance(value.get("authority_attestation_ref_hash"), str)
+            or len(value["authority_attestation_ref_hash"]) != 64
+            or not isinstance(value.get("record_revision"), int)
+            or value["record_revision"] < 1
+            or value.get("provenance_state") not in {"observed", "owner_recovered"}
+        ):
+            return None
+        return {
+            "memory_id": value["memory_id"][:120],
+            "record_digest": value["record_digest"].lower(),
+            "record_revision": value["record_revision"],
+            "source_event_ref_hash": value["source_event_ref_hash"].lower(),
+            "authority_attestation_ref_hash": value["authority_attestation_ref_hash"].lower(),
+            "provenance_state": value["provenance_state"],
+        }
+
+    @staticmethod
+    def _safe_rollback_audit(value: Mapping[str, Any]) -> dict[str, Any] | None:
+        memory_id = value.get("memory_id")
+        before_digest = value.get("before_digest")
+        after_digest = value.get("after_digest")
+        from_revision = value.get("from_revision")
+        to_revision = value.get("to_revision")
+        if (
+            not isinstance(memory_id, str)
+            or not memory_id
+            or not isinstance(before_digest, str)
+            or len(before_digest) != 64
+            or not isinstance(after_digest, str)
+            or len(after_digest) != 64
+            or not isinstance(from_revision, int)
+            or from_revision < 0
+            or not isinstance(to_revision, int)
+            or to_revision < 0
+        ):
+            return None
+        return {
+            "kind": "rollback",
+            "memory_id": memory_id[:120],
+            "before_digest": before_digest.lower(),
+            "after_digest": after_digest.lower(),
+            "from_revision": from_revision,
+            "to_revision": to_revision,
+        }
+
+    def _write_locked(self, document: Mapping[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_name(f".{self.path.name}.{threading.get_ident()}.tmp")
+        temporary.write_text(
+            json.dumps(document, ensure_ascii=True, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        temporary.replace(self.path)
+
+    def _backup_locked(self) -> bool:
+        if not self.path.is_file():
+            return False
+        backup = self.path.with_name(f"{self.path.name}.backup.{time.time_ns()}")
+        try:
+            shutil.copy2(self.path, backup)
+            return True
+        except OSError:
+            return False
+
+    @staticmethod
+    def _minimal_current(memory_id: str, record: Mapping[str, Any] | None) -> dict[str, Any]:
+        if isinstance(record, Mapping):
+            return deepcopy(dict(record))
+        return {"memory_id": memory_id, "record_revision": 0}
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            document = self._load_locked()
+            return {
+                "schema_version": LEDGER_SCHEMA_VERSION,
+                "records": deepcopy(document["records"]),
+                "operation_count": len(document["operations"]),
+                "observation_count": len(document["observations"]),
+                "path_present": self.path.is_file(),
+            }
+
+    def preview_legacy(self, candidates: list[Mapping[str, Any]], *, operation_ref_hash: str) -> dict[str, Any]:
+        return plan_legacy_migration(candidates, operation_ref_hash=operation_ref_hash)
+
+    def backup(self) -> dict[str, Any]:
+        with self._lock:
+            if not self.path.is_file():
+                return {"ok": True, "state": "nothing_to_backup", "created": False}
+            created = self._backup_locked()
+            return {"ok": created, "state": "backed_up" if created else "degraded", "created": created}
+
+    def apply(self, operation: Mapping[str, Any]) -> dict[str, Any]:
+        checked = validate_operation(operation)
+        if not checked.get("ok"):
+            return {"ok": False, "state": "invalid", "error_codes": checked.get("error_codes", [])}
+        op = checked["operation"]
+        with self._lock:
+            document = self._load_locked()
+            current = self._minimal_current(op["memory_id"], document["records"].get(op["memory_id"]))
+            result = apply_planned_operation(current, op)
+            if not result.get("ok") or not result.get("changed"):
+                return {**result, "backup_created": False}
+            backup_created = self._backup_locked()
+            document["records"][op["memory_id"]] = deepcopy(result["record"])
+            document["operations"].append(deepcopy(op))
+            self._write_locked(document)
+            return {**result, "backup_created": backup_created, "operation_count": len(document["operations"])}
+
+    def rollback(self, operation: Mapping[str, Any]) -> dict[str, Any]:
+        checked = validate_operation(operation)
+        if not checked.get("ok"):
+            return {"ok": False, "state": "invalid", "error_codes": checked.get("error_codes", [])}
+        op = checked["operation"]
+        with self._lock:
+            document = self._load_locked()
+            current = document["records"].get(op["memory_id"])
+            result = rollback_planned_operation(current, op)
+            if not result.get("ok"):
+                return {**result, "backup_created": False}
+            backup_created = self._backup_locked()
+            if result.get("removed"):
+                document["records"].pop(op["memory_id"], None)
+            else:
+                document["records"][op["memory_id"]] = deepcopy(result["record"])
+            document["operations"].append(
+                {
+                    "kind": "rollback",
+                    "memory_id": op["memory_id"],
+                    "before_digest": op["after_record_digest"],
+                    "after_digest": provenance_record_digest(result.get("record")) if result.get("record") else "0" * 64,
+                    "from_revision": op["after_record"]["record_revision"],
+                    "to_revision": result.get("record", {}).get("record_revision", 0) if result.get("record") else 0,
+                }
+            )
+            self._write_locked(document)
+            return {**result, "backup_created": backup_created, "operation_count": len(document["operations"])}
+
+    def record_observed(self, memory_ids: list[str], snapshot: Any) -> dict[str, Any]:
+        """Append observed metadata for selected memories without raw payloads."""
+
+        from .provenance import observed_from_companion_snapshot
+
+        safe_ids = [item for item in memory_ids if isinstance(item, str) and item][:64]
+        if not safe_ids:
+            return {"ok": False, "state": "invalid", "error_code": "memory_ids_empty", "written": 0}
+        with self._lock:
+            document = self._load_locked()
+            updates: dict[str, dict[str, Any]] = {}
+            for memory_id in safe_ids:
+                current = document["records"].get(memory_id)
+                revision = int(current.get("record_revision", 0)) if isinstance(current, dict) else 0
+                record = observed_from_companion_snapshot(memory_id, snapshot, record_revision=revision + 1)
+                checked = validate_provenance_record(record)
+                if not checked.get("ok"):
+                    continue
+                if isinstance(current, dict) and current == checked["record"]:
+                    continue
+                updates[memory_id] = deepcopy(checked["record"])
+            if not updates:
+                return {"ok": True, "state": "deduplicated", "written": 0, "backup_created": False}
+            backup_created = self._backup_locked()
+            document["records"].update(updates)
+            for record in updates.values():
+                document["observations"].append(
+                    {
+                        "memory_id": record["memory_id"],
+                        "record_digest": provenance_record_digest(record),
+                        "record_revision": record["record_revision"],
+                        "source_event_ref_hash": record["source_event_ref_hash"],
+                        "authority_attestation_ref_hash": record["authority_attestation_ref_hash"],
+                        "provenance_state": record["provenance_state"],
+                    }
+                )
+            self._write_locked(document)
+            return {
+                "ok": True,
+                "state": "written",
+                "written": len(updates),
+                "memory_ids": list(updates),
+                "backup_created": backup_created,
+            }
+
+
+__all__ = ["LEDGER_SCHEMA_VERSION", "ProvenanceLedger"]

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -16,6 +16,7 @@ from .visibility import VisibilityPolicy
 
 
 class RetrievalEngine:
+    DEFAULT_MATERIALIZE_LIMIT = 2000
     def __init__(
         self,
         store: MemoryStore,
@@ -1005,7 +1006,11 @@ class RetrievalEngine:
             )
         expanded_terms = self._merge_terms(terms, graph_terms)
         include_pending = not self.policy.hide_pending_review
-        ranked_candidates = await self.store.list_candidate_memories(limit=2000, include_pending=include_pending)
+        # Keep the broad priority scan explicitly bounded.
+        ranked_candidates = await self.store.list_candidate_memories(
+            limit=self.DEFAULT_MATERIALIZE_LIMIT,
+            include_pending=include_pending,
+        )
         current_window_candidates = await self.store.list_current_window_candidate_memories(
             scope=ctx.scope,
             session_id=ctx.session_id,

--- a/core/service.py
+++ b/core/service.py
@@ -876,6 +876,12 @@ class MemoryCompanionService:
         ctx.companion_expression_safety_mode = clean_text(decision.get("safety_mode"), 60)
         ctx.companion_expression_blocker = clean_text(decision.get("blocker"), 60)
         ctx.companion_expression_reason_codes = tuple(decision.get("reason_codes") or ())
+        ctx.companion_expression_pacing = clean_text(decision.get("pacing"), 24)
+        ctx.companion_expression_directness = clean_text(decision.get("directness"), 24)
+        ctx.companion_expression_validation_style = clean_text(decision.get("validation_style"), 24)
+        ctx.companion_expression_self_disclosure = clean_text(decision.get("self_disclosure"), 24)
+        ctx.companion_expression_humor_mode = clean_text(decision.get("humor_mode"), 24)
+        ctx.companion_expression_topic_initiative = clean_text(decision.get("topic_initiative"), 24)
 
     def _sanitize_visible_timeline_text(self, text: Any) -> str:
         cleaned = clean_text(text, 1200)

--- a/core/service.py
+++ b/core/service.py
@@ -834,6 +834,17 @@ class MemoryCompanionService:
         ctx.companion_relationship_phase_label = clean_text(projection.get("phase_label"), 40)
         ctx.companion_relationship_tone = clean_text(projection.get("tone"), 160)
         ctx.companion_relationship_address_level = clean_text(projection.get("address_level"), 120)
+        interaction = projection.get("current_interaction")
+        if isinstance(interaction, dict):
+            ctx.companion_interaction_dynamics_version = clean_text(interaction.get("dynamics_version"), 48)
+            ctx.companion_interaction_band = clean_text(interaction.get("expression_band"), 24)
+            ctx.companion_interaction_recovery_band = clean_text(interaction.get("recovery_band"), 24)
+            try:
+                ctx.companion_interaction_expires_at = max(0.0, min(10**12, float(interaction.get("expires_at") or 0.0)))
+                ctx.companion_interaction_projection_revision = max(0, min(1000000, int(interaction.get("projection_revision") or 0)))
+            except (TypeError, ValueError):
+                ctx.companion_interaction_expires_at = 0.0
+                ctx.companion_interaction_projection_revision = 0
 
     @staticmethod
     def _apply_companion_expression_decision(

--- a/core/service.py
+++ b/core/service.py
@@ -83,6 +83,14 @@ from .visibility import VisibilityPolicy
 
 LOCAL_TZ = ZoneInfo("Asia/Shanghai")
 
+USER_MEMORY_SUMMARY_VERSION = "memory.user_memory_summary.v1"
+_USER_MEMORY_PROFILE_TYPES = frozenset({"user_profile", "user_habit", "manual_memory"})
+_USER_MEMORY_PREFERENCE_TYPES = frozenset({"user_preference"})
+_USER_MEMORY_RELATIONSHIP_TYPES = frozenset({"relationship_claim", "relationship_phase_summary"})
+_USER_MEMORY_CONVERSATION_TYPES = frozenset(
+    {"conversation_event", "conversation_summary", "important_event", "memory_decay_summary", "self_action"}
+)
+
 
 _RECENT_FACT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("meal", re.compile(r"吃过|吃完|吃了|没吃|还没吃|正在吃|吃饭|早饭|早餐|午饭|午餐|晚饭|晚餐|夜宵")),
@@ -1157,6 +1165,127 @@ class MemoryCompanionService:
                 "summary": f"Bot Personal archive reference [{record.memory_type}]",
             })
         return {"ok": True, "read_only": True, "state": "ready", "degraded": False, "pending": False, "items": items[:max(1, min(100, int(limit or 10)))]}
+
+    async def read_user_memory_summary(
+        self,
+        user_id: str,
+        *,
+        session_id: str = "",
+        limit: int = 6,
+    ) -> dict[str, Any]:
+        """Return a bounded, content-free Memory workspace projection for one user.
+
+        Companion remains the authority for relationship and interaction state.
+        This method only reports exact-user Memory categories and opaque, redacted
+        anchors that can be used to open the Memory workspace.
+        """
+
+        identity = clean_text(user_id, 120)
+        requested_session = clean_text(session_id, 200)
+        base = self._user_memory_summary_base(identity, requested_session)
+        if not identity:
+            return {**base, "error_code": "missing_user_id"}
+        if requested_session and session_target_id(requested_session, "private") != identity:
+            return {**base, "error_code": "session_identity_mismatch"}
+        try:
+            bridge_enabled = self.config.bridge_enabled()
+        except Exception:
+            return {**base, "error_code": "bridge_config_unavailable"}
+        if bridge_enabled is not True:
+            return {**base, "error_code": "bridge_disabled"}
+        store = getattr(self, "store", None)
+        reader = getattr(store, "read_user_memory_summary_records", None)
+        if not callable(reader):
+            return {**base, "error_code": "store_unavailable"}
+        try:
+            safe_limit = max(1, min(8, int(limit or 6)))
+        except (TypeError, ValueError, OverflowError):
+            safe_limit = 6
+        try:
+            raw = await reader(identity, session_id=requested_session, limit=safe_limit)
+        except Exception:
+            return {**base, "error_code": "store_query_failed"}
+        if not isinstance(raw, dict):
+            return {**base, "error_code": "invalid_store_response"}
+
+        type_counts = raw.get("type_counts") if isinstance(raw.get("type_counts"), dict) else {}
+        counts = {"profile": 0, "preference": 0, "relationship": 0, "private_conversation": 0, "other": 0, "total": 0}
+        for memory_type, value in type_counts.items():
+            try:
+                count = max(0, int(value))
+            except (TypeError, ValueError, OverflowError):
+                continue
+            counts[self._user_memory_category(memory_type)] += count
+            counts["total"] += count
+
+        summaries: list[dict[str, Any]] = []
+        records = raw.get("records") if isinstance(raw.get("records"), list) else []
+        for record in records[:safe_limit]:
+            if not isinstance(record, MemoryRecord):
+                continue
+            memory_type = clean_text(record.memory_type, 80)
+            category = self._user_memory_category(memory_type)
+            summaries.append(
+                {
+                    "category": category,
+                    "memory_type": memory_type,
+                    "occurred_at": clean_text(record.occurred_at or record.created_at, 80),
+                    "summary": f"{self._user_memory_category_label(category)}（内容已脱敏）",
+                    "content_redacted": True,
+                    "truncated": True,
+                }
+            )
+        return {
+            **base,
+            "ok": True,
+            "state": "ready",
+            "degraded": False,
+            "pending": False,
+            "counts": counts,
+            "summaries": summaries,
+        }
+
+    @staticmethod
+    def _user_memory_summary_base(user_id: str, session_id: str) -> dict[str, Any]:
+        return {
+            "contract": USER_MEMORY_SUMMARY_VERSION,
+            "ok": False,
+            "read_only": True,
+            "state": "degraded",
+            "degraded": True,
+            "pending": True,
+            "user_id": user_id,
+            "session_id": session_id,
+            "counts": {"profile": 0, "preference": 0, "relationship": 0, "private_conversation": 0, "other": 0, "total": 0},
+            "summaries": [],
+            "workspace": {
+                "kind": "memory_user_workspace",
+                "route_hint": "user_memory",
+                "user_id": user_id,
+            },
+        }
+
+    @staticmethod
+    def _user_memory_category(memory_type: Any) -> str:
+        normalized = clean_text(memory_type, 80).lower()
+        if normalized in _USER_MEMORY_PROFILE_TYPES:
+            return "profile"
+        if normalized in _USER_MEMORY_PREFERENCE_TYPES:
+            return "preference"
+        if normalized in _USER_MEMORY_RELATIONSHIP_TYPES:
+            return "relationship"
+        if normalized in _USER_MEMORY_CONVERSATION_TYPES:
+            return "private_conversation"
+        return "other"
+
+    @staticmethod
+    def _user_memory_category_label(category: str) -> str:
+        return {
+            "profile": "用户画像记忆",
+            "preference": "用户偏好记忆",
+            "relationship": "关系线索记忆",
+            "private_conversation": "私聊连续性记忆",
+        }.get(category, "其他用户记忆")
 
     async def read_bot_profile(
         self,

--- a/core/service.py
+++ b/core/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import time
 from collections import Counter, defaultdict
 from copy import deepcopy
@@ -8456,6 +8457,51 @@ class MemoryCompanionService:
         state = self._relationship_phase_state[key]
         state["_identity"] = identity
         return state
+
+    def _peek_relationship_phase(self, ctx: SessionContext) -> dict[str, Any]:
+        """Project an existing phase without creating or saving state."""
+        fallback = {"observed": False, "phase": "unknown", "momentum_band": "unknown"}
+        try:
+            identity = self._phase_identity(ctx)
+            key = self._phase_key(ctx)
+            state = self._relationship_phase_state.get(key)
+            if type(state) is not dict and not identity["bot_id"]:
+                matches = [
+                    candidate
+                    for candidate in self._relationship_phase_state.values()
+                    if type(candidate) is dict
+                    and type(candidate.get("_identity")) is dict
+                    and all(candidate["_identity"].get(field, "") == identity[field] for field in ("platform", "scope", "target_id", "member_id"))
+                ]
+                if len(matches) == 1:
+                    state = matches[0]
+            if type(state) is not dict:
+                legacy_key = clean_text(f"{ctx.scope}:{ctx.current_target_id or ctx.session_id}", 120)
+                legacy_state = self._relationship_phase_state.get(legacy_key)
+                if type(legacy_state) is dict:
+                    state = legacy_state
+            if type(state) is not dict:
+                return fallback
+            phase = state.get("phase")
+            momentum = state.get("momentum")
+            touch_count = state.get("touch_count")
+            if type(phase) is not str or phase not in self._PHASES:
+                return fallback
+            if type(momentum) not in {int, float} or type(momentum) is bool:
+                return fallback
+            if not math.isfinite(momentum):
+                return fallback
+            if type(touch_count) is not int:
+                return fallback
+        except Exception:
+            return fallback
+        momentum_band = "rising" if momentum >= 0.08 else "cooling" if momentum <= -0.08 else "steady"
+        return {
+            "observed": True,
+            "phase": phase,
+            "momentum_band": momentum_band,
+            "touch_count": max(0, min(256, touch_count)),
+        }
 
     def _update_relationship_phase_momentum(
         self,

--- a/core/service.py
+++ b/core/service.py
@@ -1718,31 +1718,9 @@ class MemoryCompanionService:
         return injection
 
     def bridge_get_emotional_events(self, *, session_id: str = "", limit: int = 5) -> list[dict[str, Any]]:
-        """Return pending emotional drift events for the companion plugin to consume."""
-        if not session_id and not self.config.bool(
-            "private_companion_bridge.cross_window_emotional_continuity_enabled", False
-        ):
-            return []
-        now = time.time()
-        events: list[dict[str, Any]] = []
-        if session_id:
-            keys = [session_id]
-        else:
-            keys = list(self._emotional_event_queue.keys())
-        for key in keys:
-            queue = self._emotional_event_queue.get(key, [])
-            fresh = [e for e in queue if (now - e.get("ts", 0)) < self._EMOTIONAL_EVENT_TTL]
-            if len(fresh) != len(queue):
-                self._emotional_event_queue[key] = fresh
-            events.extend(fresh)
-        events.sort(key=lambda e: e.get("ts", 0), reverse=True)
-        result = events[:max(1, min(limit, 20))]
-        for key in keys:
-            queue = self._emotional_event_queue.get(key, [])
-            consumed_ids = {e.get("id", "") for e in result if e.get("session_id") == key}
-            if consumed_ids:
-                self._emotional_event_queue[key] = [e for e in queue if e.get("id", "") not in consumed_ids]
-        return result
+        """Deprecated unscoped read path; opaque delivery contexts own event consumption."""
+        _ = (session_id, limit)
+        return []
 
     async def bridge_search_open_loops(self, *, session_id: str = "", limit: int = 3) -> list[dict[str, Any]]:
         """Search for unresolved open-loop / promise memories for proactive companionship."""
@@ -1898,6 +1876,27 @@ class MemoryCompanionService:
         if len(queue) > self._EMOTIONAL_EVENT_MAX_PER_SESSION:
             queue[:] = queue[-self._EMOTIONAL_EVENT_MAX_PER_SESSION:]
 
+    @staticmethod
+    def _same_private_emotion_domain(event: Any, ctx: SessionContext) -> bool:
+        if not isinstance(event, dict):
+            return False
+        actor = event.get("actor_ref") if isinstance(event.get("actor_ref"), dict) else {}
+        target = event.get("target_ref") if isinstance(event.get("target_ref"), dict) else {}
+        bot_id = clean_text(ctx.bot_id, 160)
+        platform = clean_text(ctx.platform, 80)
+        user_id = clean_text(ctx.user_id, 160)
+        return (
+            bool(bot_id and platform and user_id)
+            and clean_text(ctx.scope, 24).lower() == "private"
+            and clean_text(event.get("bot_id"), 160) == bot_id
+            and clean_text(event.get("scope"), 24).lower() == "private"
+            and clean_text(event.get("platform"), 80) == platform
+            and clean_text(actor.get("kind"), 24) == "user"
+            and clean_text(actor.get("id"), 160) == user_id
+            and clean_text(target.get("kind"), 24) == "bot"
+            and clean_text(target.get("id"), 160) == bot_id
+        )
+
     def _get_cross_window_emotional_hint(self, ctx: SessionContext) -> str:
         """Generate a subtle hint about emotional residue from other chat windows.
 
@@ -1908,7 +1907,9 @@ class MemoryCompanionService:
         if not self.config.bool("private_companion_bridge.cross_window_emotional_continuity_enabled", False):
             return ""
         now = time.time()
-        current_session = ctx.session_id
+        current_session = clean_text(ctx.session_id, 220)
+        if not current_session:
+            return ""
         # Collect recent events from OTHER sessions (within last 30 minutes)
         recent_window = 1800.0  # 30 minutes
         other_events: list[dict[str, Any]] = []
@@ -1916,8 +1917,14 @@ class MemoryCompanionService:
             if session_id == current_session:
                 continue
             for event in queue:
-                age = now - event.get("ts", 0)
-                if age < recent_window:
+                try:
+                    age = now - float(event.get("ts") or 0.0)
+                except (TypeError, ValueError):
+                    continue
+                if (
+                    0.0 <= age < recent_window
+                    and self._same_private_emotion_domain(event, ctx)
+                ):
                     other_events.append(event)
         if not other_events:
             return ""
@@ -1948,42 +1955,14 @@ class MemoryCompanionService:
         window_seconds: float = 1800.0,
         limit: int = 5,
     ) -> dict[str, Any]:
-        """Return a summary of recent emotional events across all sessions for the companion plugin."""
-        if not self.config.bool("private_companion_bridge.cross_window_emotional_continuity_enabled", False):
-            return {
-                "enabled": False,
-                "total": 0,
-                "scar_count": 0,
-                "warm_count": 0,
-                "vulnerable_count": 0,
-            }
-        now = time.time()
-        recent_window = max(60.0, min(86400.0, float(window_seconds or 1800.0)))
-        excluded = clean_text(exclude_session_id, 220)
-        all_events: list[dict[str, Any]] = []
-        for session_id, queue in self._emotional_event_queue.items():
-            if excluded and session_id == excluded:
-                continue
-            for event in queue:
-                age = now - event.get("ts", 0)
-                if age < recent_window:
-                    all_events.append({
-                        "event_id": clean_text(event.get("event_id") or event.get("id"), 96),
-                        "session_id": clean_text(event.get("session_id"), 220),
-                        "event_type": clean_text(event.get("event_type"), 48),
-                        "energy_delta": max(-8.0, min(5.0, float(event.get("energy_delta") or 0.0))),
-                        "age_seconds": round(max(0.0, age), 0),
-                        "ts": float(event.get("ts") or 0.0),
-                    })
-        if not all_events:
-            return {"total": 0, "scar_count": 0, "warm_count": 0, "vulnerable_count": 0}
-        all_events.sort(key=lambda e: e.get("ts", 0), reverse=True)
+        """Deprecated unscoped aggregate; callers must use a delivery context."""
+        _ = (exclude_session_id, window_seconds, limit)
         return {
-            "total": len(all_events),
-            "scar_count": sum(1 for e in all_events if e.get("event_type") == "scar_touched"),
-            "warm_count": sum(1 for e in all_events if e.get("event_type") == "warm_memory"),
-            "vulnerable_count": sum(1 for e in all_events if e.get("event_type") == "vulnerable_resonance"),
-            "recent": all_events[: max(1, min(20, int(limit or 5)))],
+            "enabled": False,
+            "total": 0,
+            "scar_count": 0,
+            "warm_count": 0,
+            "vulnerable_count": 0,
         }
 
     async def _retrieval_cache_key(

--- a/core/service.py
+++ b/core/service.py
@@ -24,7 +24,7 @@ from .astrbot_compat import (
     remove_temp_text,
     sanitize_request_history,
 )
-from .bridge import serialize_memory
+from .bridge import sanitize_companion_relationship_projection, serialize_memory
 from .bot_personal_dto import (
     BotPersonalArchiveDTO,
     BotPersonalValidationError,
@@ -469,6 +469,7 @@ class MemoryCompanionService:
     async def handle_llm_request(self, event: Any, req: Any) -> None:
         ctx = await self.identity.resolve_event_context(event)
         self._sanitize_session_context_message_text(ctx)
+        self._apply_companion_relationship_projection(ctx, event=event, req=req)
         self._ensure_reconstruction_turn_token(event, ctx)
         self._apply_private_companion_preferred_address(ctx, req=req, event=event)
         if self._private_companion_internal_generation_event(event):
@@ -783,6 +784,43 @@ class MemoryCompanionService:
             getattr(req, "_private_companion_preferred_address_locked", False)
             or getattr(event, "_private_companion_preferred_address_locked", False)
         )
+
+    @staticmethod
+    def _apply_companion_relationship_projection(
+        ctx: SessionContext,
+        *,
+        event: Any = None,
+        req: Any = None,
+    ) -> None:
+        """Consume a bounded Companion-owned relationship projection in private scope."""
+
+        if ctx.scope != "private":
+            return
+        raw_projection: Any = None
+        for target in (event, req):
+            if target is None:
+                continue
+            for attr in (
+                "private_companion_context",
+                "companion_context",
+                "memory_companion_context",
+            ):
+                payload = getattr(target, attr, None)
+                if isinstance(payload, dict) and isinstance(payload.get("relationship_projection"), dict):
+                    raw_projection = payload["relationship_projection"]
+                    break
+            if raw_projection is not None:
+                break
+        consumed = sanitize_companion_relationship_projection(raw_projection)
+        projection = consumed.get("projection") if isinstance(consumed, dict) else None
+        if not isinstance(projection, dict):
+            return
+        ctx.relationship_authority_source = "private_companion.relationship_score"
+        ctx.companion_relationship_score = int(projection.get("score") or 0)
+        ctx.companion_relationship_phase_key = clean_text(projection.get("phase_key"), 40)
+        ctx.companion_relationship_phase_label = clean_text(projection.get("phase_label"), 40)
+        ctx.companion_relationship_tone = clean_text(projection.get("tone"), 160)
+        ctx.companion_relationship_address_level = clean_text(projection.get("address_level"), 120)
 
     def _sanitize_visible_timeline_text(self, text: Any) -> str:
         cleaned = clean_text(text, 1200)
@@ -8876,7 +8914,12 @@ class MemoryCompanionService:
         recent_ids.append(message_id)
         state["recent_touch_message_ids"] = recent_ids[-self._RELATIONSHIP_TOUCH_HISTORY_LIMIT :]
         state["updated_at"] = utc_now()
-        self._maybe_transition_phase(ctx, state)
+        if ctx.relationship_authority_source == "private_companion.relationship_score":
+            state["companion_phase_key"] = clean_text(ctx.companion_relationship_phase_key, 40)
+            state["companion_phase_label"] = clean_text(ctx.companion_relationship_phase_label, 40)
+            state["phase_authority"] = "private_companion.relationship_score"
+        else:
+            self._maybe_transition_phase(ctx, state)
         self._save_relationship_phase_state()
         return True
 
@@ -8984,6 +9027,18 @@ class MemoryCompanionService:
                 f"当前对象已明确固定称呼为“{preferred_address}”。需要直接称呼时只使用这一项，"
                 "不必每句都带称呼；关系阶段建议、历史称呼、显示名和旧记忆只作识别资料，"
                 "不能另造或追加亲昵称呼。若对方本轮明确要求改称呼，以本轮最新要求为准。"
+            )
+        if ctx.relationship_authority_source == "private_companion.relationship_score":
+            label = clean_text(ctx.companion_relationship_phase_label, 40) or clean_text(
+                ctx.companion_relationship_phase_key,
+                40,
+            )
+            tone = clean_text(ctx.companion_relationship_tone, 160)
+            address = clean_text(ctx.companion_relationship_address_level, 120)
+            return (
+                f"陪伴插件是长期亲密度权威：当前阶段为“{label or '未标注'}”。"
+                f"基础语气按“{tone or '自然、尊重当前节奏'}”，称呼尺度按“{address or '沿用已确认称呼'}”。"
+                "Memory 仅提供记忆触动趋势和相关事实，不得用自身阶段另行升级称呼、语气或权限。"
             )
         state = self._get_relationship_phase(ctx)
         user_address_phase = state.get("current_address_phase", "")

--- a/core/service.py
+++ b/core/service.py
@@ -24,7 +24,11 @@ from .astrbot_compat import (
     remove_temp_text,
     sanitize_request_history,
 )
-from .bridge import sanitize_companion_relationship_projection, serialize_memory
+from .bridge import (
+    sanitize_companion_expression_decision,
+    sanitize_companion_relationship_projection,
+    serialize_memory,
+)
 from .bot_personal_dto import (
     BotPersonalArchiveDTO,
     BotPersonalValidationError,
@@ -470,6 +474,7 @@ class MemoryCompanionService:
         ctx = await self.identity.resolve_event_context(event)
         self._sanitize_session_context_message_text(ctx)
         self._apply_companion_relationship_projection(ctx, event=event, req=req)
+        self._apply_companion_expression_decision(ctx, event=event, req=req)
         self._ensure_reconstruction_turn_token(event, ctx)
         self._apply_private_companion_preferred_address(ctx, req=req, event=event)
         if self._private_companion_internal_generation_event(event):
@@ -821,6 +826,36 @@ class MemoryCompanionService:
         ctx.companion_relationship_phase_label = clean_text(projection.get("phase_label"), 40)
         ctx.companion_relationship_tone = clean_text(projection.get("tone"), 160)
         ctx.companion_relationship_address_level = clean_text(projection.get("address_level"), 120)
+
+    @staticmethod
+    def _apply_companion_expression_decision(
+        ctx: SessionContext,
+        *,
+        event: Any = None,
+        req: Any = None,
+    ) -> None:
+        """Consume a bounded, request-scoped Companion expression decision."""
+
+        if ctx.scope != "private":
+            return
+        raw_decision: Any = None
+        for target in (req, event):
+            if target is None:
+                continue
+            candidate = getattr(target, "_private_companion_expression_decision", None)
+            if candidate is not None:
+                raw_decision = candidate
+                break
+        consumed = sanitize_companion_expression_decision(raw_decision)
+        decision = consumed.get("decision") if isinstance(consumed, dict) else None
+        if not isinstance(decision, dict):
+            return
+        ctx.companion_expression_contract = clean_text(decision.get("contract"), 80)
+        ctx.companion_expression_band = clean_text(decision.get("expression_band"), 40)
+        ctx.companion_expression_allowed_behaviors = tuple(decision.get("allowed_behaviors") or ())
+        ctx.companion_expression_safety_mode = clean_text(decision.get("safety_mode"), 60)
+        ctx.companion_expression_blocker = clean_text(decision.get("blocker"), 60)
+        ctx.companion_expression_reason_codes = tuple(decision.get("reason_codes") or ())
 
     def _sanitize_visible_timeline_text(self, text: Any) -> str:
         cleaned = clean_text(text, 1200)
@@ -8034,6 +8069,9 @@ class MemoryCompanionService:
             return "uncertain", "low_confidence"
         text = clean_text(query_text or ctx.message_text, 800)
         explicit_memory = self._message_is_contextual_memory_request(text) or self._message_requests_temporal_aggregate(text)
+        companion_cap_reason = self._companion_memory_mention_cap(ctx, explicit_memory=explicit_memory)
+        if companion_cap_reason:
+            return "tone", companion_cap_reason
         acl_authorized_for_sender = self._acl_authorized_private_group_result(
             ctx,
             memory,
@@ -8115,6 +8153,23 @@ class MemoryCompanionService:
         if memory.sayability == "indirect" and not explicit_memory and not acl_authorized_for_sender:
             return "tone", "indirect_memory"
         return "mention", "direct_relevance"
+
+    @staticmethod
+    def _companion_memory_mention_cap(ctx: SessionContext, *, explicit_memory: bool) -> str:
+        """Return a reason when Companion limits unsolicited memory expression."""
+
+        if explicit_memory or ctx.scope != "private" or not ctx.companion_expression_contract:
+            return ""
+        if ctx.companion_expression_blocker:
+            return "companion_expression:blocker"
+        if ctx.companion_expression_safety_mode != "normal":
+            return f"companion_expression:safety_{ctx.companion_expression_safety_mode}"
+        if ctx.companion_expression_band in {"avoidant", "hurt"}:
+            return f"companion_expression:band_{ctx.companion_expression_band}"
+        mention_capable = {"support", "followup", "shared_ritual"}
+        if not mention_capable.intersection(ctx.companion_expression_allowed_behaviors):
+            return "companion_expression:behavior_cap"
+        return ""
 
     def _memory_age_days(self, memory: MemoryRecord) -> float | None:
         timestamp = clean_text(memory.occurred_at or memory.updated_at or memory.created_at, 80)
@@ -8890,6 +8945,11 @@ class MemoryCompanionService:
         message_id = clean_text(message_id or ctx.message_id, 160)
         if not message_id:
             return False
+        if (
+            ctx.relationship_authority_source == "private_companion.relationship_score"
+            or ctx.companion_expression_contract
+        ):
+            return False
         state = self._get_relationship_phase(ctx)
         recent_ids = state.get("recent_touch_message_ids")
         if not isinstance(recent_ids, list):
@@ -8914,12 +8974,7 @@ class MemoryCompanionService:
         recent_ids.append(message_id)
         state["recent_touch_message_ids"] = recent_ids[-self._RELATIONSHIP_TOUCH_HISTORY_LIMIT :]
         state["updated_at"] = utc_now()
-        if ctx.relationship_authority_source == "private_companion.relationship_score":
-            state["companion_phase_key"] = clean_text(ctx.companion_relationship_phase_key, 40)
-            state["companion_phase_label"] = clean_text(ctx.companion_relationship_phase_label, 40)
-            state["phase_authority"] = "private_companion.relationship_score"
-        else:
-            self._maybe_transition_phase(ctx, state)
+        self._maybe_transition_phase(ctx, state)
         self._save_relationship_phase_state()
         return True
 
@@ -8994,6 +9049,11 @@ class MemoryCompanionService:
 
     def _update_address_evolution(self, ctx: SessionContext, text: str) -> None:
         """Track address evolution in the relationship phase state."""
+        if (
+            ctx.relationship_authority_source == "private_companion.relationship_score"
+            or ctx.companion_expression_contract
+        ):
+            return
         phase = self._detect_address_phase(text)
         if not phase:
             return
@@ -9028,6 +9088,8 @@ class MemoryCompanionService:
                 "不必每句都带称呼；关系阶段建议、历史称呼、显示名和旧记忆只作识别资料，"
                 "不能另造或追加亲昵称呼。若对方本轮明确要求改称呼，以本轮最新要求为准。"
             )
+        if ctx.companion_expression_contract:
+            return ""
         if ctx.relationship_authority_source == "private_companion.relationship_score":
             label = clean_text(ctx.companion_relationship_phase_label, 40) or clean_text(
                 ctx.companion_relationship_phase_key,

--- a/core/service.py
+++ b/core/service.py
@@ -77,6 +77,9 @@ from .turn_signal import analyze_turn_signal, message_terms
 from .visibility import VisibilityPolicy
 
 
+LOCAL_TZ = ZoneInfo("Asia/Shanghai")
+
+
 _RECENT_FACT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("meal", re.compile(r"吃过|吃完|吃了|没吃|还没吃|正在吃|吃饭|早饭|早餐|午饭|午餐|晚饭|晚餐|夜宵")),
     ("bath", re.compile(r"洗澡|洗完澡|冲澡|沐浴")),
@@ -2418,7 +2421,7 @@ class MemoryCompanionService:
         error: str = "",
     ) -> None:
         usage = self._extract_token_usage(resp, prompt, completion)
-        now_dt = datetime.now()
+        now_dt = datetime.now(LOCAL_TZ)
         now_ts = time.time()
         day = now_dt.strftime("%Y-%m-%d")
         hour = now_dt.strftime("%Y-%m-%dT%H:00")
@@ -2581,9 +2584,13 @@ class MemoryCompanionService:
         provider_id = clean_text(provider_id, 160)
         indexed = 0
         try:
+            batch_size = max(
+                1,
+                min(200, self.config.int("retrieval.embedding_backfill_batch_size", 50)),
+            )
             records = await self.store.list_memories_missing_embeddings(
                 provider_id=provider_id,
-                limit=self.config.int("retrieval.embedding_backfill_batch_size", 50),
+                limit=batch_size,
                 include_pending=self.config.bool("retrieval.embedding_index_pending", False),
             )
             for record in records:
@@ -8113,7 +8120,7 @@ class MemoryCompanionService:
         if not check_like:
             return False
         try:
-            hour = datetime.now().hour
+            hour = datetime.now(LOCAL_TZ).hour
         except Exception:
             return True
         return hour >= 23 or hour < 7
@@ -8647,7 +8654,7 @@ class MemoryCompanionService:
     def _compute_time_of_day(self) -> str:
         """Compute time-of-day category for atmosphere hints."""
         try:
-            hour = datetime.now().hour
+            hour = datetime.now(LOCAL_TZ).hour
         except Exception:
             return ""
         if 23 <= hour or hour < 4:

--- a/core/service.py
+++ b/core/service.py
@@ -72,6 +72,7 @@ from .operations import (
 )
 from .provenance import observed_from_companion_snapshot
 from .provenance_store import ProvenanceLedger
+from .portrait_service import PortraitService
 from .qq_history import QQHistoryReader
 from .reply_chain import ReplyChainResolver
 from .retrieval import RetrievalEngine
@@ -193,6 +194,7 @@ class MemoryCompanionService:
 
         self.store = MemoryStore(self.data_dir / "memory_companion.db")
         self.store.initialize()
+        self.portraits = PortraitService(self.store, self.config)
         normalized = self.store.normalize_legacy_manual_visibility()
         if normalized:
             logger.info("[MemoryCompanion] 已收回早期过宽的手动记忆可见性: count=%s", normalized)
@@ -219,6 +221,13 @@ class MemoryCompanionService:
         self._SUMMARY_LOCK_TTL: float = 600.0  # 10 minutes
         self._decay_lock = asyncio.Lock()
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._portrait_dispatch_task: asyncio.Task[Any] | None = None
+        self._portrait_dispatch_status: dict[str, Any] = {
+            "state": "idle",
+            "last_run_day": "",
+            "last_result": "",
+            "last_completed_at": "",
+        }
         self._closing = False
         self._closed = False
         self._embedding_backfill_inflight: set[str] = set()
@@ -480,6 +489,10 @@ class MemoryCompanionService:
         return result
 
     async def handle_llm_request(self, event: Any, req: Any) -> None:
+        if bool(getattr(event, "private_companion_req036_denied", False)):
+            # Companion owns the fixed-reply branch. Do not resolve identity,
+            # read memory, write evidence, or enter any LLM path here.
+            return
         ctx = await self.identity.resolve_event_context(event)
         self._sanitize_session_context_message_text(ctx)
         self._apply_companion_relationship_projection(ctx, event=event, req=req)
@@ -572,6 +585,8 @@ class MemoryCompanionService:
                         source_memory_id=derived_id,
                         metadata={"source": "relationship_claim"},
                     )
+        await self.portraits.capture_user_message(ctx, event=event, req=req)
+        self._ensure_portrait_daily_dispatcher()
         if not self.config.bool("memory_capture.capture_bot_responses", True):
             self._schedule_session_summary(ctx, reason="after_user_message")
 
@@ -620,7 +635,99 @@ class MemoryCompanionService:
         )
         if self.config.bool("memory_capture.record_relationship_edges", True):
             await self.note_relationships(ctx)
+        await self.portraits.capture_user_message(ctx, event=event)
+        self._ensure_portrait_daily_dispatcher()
         self._schedule_session_summary(ctx, reason="group_conversation")
+
+    async def read_unified_profile_portrait(self, request: dict[str, Any], *, limit: int = 8) -> dict[str, Any]:
+        """Read a pre-authorized low-sensitivity summary through the Bridge."""
+        return await self.portraits.read_summary(request, limit=limit)
+
+    async def unified_profile_portrait_status(self, person_id: str) -> dict[str, Any]:
+        """Expose synchronization state without returning portrait facts."""
+        return await self.portraits.status(person_id)
+
+    async def run_unified_profile_portrait_batch(self, person_id: str, *, run_day: str = "") -> dict[str, Any]:
+        return await self.portraits.run_daily_batch(person_id, run_day=run_day)
+
+    def _portrait_window_hours(self) -> tuple[int, int]:
+        start = max(0, min(23, self.config.int("portrait.update_window_start_hour", 3)))
+        end = max(1, min(24, self.config.int("portrait.update_window_end_hour", 5)))
+        if end <= start:
+            start, end = 3, 5
+        return start, end
+
+    def _portrait_seconds_until_window(self, now: datetime | None = None) -> float:
+        local_now = (now or datetime.now(LOCAL_TZ)).astimezone(LOCAL_TZ)
+        start, end = self._portrait_window_hours()
+        if start <= local_now.hour < end:
+            return 0.0
+        candidate = local_now.replace(hour=start, minute=0, second=0, microsecond=0)
+        if local_now.hour >= end:
+            candidate += timedelta(days=1)
+        return max(1.0, (candidate - local_now).total_seconds())
+
+    def _ensure_portrait_daily_dispatcher(self) -> None:
+        """Start one retained scheduler after the first eligible observation."""
+        if self._closing or self._closed or not self.config.bool("portrait.daily_dispatch_enabled", True):
+            return
+        if self._portrait_dispatch_task is not None and not self._portrait_dispatch_task.done():
+            return
+        task = self._spawn_background(self._portrait_daily_dispatch_loop(), label="portrait-daily-dispatch")
+        self._portrait_dispatch_task = task
+        if task is not None:
+            self._portrait_dispatch_status["state"] = "scheduled"
+
+    async def _portrait_daily_dispatch_loop(self) -> None:
+        """Run only in the configured daily window, never on a message path."""
+        while not self._closing and not self._closed and self.config.bool("portrait.daily_dispatch_enabled", True):
+            try:
+                delay = self._portrait_seconds_until_window()
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                if self._closing or self._closed:
+                    break
+                await self.run_due_portrait_batches(force_window=True)
+                # One bounded retry window supports the configured second
+                # attempt without turning evidence capture into LLM work.
+                await asyncio.sleep(15 * 60)
+                if self._portrait_seconds_until_window() == 0:
+                    await self.run_due_portrait_batches(force_window=True)
+                # Do not repeatedly re-enter the same window after the two
+                # bounded attempts.  The next pass begins on the next local
+                # calendar day.
+                next_start = (datetime.now(LOCAL_TZ) + timedelta(days=1)).replace(
+                    hour=self._portrait_window_hours()[0], minute=0, second=0, microsecond=0
+                )
+                await asyncio.sleep(max(60.0, (next_start - datetime.now(LOCAL_TZ)).total_seconds()))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._portrait_dispatch_status.update({
+                    "state": "degraded",
+                    "last_result": clean_text(exc, 160) or "bridge_degraded",
+                    "last_completed_at": utc_now(),
+                })
+                await asyncio.sleep(15 * 60)
+
+    async def run_due_portrait_batches(self, *, force_window: bool = False) -> dict[str, Any]:
+        now = datetime.now(LOCAL_TZ)
+        if not force_window and self._portrait_seconds_until_window(now) > 0:
+            return {"ok": True, "code": "portrait_window_closed", "processed": 0, "results": []}
+        run_day = now.date().isoformat()
+        people = await self.store.list_pending_portrait_people(limit=500)
+        results: list[dict[str, Any]] = []
+        for person_id in people:
+            result = await self.portraits.run_daily_batch(person_id, run_day=run_day)
+            results.append({"person_id": person_id, "code": clean_text(result.get("code"), 80), "ok": bool(result.get("ok"))})
+        code = "profile_exact" if any(item["ok"] for item in results) else "portrait_insufficient_evidence"
+        self._portrait_dispatch_status.update({
+            "state": "ready",
+            "last_run_day": run_day,
+            "last_result": code,
+            "last_completed_at": utc_now(),
+        })
+        return {"ok": True, "code": code, "processed": len(results), "results": results}
 
     async def handle_llm_response(self, event: Any, resp: Any) -> None:
         if self._private_companion_internal_generation_event(event):
@@ -7517,16 +7624,11 @@ class MemoryCompanionService:
         *,
         query_text: str = "",
     ) -> tuple[dict[str, list[Any]], list[dict[str, str]]]:
-        """Keep group injections tied to the current speaker without disabling explicit sharing."""
+        """Keep group injections scoped to the current speaker and group."""
         if ctx.scope != "group" or not slot_map:
             return slot_map, []
-        if not self._context_bool(ctx, "group_actor_relevance_guard_enabled", True):
-            return slot_map, []
 
-        query = clean_text(query_text or ctx.message_text, 1200)
-        explicit_recall = self._message_is_contextual_memory_request(query) or self._message_requests_temporal_aggregate(query)
-        personalized_context = self._message_requests_personalized_context(query)
-        contextual_private_use = explicit_recall or personalized_context
+        del query_text
         current_user_id = clean_text(ctx.user_id, 160)
         cleaned = {slot: list(items or []) for slot, items in (slot_map or {}).items()}
         blocked: list[dict[str, str]] = []
@@ -7538,16 +7640,10 @@ class MemoryCompanionService:
                 if memory is None:
                     kept.append(item)
                     continue
-                owner_id, owner_names = self._memory_user_actor(memory)
-                actor_mentioned = self._query_mentions_memory_actor(query, owner_id, owner_names)
+                owner_id, _owner_names = self._memory_user_actor(memory)
                 memory_type = clean_text(getattr(memory, "memory_type", ""), 80).lower()
                 visibility = clean_text(getattr(memory, "visibility", ""), 80).lower()
                 is_private = clean_text(getattr(memory, "scope", ""), 40).lower() == "private" or visibility == "private_pair"
-                acl_authorized_for_sender = self._acl_authorized_private_group_result(
-                    ctx,
-                    memory,
-                    item,
-                )
                 is_user_profile = slot == "user_profile" or memory_type in {
                     "user_profile",
                     "user_preference",
@@ -7557,17 +7653,19 @@ class MemoryCompanionService:
                 }
 
                 reason = ""
-                if is_private:
-                    if not contextual_private_use and not acl_authorized_for_sender:
-                        reason = "group_private_memory_requires_recall_or_personalization"
-                    elif not owner_id and not actor_mentioned:
-                        reason = "group_private_memory_actor_unknown"
-                    elif current_user_id and owner_id and owner_id != current_user_id and not actor_mentioned:
-                        reason = "group_private_memory_actor_not_current_sender"
-                    elif not current_user_id and not actor_mentioned:
-                        reason = "group_private_memory_sender_unknown"
-                elif is_user_profile and owner_id and current_user_id and owner_id != current_user_id and not actor_mentioned:
-                    reason = "group_profile_actor_not_current_sender"
+                if is_user_profile:
+                    # A group is a presentation scope, never an unbounded
+                    # profile lookup surface. Companion can add an exact-self,
+                    # low-sensitivity portrait summary after its own gate.
+                    reason = (
+                        "req036_group_third_party_profile_forbidden"
+                        if not current_user_id or not owner_id or owner_id != current_user_id
+                        else "req036_group_profile_requires_portrait_summary"
+                    )
+                elif is_private:
+                    # Private legacy memories never become group retrieval
+                    # material, even through an ACL or a named request.
+                    reason = "req036_group_private_memory_forbidden"
 
                 if reason:
                     blocked.append({

--- a/core/service.py
+++ b/core/service.py
@@ -36,6 +36,7 @@ from .chat_import import HistoricalChatImporter
 from .classifier import MemoryClassifier
 from .config import ConfigView
 from .context_orchestrator import RetrievalIntent, RetrievalIntentBuilder
+from .emotion_event_contract import normalize_emotion_event
 from .identity import IdentityResolver, looks_like_command, maybe_await, normalize_session_context_fields, session_target_id
 from .importance import ImportanceEvaluator
 from .injection import (
@@ -1314,7 +1315,7 @@ class MemoryCompanionService:
                 break
         return open_loops
 
-    def _detect_and_queue_emotional_events(
+    async def _detect_and_queue_emotional_events(
         self,
         ctx: SessionContext,
         results: list[Any],
@@ -1368,23 +1369,54 @@ class MemoryCompanionService:
             event_id = hashlib.sha1(
                 f"{ctx.session_id}|{event_key}|{memory.id}|{event_type}".encode("utf-8", errors="ignore")
             ).hexdigest()[:20]
-            events.append({
-                "id": f"emo_{event_id}",
-                "ts": now,
+            event = normalize_emotion_event({
+                "event_id": f"emo_{event_id}",
+                "trace_id": f"etr_{event_id}",
+                "producer_plugin": "memory_companion",
+                "origin_kind": "memory_recall",
+                "platform": ctx.platform,
+                "bot_id": ctx.bot_id,
+                "scope": ctx.scope,
                 "session_id": ctx.session_id,
+                "actor_ref": {
+                    "kind": memory.subject.kind,
+                    "id": memory.subject.id,
+                    "role": memory.subject.role,
+                },
+                "target_ref": {"kind": "bot", "id": ctx.bot_id or "self", "role": "bot_self"},
                 "event_type": event_type,
+                "intensity": max(scar_w, emotional_w, vulnerability_w) * 100.0,
+                "confidence": max(0.5, min(1.0, getattr(item, "score", 0.5))),
+                "valence_hint": 0.35 if event_type == "warm_memory" else -0.45 if event_type == "scar_touched" else -0.1,
+                "arousal_hint": min(1.0, max(scar_w, emotional_w)),
+                "vulnerability_hint": max(vulnerability_w, 0.6 if event_type == "vulnerable_resonance" else 0.0),
+                "source_rule": event_type,
+                "occurred_at": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(timespec="seconds"),
+                "dedupe_key": f"{ctx.session_id}|{event_key}|{memory.id}|{event_type}",
+                "payload_hash": hashlib.sha256(memory.id.encode("utf-8", errors="ignore")).hexdigest(),
+                "privacy_level": "redacted",
+                "applied_energy_delta": round(energy_delta, 2),
+                "status": "observed",
+                "reason_codes": [event_type, "memory_recall_resonance"],
+            }, producer_plugin="memory_companion")
+            event.update({
+                "id": event["event_id"],
+                "ts": now,
                 "memory_id": memory.id,
                 "energy_delta": round(energy_delta, 2),
                 "mood_hint": mood_hint,
                 "scar_weight": round(scar_w, 3),
                 "emotional_weight": round(emotional_w, 3),
-                "content_preview": clean_text(memory.content, 120),
             })
+            events.append(event)
         if not events:
             return
         queue = self._emotional_event_queue.setdefault(ctx.session_id, [])
         existing_ids = {clean_text(item.get("id"), 80) for item in queue if isinstance(item, dict)}
-        queue.extend(event for event in events if clean_text(event.get("id"), 80) not in existing_ids)
+        fresh_events = [event for event in events if clean_text(event.get("id"), 80) not in existing_ids]
+        queue.extend(fresh_events)
+        for event in fresh_events:
+            await self.store.upsert_emotion_event(event)
         # Trim old events
         queue[:] = [e for e in queue if (now - e.get("ts", 0)) < self._EMOTIONAL_EVENT_TTL]
         if len(queue) > self._EMOTIONAL_EVENT_MAX_PER_SESSION:
@@ -5229,7 +5261,7 @@ class MemoryCompanionService:
             slot_map,
             recent_fact_context=(recent_fact_context if "<recent_fact_context>" in injection else ""),
         )
-        self._detect_and_queue_emotional_events(
+        await self._detect_and_queue_emotional_events(
             ctx, results,
             companion_bot_mood=merged_bot_mood,
             companion_bot_energy=merged_bot_energy,
@@ -5515,7 +5547,7 @@ class MemoryCompanionService:
             slot_map,
             recent_fact_context=(recent_fact_context if "<recent_fact_context>" in injection else ""),
         )
-        self._detect_and_queue_emotional_events(
+        await self._detect_and_queue_emotional_events(
             ctx, results,
             companion_bot_mood=_bot_mood,
             companion_bot_energy=_bot_energy,

--- a/core/service.py
+++ b/core/service.py
@@ -6975,9 +6975,11 @@ class MemoryCompanionService:
             )
 
     def companion_coordination_status(self) -> dict[str, Any]:
-        bridge_enabled = self.config.bool("private_companion_bridge.enabled", True)
+        bridge_enabled = self.config.bridge_enabled()
         return {
             "available": True,
+            "state": "ready" if bridge_enabled else "local_only",
+            "degraded": False,
             "schedule_fast_context": bridge_enabled and self.config.bool(
                 "private_companion_bridge.schedule_fast_context_enabled",
                 True,

--- a/core/service.py
+++ b/core/service.py
@@ -12,7 +12,7 @@ import inspect
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 from zoneinfo import ZoneInfo
 
 from .astrbot_compat import (
@@ -65,6 +65,8 @@ from .operations import (
     detect_preset,
     persist_runtime_config,
 )
+from .provenance import observed_from_companion_snapshot
+from .provenance_store import ProvenanceLedger
 from .qq_history import QQHistoryReader
 from .reply_chain import ReplyChainResolver
 from .retrieval import RetrievalEngine
@@ -234,6 +236,148 @@ class MemoryCompanionService:
         self._relationship_phase_state: dict[str, dict[str, Any]] = {}
         self._RELATIONSHIP_PHASE_FILE = self.data_dir / "memory_companion_relationship_phase.json"
         self._load_relationship_phase_state()
+        self.provenance_ledger = ProvenanceLedger(self.data_dir / "provenance_ledger.json")
+        self._last_p5_gate_status: dict[str, Any] = {"state": "disabled", "enabled": False}
+
+    def _p5_gate_enabled(self, sink: str) -> bool:
+        key = (
+            "private_companion_bridge.enable_p5_b1_recall_gate"
+            if sink == "memory_recall"
+            else "private_companion_bridge.enable_p5_b1_bridge_gate"
+        )
+        return self.config.bool(key, False)
+
+    async def _p5_gate(
+        self,
+        *,
+        event: Any = None,
+        sink: str,
+        attestation: Any = None,
+        consumer: Any = None,
+    ) -> dict[str, Any]:
+        """Consume an opaque Companion attestation when a P5 gate is enabled."""
+
+        if not self._p5_gate_enabled(sink):
+            if attestation is not None and callable(consumer):
+                try:
+                    consumed = consumer(attestation, sink)
+                    if inspect.isawaitable(consumed):
+                        await consumed
+                except Exception:
+                    pass
+            result = {"ok": True, "state": "legacy", "legacy": True, "enabled": False}
+            self._last_p5_gate_status = result
+            return result
+        if attestation is None and event is not None:
+            issuer = getattr(event, "private_companion_p5_issue_attestation", None)
+            if callable(issuer):
+                try:
+                    issued = issuer(sink)
+                except Exception:
+                    issued = None
+                if isinstance(issued, tuple) and len(issued) == 2:
+                    attestation, consumer = issued
+        if attestation is None or not callable(consumer):
+            result = {
+                "ok": False,
+                "state": "degraded",
+                "enabled": True,
+                "error_code": "p5_attestation_required",
+                "warnings": ["legacy_call_not_attested"],
+            }
+            self._last_p5_gate_status = result
+            return result
+        try:
+            snapshot = consumer(attestation, sink)
+            if inspect.isawaitable(snapshot):
+                snapshot = await snapshot
+        except Exception:
+            snapshot = None
+        snapshot_record = observed_from_companion_snapshot("p5_gate", snapshot)
+        snapshot_sink = getattr(snapshot, "sink", None)
+        if snapshot_sink is None and isinstance(snapshot, Mapping):
+            snapshot_sink = snapshot.get("sink")
+        if snapshot_record.get("provenance_state") != "observed" or snapshot_sink != sink:
+            result = {
+                "ok": False,
+                "state": "denied",
+                "enabled": True,
+                "error_code": "p5_attestation_invalid",
+                "warnings": ["invalid_or_replayed_attestation"],
+            }
+            self._last_p5_gate_status = result
+            return result
+        disposition = str(getattr(snapshot, "disposition", "") or "")
+        trust = str(getattr(snapshot, "source_trust", "") or "")
+        if isinstance(snapshot, Mapping):
+            disposition = str(snapshot.get("disposition") or disposition)
+            trust = str(snapshot.get("source_trust") or snapshot.get("trust") or trust)
+        if disposition == "deny_high_risk":
+            state, error_code, allowed = "denied", "p5_high_risk_denied", False
+        elif disposition != "allow" or trust in {"T3", "T4"}:
+            state, error_code, allowed = "shadow", "p5_source_shadowed", False
+        else:
+            state, error_code, allowed = "allowed", "", True
+        result = {
+            "ok": allowed,
+            "state": state,
+            "enabled": True,
+            "snapshot": snapshot,
+            "error_code": error_code or None,
+            "warnings": [] if allowed else [error_code],
+        }
+        self._last_p5_gate_status = {key: value for key, value in result.items() if key != "snapshot"}
+        return result
+
+    def p5_capability_status(self) -> dict[str, Any]:
+        ledger = getattr(self, "provenance_ledger", None)
+        snapshot = ledger.snapshot() if isinstance(ledger, ProvenanceLedger) else {
+            "records": {}, "operation_count": 0, "observation_count": 0, "path_present": False,
+        }
+        return {
+            "schema_version": "ops.p5.provenance.v1",
+            "recall_gate": self._p5_gate_enabled("memory_recall"),
+            "bridge_gate": self._p5_gate_enabled("bridge_serialization"),
+            "last_gate_state": str(getattr(self, "_last_p5_gate_status", {}).get("state") or "disabled"),
+            "provenance_records": len(snapshot.get("records", {})),
+            "provenance_operations": int(snapshot.get("operation_count", 0) or 0),
+            "provenance_observations": int(snapshot.get("observation_count", 0) or 0),
+            "provenance_file_present": bool(snapshot.get("path_present", False)),
+        }
+
+    async def _p5_record_observed(self, memory_ids: list[str], snapshot: Any) -> dict[str, Any]:
+        ledger = getattr(self, "provenance_ledger", None)
+        if not isinstance(ledger, ProvenanceLedger):
+            return {"ok": False, "state": "degraded", "error_code": "provenance_ledger_unavailable"}
+        return await asyncio.to_thread(ledger.record_observed, memory_ids, snapshot)
+
+    def provenance_snapshot(self) -> dict[str, Any]:
+        ledger = getattr(self, "provenance_ledger", None)
+        return ledger.snapshot() if isinstance(ledger, ProvenanceLedger) else {"records": {}, "operation_count": 0}
+
+    def provenance_preview(self, candidates: list[Mapping[str, Any]], *, operation_ref_hash: str) -> dict[str, Any]:
+        ledger = getattr(self, "provenance_ledger", None)
+        if not isinstance(ledger, ProvenanceLedger):
+            return {"mode": "preview", "readonly": True, "write_count": 0, "error_codes": ["ledger_unavailable"]}
+        return ledger.preview_legacy(candidates, operation_ref_hash=operation_ref_hash)
+
+    async def provenance_backup(self) -> dict[str, Any]:
+        ledger = getattr(self, "provenance_ledger", None)
+        if not isinstance(ledger, ProvenanceLedger):
+            return {"ok": False, "state": "degraded", "error_code": "ledger_unavailable"}
+        return await asyncio.to_thread(ledger.backup)
+
+    async def provenance_apply(self, operation: Mapping[str, Any]) -> dict[str, Any]:
+        ledger = getattr(self, "provenance_ledger", None)
+        if not isinstance(ledger, ProvenanceLedger):
+            return {"ok": False, "state": "degraded", "error_code": "ledger_unavailable"}
+        return await asyncio.to_thread(ledger.apply, operation)
+
+    async def provenance_rollback(self, operation: Mapping[str, Any]) -> dict[str, Any]:
+        ledger = getattr(self, "provenance_ledger", None)
+        if not isinstance(ledger, ProvenanceLedger):
+            return {"ok": False, "state": "degraded", "error_code": "ledger_unavailable"}
+        return await asyncio.to_thread(ledger.rollback, operation)
 
     def preview_historical_chat_upload(
         self,
@@ -1020,10 +1164,23 @@ class MemoryCompanionService:
         *,
         session_context: SessionContext | dict[str, Any] | None = None,
         top_k: int | None = None,
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
     ) -> list[dict[str, Any]]:
+        gate = await self._p5_gate(
+            sink="bridge_serialization",
+            attestation=p5_attestation,
+            consumer=p5_attestation_consumer,
+        )
+        if not gate.get("ok"):
+            return []
         ctx = self.session_context_from_bridge(session_context)
         results = await self.search(query, ctx, top_k or self.config.int("memory_injection.top_k", 6))
-        return [serialize_memory(item.memory, item.score, item.reason) for item in results]
+        serialized = [serialize_memory(item.memory, item.score, item.reason) for item in results]
+        snapshot = gate.get("snapshot")
+        if snapshot is not None:
+            await self._p5_record_observed([item.memory.id for item in results], snapshot)
+        return serialized
 
     async def bridge_compose_injection(
         self,
@@ -1034,7 +1191,18 @@ class MemoryCompanionService:
         max_chars: int | None = None,
         companion_bot_mood: str = "",
         companion_bot_energy: float = 0.0,
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
+        _p5_gate_passed: bool = False,
     ) -> str:
+        if not _p5_gate_passed:
+            gate = await self._p5_gate(
+                sink="bridge_serialization",
+                attestation=p5_attestation,
+                consumer=p5_attestation_consumer,
+            )
+            if not gate.get("ok"):
+                return ""
         ctx = self.session_context_from_bridge(session_context)
         query_text = clean_text(query or ctx.message_text, 1400)
         if not query_text:
@@ -1060,7 +1228,16 @@ class MemoryCompanionService:
         companion_bot_mood: str = "",
         companion_bot_energy: float = 0.0,
         retrieval_profile: str = "",
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
     ) -> str:
+        gate = await self._p5_gate(
+            sink="bridge_serialization",
+            attestation=p5_attestation,
+            consumer=p5_attestation_consumer,
+        )
+        if not gate.get("ok"):
+            return ""
         profile = clean_text(retrieval_profile, 40).lower()
         fast_profile_enabled = {
             "schedule_fast": self.config.bool(
@@ -1089,6 +1266,7 @@ class MemoryCompanionService:
             max_chars=max_chars,
             companion_bot_mood=companion_bot_mood,
             companion_bot_energy=companion_bot_energy,
+            _p5_gate_passed=True,
         )
 
     async def _bridge_compose_schedule_fast_context(
@@ -3694,11 +3872,32 @@ class MemoryCompanionService:
             )
             return {"ok": False, "error": "memory write failed"}
 
-    async def tool_recall(self, event: Any, query: str, top_k: int = 5) -> dict[str, Any]:
+    async def tool_recall(
+        self,
+        event: Any,
+        query: str,
+        top_k: int = 5,
+        *,
+        p5_attestation: Any = None,
+        p5_attestation_consumer: Any = None,
+    ) -> dict[str, Any]:
         ctx = await self.identity.resolve_event_context(event)
         query = clean_text(query, 1000)
         if not query:
             return {"ok": False, "error": "empty query", "memories": []}
+        p5_gate = await self._p5_gate(
+            event=event,
+            sink="memory_recall",
+            attestation=p5_attestation,
+            consumer=p5_attestation_consumer,
+        )
+        if not p5_gate.get("ok"):
+            return {
+                "ok": False,
+                "state": p5_gate.get("state", "degraded"),
+                "error": p5_gate.get("error_code", "p5_attestation_required"),
+                "memories": [],
+            }
         limit = max(1, min(10, int(top_k or 5)))
         results, _blocked, slot_map = await self.search_context_slots(
             query,
@@ -3716,8 +3915,12 @@ class MemoryCompanionService:
             "acl_allowed:private:" in clean_text(getattr(item, "reason", ""), 1200)
             for item in results
         )
+        snapshot = p5_gate.get("snapshot")
+        if snapshot is not None:
+            await self._p5_record_observed([item.memory.id for item in results], snapshot)
         return {
             "ok": True,
+            "state": p5_gate.get("state", "legacy"),
             "usage": (
                 "群聊中的 acl_allowed 私聊结果只是条件候选：仅当当前发言者的核心意图确实需要其本人相关事实时使用；"
                 "普通陈述、转述、反问或意图不清时忽略，不主动公开或扩展私聊内容。"
@@ -5376,6 +5579,22 @@ class MemoryCompanionService:
             self._mark_memory_companion_injection_state(event, req, injected=False, conversation_memory=False, slot_map={})
             if self.config.bool("memory_injection.debug_log_injection_enabled", False):
                 logger.info("[MemoryCompanion] 记忆注入已关闭: session=%s", ctx.session_id)
+            return
+        p5_gate = await self._p5_gate(event=event, sink="memory_recall")
+        if not p5_gate.get("ok"):
+            self._mark_memory_companion_injection_state(
+                event,
+                req,
+                injected=False,
+                conversation_memory=False,
+                slot_map={},
+            )
+            logger.info(
+                "[MemoryCompanion] P5 召回闸门未放行本轮记忆注入: session=%s state=%s error=%s",
+                ctx.session_id,
+                p5_gate.get("state"),
+                p5_gate.get("error_code"),
+            )
             return
         self._sanitize_request_history_for_companion(ctx, req)
         recent_fact_context = await self._recent_fact_guard_context(ctx)

--- a/core/service.py
+++ b/core/service.py
@@ -42,6 +42,7 @@ from .classifier import MemoryClassifier
 from .config import ConfigView
 from .context_orchestrator import RetrievalIntent, RetrievalIntentBuilder
 from .emotion_event_contract import normalize_emotion_event
+from .emotion_targeting import memory_emotion_refs
 from .identity import IdentityResolver, looks_like_command, maybe_await, normalize_session_context_fields, session_target_id
 from .importance import ImportanceEvaluator
 from .injection import (
@@ -1829,6 +1830,9 @@ class MemoryCompanionService:
                 mood_hint = "柔软"
             if not event_type:
                 continue
+            refs = memory_emotion_refs(memory, ctx)
+            if refs is None:
+                continue
             # Mood resonance check: if Bot is already in a contrasting mood, dampen the drift
             if companion_bot_mood:
                 mood_lower = companion_bot_mood.strip().lower()
@@ -1849,12 +1853,7 @@ class MemoryCompanionService:
                 "bot_id": ctx.bot_id,
                 "scope": ctx.scope,
                 "session_id": ctx.session_id,
-                "actor_ref": {
-                    "kind": memory.subject.kind,
-                    "id": memory.subject.id,
-                    "role": memory.subject.role,
-                },
-                "target_ref": {"kind": "bot", "id": ctx.bot_id or "self", "role": "bot_self"},
+                **refs,
                 "event_type": event_type,
                 "intensity": max(scar_w, emotional_w, vulnerability_w) * 100.0,
                 "confidence": max(0.5, min(1.0, getattr(item, "score", 0.5))),

--- a/core/service.py
+++ b/core/service.py
@@ -24,6 +24,13 @@ from .astrbot_compat import (
     sanitize_request_history,
 )
 from .bridge import serialize_memory
+from .bot_personal_dto import (
+    BotPersonalArchiveDTO,
+    BotPersonalValidationError,
+    bot_personal_payload_fingerprint,
+    build_bot_personal_archive,
+    sanitize_bot_personal_value,
+)
 from .chat_import import HistoricalChatImporter
 from .classifier import MemoryClassifier
 from .config import ConfigView
@@ -744,6 +751,189 @@ class MemoryCompanionService:
                 metadata={"memory_id": memory_id, "source_plugin": record.source_plugin},
             )
         return memory_id
+
+    async def record_bot_personal_archive(self, envelope: BotPersonalArchiveDTO | dict[str, Any]) -> dict[str, Any]:
+        """Persist one Bot Personal envelope in its isolated memory domain."""
+        result = {
+            "ok": False, "record_id": "", "deduplicated": False, "version": 0,
+            "error_code": None, "state": "degraded",
+        }
+        try:
+            dto = build_bot_personal_archive(envelope)
+        except BotPersonalValidationError as exc:
+            return {**result, "state": "invalid", "error_code": exc.error_code, "field": exc.field}
+        except Exception:
+            return {**result, "state": "invalid", "error_code": "invalid"}
+
+        store = getattr(self, "store", None)
+        getter = getattr(store, "get_memory", None)
+        inserter = getattr(store, "insert_memory", None)
+        if not callable(inserter):
+            return {**result, "error_code": "store_unavailable", "state": "degraded"}
+        fingerprint = bot_personal_payload_fingerprint(dto)
+        existing = None
+        if callable(getter):
+            try:
+                existing = await getter(dto.record_id)
+            except Exception:
+                return {**result, "record_id": dto.record_id, "error_code": "store_unavailable", "state": "degraded"}
+        if existing is not None:
+            metadata = existing.metadata if isinstance(existing.metadata, dict) else {}
+            old_version = int(metadata.get("version") or 0)
+            old_fingerprint = str(metadata.get("payload_fingerprint") or "")
+            if old_version > dto.version:
+                return {**result, "record_id": dto.record_id, "version": old_version, "error_code": "stale_version", "state": "stale_version"}
+            if old_version == dto.version:
+                if old_fingerprint == fingerprint:
+                    return {**result, "ok": True, "record_id": dto.record_id, "deduplicated": True, "version": old_version, "state": "deduplicated"}
+                return {**result, "record_id": dto.record_id, "version": old_version, "error_code": "version_conflict", "state": "version_conflict"}
+
+        payload = dict(dto.payload)
+        # The raw payload stays in the isolated Bot domain for future internal use;
+        # Profile readers below deliberately expose only a safe reference.
+        metadata = {
+            "bot_personal": True,
+            "memory_domain": dto.memory_domain,
+            "subject": dto.subject,
+            "date": dto.date,
+            "window": dto.window,
+            "occurred_at": dto.occurred_at,
+            "source_kind": dto.source_kind,
+            "source_refs": list(dto.source_refs),
+            "certainty": dto.certainty,
+            "evidence_level": dto.evidence_level,
+            "status": dto.status,
+            "version": dto.version,
+            "idempotency_key": dto.idempotency_key,
+            "payload_schema_version": dto.payload_schema_version,
+            "payload_fingerprint": fingerprint,
+            "payload": payload,
+        }
+        reality_level = {
+            "planned": "planned",
+            "observed": "observed_activity",
+            "reconciled": "reconciled",
+            "projection": "window_projection",
+            "subjective": "subjective",
+            "creative": "creative_work",
+            "media": "media_index",
+            "shared": "shared_activity",
+            "detail": "detail_fragment",
+            "calendar": "calendar_event",
+            "proactive": "proactive_action",
+        }.get(dto.source_kind, dto.source_kind)
+        record = MemoryRecord(
+            id=dto.record_id,
+            memory_type=dto.memory_type,
+            subject=EntityRef(kind="bot", id=dto.subject, role="subject"),
+            object=EntityRef(kind="bot", id=dto.subject, role="object"),
+            scope="private",
+            session_id="bot_personal",
+            visibility="bot_self",
+            sayability="indirect",
+            reality_level=reality_level,
+            lifecycle="planned_projection" if dto.status == "planned" else "stable_memory",
+            content=f"Bot Personal archive reference [{dto.memory_type}]",
+            evidence="; ".join(dto.source_refs),
+            confidence=dto.certainty,
+            importance=0.55,
+            review_status="auto",
+            tags=["bot_personal", dto.memory_type, dto.source_kind],
+            metadata=metadata,
+            source_plugin="bot_personal_bridge",
+            occurred_at=dto.occurred_at,
+            # MemoryStore's generic content dedupe intentionally ignores the
+            # metadata payload.  Bot Personal records therefore need a stable
+            # key-derived fingerprint or different agenda keys would merge
+            # into one row merely because their display reference is similar.
+            content_fingerprint=hashlib.sha256(
+                f"bot_personal|{dto.memory_type}|{dto.idempotency_key}".encode("utf-8")
+            ).hexdigest(),
+        )
+        try:
+            memory_id = await inserter(record)
+            scheduler = getattr(self, "_schedule_memory_embedding", None)
+            if callable(scheduler):
+                try:
+                    scheduler(memory_id, record)
+                except Exception:
+                    pass
+        except Exception:
+            return {**result, "record_id": dto.record_id, "version": dto.version, "error_code": "store_write_failed", "state": "degraded"}
+        return {**result, "ok": True, "record_id": dto.record_id, "version": dto.version, "state": "sent"}
+
+    async def record_bot_personal_memory(self, *, memory_type: str, payload: dict[str, Any] | None = None, **kwargs: Any) -> dict[str, Any]:
+        try:
+            dto = build_bot_personal_archive(memory_type=memory_type, payload=payload or {}, **kwargs)
+        except BotPersonalValidationError as exc:
+            return {"ok": False, "record_id": "", "deduplicated": False, "version": 0, "error_code": exc.error_code, "state": "invalid"}
+        return await self.record_bot_personal_archive(dto)
+
+    async def read_bot_personal_profile(self, query: str = "", *, limit: int = 10) -> dict[str, Any]:
+        """Read-only, domain-isolated Bot Personal references with no payload output."""
+        store = getattr(self, "store", None)
+        lister = getattr(store, "list_memories", None)
+        if not callable(lister):
+            return {"ok": False, "read_only": True, "state": "degraded", "degraded": True, "pending": True, "items": [], "error_code": "store_unavailable"}
+        try:
+            records = await lister(
+                limit=max(1, min(100, int(limit or 10) * 3)),
+                include_pending=False,
+                query="",
+                scope="private",
+                visibility="bot_self",
+                session_id="bot_personal",
+            )
+        except Exception:
+            return {"ok": False, "read_only": True, "state": "degraded", "degraded": True, "pending": True, "items": [], "error_code": "store_unavailable"}
+        query_text = clean_text(query, 240).lower()
+        items: list[dict[str, Any]] = []
+        for record in records:
+            metadata = record.metadata if isinstance(record.metadata, dict) else {}
+            if clean_text(metadata.get("memory_domain"), 80) != "bot_self_schedule":
+                continue
+            source_refs: list[str] = []
+            raw_source_refs = metadata.get("source_refs")
+            if isinstance(raw_source_refs, (list, tuple)):
+                for raw_reference in raw_source_refs:
+                    if not isinstance(raw_reference, str):
+                        continue
+                    try:
+                        safe_reference = sanitize_bot_personal_value(
+                            raw_reference,
+                            path="source_refs",
+                        )
+                    except BotPersonalValidationError:
+                        continue
+                    source_refs.append(clean_text(safe_reference, 240))
+            searchable = " ".join([
+                clean_text(record.memory_type, 80), clean_text(metadata.get("date"), 20),
+                clean_text(metadata.get("window"), 40), clean_text(metadata.get("source_kind"), 40),
+                clean_text((metadata.get("payload") or {}).get("summary"), 240)
+                if isinstance(metadata.get("payload"), dict) else "",
+                clean_text((metadata.get("payload") or {}).get("title"), 240)
+                if isinstance(metadata.get("payload"), dict) else "",
+                clean_text((metadata.get("payload") or {}).get("activity"), 240)
+                if isinstance(metadata.get("payload"), dict) else "",
+            ]).lower()
+            if query_text and query_text not in searchable:
+                continue
+            items.append({
+                "record_id": record.id,
+                "memory_domain": "bot_self_schedule",
+                "memory_type": record.memory_type,
+                "subject": "bot_self",
+                "date": clean_text(metadata.get("date"), 20),
+                "window": clean_text(metadata.get("window"), 40),
+                "occurred_at": clean_text(record.occurred_at, 80),
+                "source_kind": clean_text(metadata.get("source_kind"), 40),
+                "source_refs": source_refs[:8],
+                "evidence_level": clean_text(metadata.get("evidence_level"), 8),
+                "status": clean_text(metadata.get("status"), 40),
+                "version": int(metadata.get("version") or 0),
+                "summary": f"Bot Personal archive reference [{record.memory_type}]",
+            })
+        return {"ok": True, "read_only": True, "state": "ready", "degraded": False, "pending": False, "items": items[:max(1, min(100, int(limit or 10)))]}
 
     async def bridge_search(
         self,
@@ -6975,7 +7165,7 @@ class MemoryCompanionService:
             )
 
     def companion_coordination_status(self) -> dict[str, Any]:
-        bridge_enabled = self.config.bridge_enabled()
+        bridge_enabled = self.config.bool("private_companion_bridge.enabled", True)
         return {
             "available": True,
             "state": "ready" if bridge_enabled else "local_only",

--- a/core/service.py
+++ b/core/service.py
@@ -1925,7 +1925,13 @@ class MemoryCompanionService:
             return ""
         return " ".join(hints)
 
-    def _get_cross_window_emotional_state(self) -> dict[str, Any]:
+    def _get_cross_window_emotional_state(
+        self,
+        *,
+        exclude_session_id: str = "",
+        window_seconds: float = 1800.0,
+        limit: int = 5,
+    ) -> dict[str, Any]:
         """Return a summary of recent emotional events across all sessions for the companion plugin."""
         if not self.config.bool("private_companion_bridge.cross_window_emotional_continuity_enabled", False):
             return {
@@ -1936,13 +1942,23 @@ class MemoryCompanionService:
                 "vulnerable_count": 0,
             }
         now = time.time()
-        recent_window = 1800.0
+        recent_window = max(60.0, min(86400.0, float(window_seconds or 1800.0)))
+        excluded = clean_text(exclude_session_id, 220)
         all_events: list[dict[str, Any]] = []
         for session_id, queue in self._emotional_event_queue.items():
+            if excluded and session_id == excluded:
+                continue
             for event in queue:
                 age = now - event.get("ts", 0)
                 if age < recent_window:
-                    all_events.append({**event, "age_seconds": round(age, 0)})
+                    all_events.append({
+                        "event_id": clean_text(event.get("event_id") or event.get("id"), 96),
+                        "session_id": clean_text(event.get("session_id"), 220),
+                        "event_type": clean_text(event.get("event_type"), 48),
+                        "energy_delta": max(-8.0, min(5.0, float(event.get("energy_delta") or 0.0))),
+                        "age_seconds": round(max(0.0, age), 0),
+                        "ts": float(event.get("ts") or 0.0),
+                    })
         if not all_events:
             return {"total": 0, "scar_count": 0, "warm_count": 0, "vulnerable_count": 0}
         all_events.sort(key=lambda e: e.get("ts", 0), reverse=True)
@@ -1951,7 +1967,7 @@ class MemoryCompanionService:
             "scar_count": sum(1 for e in all_events if e.get("event_type") == "scar_touched"),
             "warm_count": sum(1 for e in all_events if e.get("event_type") == "warm_memory"),
             "vulnerable_count": sum(1 for e in all_events if e.get("event_type") == "vulnerable_resonance"),
-            "recent": all_events[:5],
+            "recent": all_events[: max(1, min(20, int(limit or 5)))],
         }
 
     async def _retrieval_cache_key(

--- a/core/service.py
+++ b/core/service.py
@@ -32,6 +32,7 @@ from .bot_personal_dto import (
     build_bot_personal_archive,
     sanitize_bot_personal_value,
 )
+from .profile_api import build_profile_result
 from .chat_import import HistoricalChatImporter
 from .classifier import MemoryClassifier
 from .config import ConfigView
@@ -936,6 +937,82 @@ class MemoryCompanionService:
                 "summary": f"Bot Personal archive reference [{record.memory_type}]",
             })
         return {"ok": True, "read_only": True, "state": "ready", "degraded": False, "pending": False, "items": items[:max(1, min(100, int(limit or 10)))]}
+
+    async def read_bot_profile(
+        self,
+        profile: str,
+        query: str = "",
+        *,
+        limit: int = 10,
+        current_date: str = "",
+        current_window: str = "",
+        authorized: bool = False,
+    ) -> dict[str, Any]:
+        """Read a C4 Bot Profile after hard domain and storage filtering."""
+
+        store = getattr(self, "store", None)
+        lister = getattr(store, "list_memories", None)
+        if not callable(lister):
+            return {
+                "ok": False,
+                "read_only": True,
+                "state": "degraded",
+                "degraded": True,
+                "pending": True,
+                "profile": clean_text(profile, 80),
+                "items": [],
+                "warnings": ["store_unavailable"],
+            }
+        try:
+            safe_limit = max(1, min(100, int(limit or 10)))
+        except (TypeError, ValueError):
+            safe_limit = 10
+        try:
+            records = await lister(
+                # The profile filter is applied again in profile_api; this
+                # bounded overscan leaves room for malformed or other-domain
+                # rows without scanning the whole database.
+                limit=min(300, max(24, safe_limit * 3)),
+                include_pending=False,
+                query="",
+                scope="private",
+                visibility="bot_self",
+                session_id="bot_personal",
+            )
+        except Exception:
+            return {
+                "ok": False,
+                "read_only": True,
+                "state": "degraded",
+                "degraded": True,
+                "pending": True,
+                "profile": clean_text(profile, 80),
+                "items": [],
+                "warnings": ["store_unavailable"],
+            }
+        if not clean_text(current_date, 20) or not clean_text(current_window, 40):
+            now = datetime.now(ZoneInfo("Asia/Shanghai"))
+            current_date = current_date or now.strftime("%Y-%m-%d")
+            current_window = current_window or self._bot_personal_window_for_datetime(now)
+        return build_profile_result(
+            records,
+            profile,
+            query=query,
+            limit=safe_limit,
+            current_date=current_date,
+            current_window=current_window,
+            authorized=authorized,
+        )
+
+    @staticmethod
+    def _bot_personal_window_for_datetime(value: datetime) -> str:
+        minutes = value.hour * 60 + value.minute
+        try:
+            from .bot_personal_contract import window_for_minutes
+
+            return window_for_minutes(minutes)
+        except Exception:
+            return ""
 
     async def bridge_search(
         self,

--- a/core/store.py
+++ b/core/store.py
@@ -485,6 +485,40 @@ class MemoryStore:
                     updated_at TEXT NOT NULL DEFAULT '',
                     PRIMARY KEY(memory_id, provider_id)
                 );
+
+                CREATE TABLE IF NOT EXISTS emotion_events (
+                    event_id TEXT NOT NULL,
+                    revision INTEGER NOT NULL DEFAULT 1,
+                    trace_id TEXT NOT NULL DEFAULT '',
+                    producer_plugin TEXT NOT NULL DEFAULT '',
+                    origin_kind TEXT NOT NULL DEFAULT '',
+                    platform TEXT NOT NULL DEFAULT '',
+                    bot_id TEXT NOT NULL DEFAULT '',
+                    scope TEXT NOT NULL DEFAULT '',
+                    session_id TEXT NOT NULL DEFAULT '',
+                    actor_ref TEXT NOT NULL DEFAULT '{}',
+                    target_ref TEXT NOT NULL DEFAULT '{}',
+                    quoted_target_ref TEXT NOT NULL DEFAULT '{}',
+                    event_type TEXT NOT NULL DEFAULT 'neutral',
+                    intensity REAL NOT NULL DEFAULT 0,
+                    confidence REAL NOT NULL DEFAULT 0,
+                    valence_hint REAL NOT NULL DEFAULT 0,
+                    arousal_hint REAL NOT NULL DEFAULT 0,
+                    vulnerability_hint REAL NOT NULL DEFAULT 0,
+                    source_rule TEXT NOT NULL DEFAULT '',
+                    occurred_at TEXT NOT NULL DEFAULT '',
+                    expires_at TEXT NOT NULL DEFAULT '',
+                    dedupe_key TEXT NOT NULL DEFAULT '',
+                    payload_hash TEXT NOT NULL DEFAULT '',
+                    privacy_level TEXT NOT NULL DEFAULT 'redacted',
+                    applied_interaction TEXT NOT NULL DEFAULT '',
+                    applied_energy_delta REAL NOT NULL DEFAULT 0,
+                    correction_of TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL DEFAULT 'observed',
+                    reason_codes TEXT NOT NULL DEFAULT '[]',
+                    created_at TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY(event_id, revision)
+                );
                 """
             )
             self._ensure_memory_columns_sync()
@@ -536,6 +570,15 @@ class MemoryStore:
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_memory_embeddings_provider ON memory_embeddings(provider_id, updated_at)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_emotion_events_trace ON emotion_events(trace_id, revision)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_emotion_events_session ON emotion_events(bot_id, scope, session_id, occurred_at DESC)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_emotion_events_dedupe ON emotion_events(dedupe_key, event_type)"
             )
             self._conn.commit()
 
@@ -6146,3 +6189,90 @@ class MemoryStore:
             )
             self._conn.commit()
         return row_id
+
+    async def upsert_emotion_event(self, value: Any) -> dict[str, Any]:
+        return await self._run_recoverable_database_operation(self._upsert_emotion_event_sync, value)
+
+    def _upsert_emotion_event_sync(self, value: Any) -> dict[str, Any]:
+        from .emotion_event_contract import normalize_emotion_event
+
+        event = normalize_emotion_event(value, producer_plugin="memory_companion")
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO emotion_events(
+                    event_id, revision, trace_id, producer_plugin, origin_kind, platform,
+                    bot_id, scope, session_id, actor_ref, target_ref, quoted_target_ref,
+                    event_type, intensity, confidence, valence_hint, arousal_hint,
+                    vulnerability_hint, source_rule, occurred_at, expires_at, dedupe_key,
+                    payload_hash, privacy_level, applied_interaction, applied_energy_delta,
+                    correction_of, status, reason_codes, created_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    event["event_id"], event["revision"], event["trace_id"], event["producer_plugin"],
+                    event["origin_kind"], event["platform"], event["bot_id"], event["scope"],
+                    event["session_id"], json_dumps(event["actor_ref"]), json_dumps(event["target_ref"]),
+                    json_dumps(event["quoted_target_ref"]), event["event_type"], event["intensity"],
+                    event["confidence"], event["valence_hint"], event["arousal_hint"],
+                    event["vulnerability_hint"], event["source_rule"], event["occurred_at"],
+                    event["expires_at"], event["dedupe_key"], event["payload_hash"],
+                    event["privacy_level"], event["applied_interaction"], event["applied_energy_delta"],
+                    event["correction_of"], event["status"], json_dumps(event["reason_codes"]), utc_now(),
+                ),
+            )
+            self._conn.commit()
+        return event
+
+    async def get_emotion_trace(self, trace_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
+        return await self._run_recoverable_database_operation(self._get_emotion_trace_sync, trace_id, limit)
+
+    def _get_emotion_trace_sync(self, trace_id: str, limit: int) -> list[dict[str, Any]]:
+        trace = clean_text(trace_id, 96)
+        if not trace:
+            return []
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM emotion_events WHERE trace_id=? ORDER BY revision ASC LIMIT ?",
+                (trace, max(1, min(500, int(limit or 100)))),
+            ).fetchall()
+        return [self._emotion_event_row(row) for row in rows]
+
+    async def list_emotion_events(
+        self,
+        *,
+        bot_id: str = "",
+        session_id: str = "",
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        return await self._run_recoverable_database_operation(
+            self._list_emotion_events_sync, bot_id, session_id, limit
+        )
+
+    def _list_emotion_events_sync(self, bot_id: str, session_id: str, limit: int) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if clean_text(bot_id, 160):
+            clauses.append("bot_id=?")
+            params.append(clean_text(bot_id, 160))
+        if clean_text(session_id, 220):
+            clauses.append("session_id=?")
+            params.append(clean_text(session_id, 220))
+        where = " WHERE " + " AND ".join(clauses) if clauses else ""
+        params.append(max(1, min(500, int(limit or 50))))
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM emotion_events{where} ORDER BY occurred_at DESC, revision DESC LIMIT ?",
+                params,
+            ).fetchall()
+        return [self._emotion_event_row(row) for row in rows]
+
+    @staticmethod
+    def _emotion_event_row(row: sqlite3.Row) -> dict[str, Any]:
+        result = dict(row)
+        for key in ("actor_ref", "target_ref", "quoted_target_ref"):
+            result[key] = json_loads(result.get(key), {})
+        result["reason_codes"] = json_loads(result.get("reason_codes"), [])
+        result.pop("created_at", None)
+        result["schema_version"] = "companion_emotion_event.v1"
+        return result

--- a/core/store.py
+++ b/core/store.py
@@ -14,6 +14,8 @@ from .models import EntityRef, MemoryRecord, clean_text, json_dumps, json_loads,
 
 
 class MemoryStore:
+    EMBEDDING_CANDIDATE_CACHE_MAX = 64
+
     def __init__(self, db_path: Path):
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1464,14 +1466,14 @@ class MemoryStore:
             self._conn.commit()
         return row_id
 
-    async def list_identities(self, limit: int = 1000) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_identities_sync, limit)
+    async def list_identities(self, limit: int = 1000, *, offset: int = 0) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._list_identities_sync, limit, offset)
 
-    def _list_identities_sync(self, limit: int) -> list[dict[str, Any]]:
+    def _list_identities_sync(self, limit: int, offset: int) -> list[dict[str, Any]]:
         with self._lock:
             rows = self._conn.execute(
-                "SELECT * FROM identities ORDER BY updated_at DESC LIMIT ?",
-                (max(1, int(limit)),),
+                "SELECT * FROM identities ORDER BY updated_at DESC LIMIT ? OFFSET ?",
+                (max(1, int(limit)), max(0, int(offset))),
             ).fetchall()
         result: list[dict[str, Any]] = []
         for row in rows:
@@ -1606,6 +1608,8 @@ class MemoryStore:
         scope: str = "",
         session_id: str = "",
         group_id: str = "",
+        *,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
             self._list_relationships_sync,
@@ -1614,6 +1618,7 @@ class MemoryStore:
             scope,
             session_id,
             group_id,
+            offset,
         )
 
     def _list_relationships_sync(
@@ -1623,6 +1628,7 @@ class MemoryStore:
         scope: str,
         session_id: str,
         group_id: str,
+        offset: int,
     ) -> list[dict[str, Any]]:
         params: list[Any] = []
         where = "1=1"
@@ -1644,9 +1650,9 @@ class MemoryStore:
                 SELECT * FROM relationship_edges
                 WHERE {where}
                 ORDER BY updated_at DESC
-                LIMIT ?
+                LIMIT ? OFFSET ?
                 """,
-                params + [max(1, int(limit))],
+                params + [max(1, int(limit)), max(0, int(offset))],
             ).fetchall()
         return [dict(row) for row in rows]
 
@@ -1857,8 +1863,8 @@ class MemoryStore:
             params.append(clean_text(group_id, 120))
         node = clean_text(node, 160)
         if node:
-            where += " AND (s.label LIKE ? OR t.label LIKE ?)"
-            like = f"%{node}%"
+            where += " AND (s.label LIKE ? ESCAPE '\\' OR t.label LIKE ? ESCAPE '\\')"
+            like = self._like_pattern(node)
             params.extend([like, like])
         with self._lock:
             rows = self._conn.execute(
@@ -2110,8 +2116,8 @@ class MemoryStore:
         if group_id:
             scope_filter += " AND (n.group_id='' OR n.group_id=?)"
             params.append(group_id)
-        like_sql = " OR ".join(["lower(n.label) LIKE ?" for _ in cleaned_terms])
-        like_params = [f"%{term}%" for term in cleaned_terms]
+        like_sql = " OR ".join(["lower(n.label) LIKE ? ESCAPE '\\'" for _ in cleaned_terms])
+        like_params = [self._like_pattern(term) for term in cleaned_terms]
         with self._lock:
             matched = self._conn.execute(
                 f"""
@@ -3452,8 +3458,17 @@ class MemoryStore:
         scope: str = "",
         session_id: str = "",
         entity_id: str = "",
+        *,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._recent_timeline_sync, limit, scope, session_id, entity_id)
+        return await asyncio.to_thread(
+            self._recent_timeline_sync,
+            limit,
+            scope,
+            session_id,
+            entity_id,
+            offset,
+        )
 
     def _recent_timeline_sync(
         self,
@@ -3461,6 +3476,7 @@ class MemoryStore:
         scope: str,
         session_id: str,
         entity_id: str,
+        offset: int,
     ) -> list[dict[str, Any]]:
         params: list[Any] = []
         where = "1=1"
@@ -3479,9 +3495,9 @@ class MemoryStore:
                 SELECT * FROM timeline
                 WHERE {where}
                 ORDER BY occurred_at DESC, created_at DESC
-                LIMIT ?
+                LIMIT ? OFFSET ?
                 """,
-                params + [max(1, int(limit))],
+                params + [max(1, int(limit)), max(0, int(offset))],
             ).fetchall()
         return [dict(row) for row in rows]
 
@@ -4428,6 +4444,7 @@ class MemoryStore:
         self,
         *,
         limit: int = 50,
+        offset: int = 0,
         include_pending: bool = True,
         query: str = "",
         memory_type: str = "",
@@ -4442,6 +4459,7 @@ class MemoryStore:
         return await self._run_recoverable_database_operation(
             self._list_memories_sync,
             limit,
+            offset,
             include_pending,
             query,
             memory_type,
@@ -4457,6 +4475,7 @@ class MemoryStore:
     def _list_memories_sync(
         self,
         limit: int,
+        offset: int,
         include_pending: bool,
         query: str,
         memory_type: str,
@@ -4473,11 +4492,11 @@ class MemoryStore:
         if not include_pending:
             where += " AND review_status != 'pending'"
         if query:
-            like = f"%{clean_text(query, 500)}%"
+            like = self._like_pattern(query)
             where += (
-                " AND (id LIKE ? OR content LIKE ? OR evidence LIKE ? OR subject_id LIKE ?"
-                " OR subject_name LIKE ? OR object_id LIKE ? OR object_name LIKE ?"
-                " OR session_id LIKE ? OR group_id LIKE ?)"
+                " AND (id LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR evidence LIKE ? ESCAPE '\\' OR subject_id LIKE ? ESCAPE '\\'"
+                " OR subject_name LIKE ? ESCAPE '\\' OR object_id LIKE ? ESCAPE '\\' OR object_name LIKE ? ESCAPE '\\'"
+                " OR session_id LIKE ? ESCAPE '\\' OR group_id LIKE ? ESCAPE '\\')"
             )
             params.extend([like] * 9)
         if memory_type:
@@ -4503,17 +4522,17 @@ class MemoryStore:
             params.append(clean_text(group_id, 120))
         if entity_id:
             entity = clean_text(entity_id, 120)
-            where += " AND (subject_id=? OR object_id=? OR group_id=? OR session_id LIKE ?)"
-            params.extend([entity, entity, entity, f"%{entity}%"])
+            where += " AND (subject_id=? OR object_id=? OR group_id=? OR session_id LIKE ? ESCAPE '\\')"
+            params.extend([entity, entity, entity, self._like_pattern(entity)])
         with self._lock:
             rows = self._conn.execute(
                 f"""
                 SELECT * FROM memories
                 WHERE {where}
                 ORDER BY occurred_at DESC, created_at DESC
-                LIMIT ?
+                LIMIT ? OFFSET ?
                 """,
-                params + [max(1, int(limit))],
+                params + [max(1, int(limit)), max(0, int(offset))],
             ).fetchall()
         return [MemoryRecord.from_row(row) for row in rows]
 
@@ -4538,7 +4557,7 @@ class MemoryStore:
         if not user_id:
             return ""
         bot_clause = ""
-        params: list[Any] = [user_id, user_id, f"%{user_id}%"]
+        params: list[Any] = [user_id, user_id, self._like_pattern(user_id)]
         if bot_id:
             bot_clause = """
                   AND (
@@ -4562,7 +4581,7 @@ class MemoryStore:
                     MAX(COALESCE(NULLIF(occurred_at, ''), created_at)) AS latest_at
                 FROM memories
                 WHERE scope='private' AND session_id!=''
-                  AND (subject_id=? OR object_id=? OR session_id LIKE ?)
+                  AND (subject_id=? OR object_id=? OR session_id LIKE ? ESCAPE '\\')
                   {bot_clause}
                 GROUP BY session_id
                 ORDER BY native_count DESC, total_count DESC, latest_at DESC
@@ -6029,6 +6048,8 @@ class MemoryStore:
             result.append((MemoryRecord.from_row(row), vector, clean_text(row["embedding_text_hash"], 80)))
         with self._lock:
             self._embedding_candidate_cache[cache_key] = result
+            while len(self._embedding_candidate_cache) > self.EMBEDDING_CANDIDATE_CACHE_MAX:
+                self._embedding_candidate_cache.pop(next(iter(self._embedding_candidate_cache)), None)
         return deepcopy(result)
 
     async def list_memories_missing_embeddings(

--- a/core/store.py
+++ b/core/store.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from .identity import parse_scope_from_session
 from .models import EntityRef, MemoryRecord, clean_text, json_dumps, json_loads, new_id, stable_fingerprint, utc_now
+from .portrait import cross_scene_whitelisted_fact
 
 
 class MemoryStore:
@@ -537,11 +538,114 @@ class MemoryStore:
                         REFERENCES emotion_events(event_id, revision)
                         ON DELETE CASCADE
                 );
+
+                CREATE TABLE IF NOT EXISTS portrait_people (
+                    person_id TEXT PRIMARY KEY,
+                    resolved_identity_key TEXT NOT NULL DEFAULT '',
+                    projection_revision INTEGER NOT NULL DEFAULT 0,
+                    identity_assurance TEXT NOT NULL DEFAULT '',
+                    profile_status TEXT NOT NULL DEFAULT '',
+                    capability_summary TEXT NOT NULL DEFAULT '{}',
+                    portrait_revision INTEGER NOT NULL DEFAULT 0,
+                    last_synced_at TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL DEFAULT ''
+                );
+
+                CREATE TABLE IF NOT EXISTS portrait_evidence (
+                    evidence_hash TEXT PRIMARY KEY,
+                    person_id TEXT NOT NULL DEFAULT '',
+                    origin_identity_key TEXT NOT NULL DEFAULT '',
+                    scope TEXT NOT NULL DEFAULT '',
+                    session_id TEXT NOT NULL DEFAULT '',
+                    message_id TEXT NOT NULL DEFAULT '',
+                    statement_fingerprint TEXT NOT NULL DEFAULT '',
+                    context_refs TEXT NOT NULL DEFAULT '[]',
+                    created_at TEXT NOT NULL DEFAULT ''
+                );
+
+                CREATE TABLE IF NOT EXISTS portrait_facts (
+                    id TEXT PRIMARY KEY,
+                    person_id TEXT NOT NULL DEFAULT '',
+                    dimension TEXT NOT NULL DEFAULT '',
+                    normalized_claim_hash TEXT NOT NULL DEFAULT '',
+                    claim_summary TEXT NOT NULL DEFAULT '',
+                    portrait_tier TEXT NOT NULL DEFAULT '',
+                    producer_kind TEXT NOT NULL DEFAULT '',
+                    producer_version TEXT NOT NULL DEFAULT '',
+                    derivation_kind TEXT NOT NULL DEFAULT '',
+                    epistemic_status TEXT NOT NULL DEFAULT '',
+                    source_scope TEXT NOT NULL DEFAULT '',
+                    usable_scope TEXT NOT NULL DEFAULT '',
+                    confidence REAL NOT NULL DEFAULT 0,
+                    sensitivity TEXT NOT NULL DEFAULT 'high',
+                    status TEXT NOT NULL DEFAULT 'active',
+                    evidence_hashes TEXT NOT NULL DEFAULT '[]',
+                    context_refs TEXT NOT NULL DEFAULT '[]',
+                    first_evidence_at TEXT NOT NULL DEFAULT '',
+                    last_evidence_at TEXT NOT NULL DEFAULT '',
+                    expires_at TEXT NOT NULL DEFAULT '',
+                    supersedes_id TEXT NOT NULL DEFAULT '',
+                    revision INTEGER NOT NULL DEFAULT 1,
+                    operation_id TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL DEFAULT '',
+                    UNIQUE(person_id, dimension, normalized_claim_hash, portrait_tier, source_scope)
+                );
+
+                CREATE TABLE IF NOT EXISTS portrait_suppressions (
+                    suppression_key TEXT PRIMARY KEY,
+                    person_id TEXT NOT NULL DEFAULT '',
+                    dimension TEXT NOT NULL DEFAULT '',
+                    normalized_claim_hash TEXT NOT NULL DEFAULT '',
+                    scope TEXT NOT NULL DEFAULT '',
+                    reason TEXT NOT NULL DEFAULT '',
+                    actor TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL DEFAULT 'active',
+                    origin_identity_key TEXT NOT NULL DEFAULT '',
+                    operation_id TEXT NOT NULL DEFAULT '',
+                    revision INTEGER NOT NULL DEFAULT 1,
+                    created_at TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL DEFAULT '',
+                    expires_at TEXT NOT NULL DEFAULT '',
+                    revoked_at TEXT NOT NULL DEFAULT ''
+                );
+
+                CREATE TABLE IF NOT EXISTS portrait_operations (
+                    operation_id TEXT PRIMARY KEY,
+                    operation_kind TEXT NOT NULL DEFAULT '',
+                    payload_hash TEXT NOT NULL DEFAULT '',
+                    snapshot TEXT NOT NULL DEFAULT '{}',
+                    state TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL DEFAULT ''
+                );
+
+                CREATE TABLE IF NOT EXISTS portrait_learning_queue (
+                    queue_id TEXT PRIMARY KEY,
+                    person_id TEXT NOT NULL DEFAULT '',
+                    fact_id TEXT NOT NULL DEFAULT '',
+                    evidence_hash TEXT NOT NULL DEFAULT '',
+                    state TEXT NOT NULL DEFAULT 'pending',
+                    created_at TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL DEFAULT '',
+                    UNIQUE(person_id, fact_id, evidence_hash)
+                );
+
+                CREATE TABLE IF NOT EXISTS portrait_daily_runs (
+                    person_id TEXT NOT NULL DEFAULT '',
+                    run_day TEXT NOT NULL DEFAULT '',
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    successes INTEGER NOT NULL DEFAULT 0,
+                    last_code TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY(person_id, run_day)
+                );
                 """
             )
             self._ensure_memory_columns_sync()
             self._ensure_timeline_columns_sync()
             self._ensure_acl_columns_sync()
+            self._ensure_portrait_columns_sync()
             self._ensure_memory_fts_sync()
             self._ensure_retrieval_revision_sync()
             self._conn.execute(
@@ -605,6 +709,18 @@ class MemoryStore:
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_emotion_event_deliveries_pending "
                 "ON emotion_event_deliveries(consumer_id, acked_at, last_delivered_at)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_portrait_evidence_person ON portrait_evidence(person_id, created_at)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_portrait_facts_person ON portrait_facts(person_id, status, sensitivity, updated_at DESC)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_portrait_suppressions_person ON portrait_suppressions(person_id, status)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_portrait_learning_queue_person ON portrait_learning_queue(person_id, state, updated_at)"
             )
             self._conn.commit()
 
@@ -866,6 +982,795 @@ class MemoryStore:
         }
         if "effect" not in existing:
             self._conn.execute("ALTER TABLE memory_acl_rules ADD COLUMN effect TEXT NOT NULL DEFAULT 'allow'")
+
+    def _ensure_portrait_columns_sync(self) -> None:
+        existing = {
+            row["name"]
+            for row in self._conn.execute("PRAGMA table_info(portrait_evidence)").fetchall()
+        }
+        if "statement_fingerprint" not in existing:
+            self._conn.execute("ALTER TABLE portrait_evidence ADD COLUMN statement_fingerprint TEXT NOT NULL DEFAULT ''")
+
+    async def upsert_portrait_person_projection(
+        self,
+        person_ref: dict[str, Any],
+        capability_summary: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._upsert_portrait_person_projection_sync,
+            deepcopy(person_ref),
+            deepcopy(capability_summary),
+        )
+
+    def _upsert_portrait_person_projection_sync(
+        self,
+        person_ref: dict[str, Any],
+        capability_summary: dict[str, Any],
+    ) -> dict[str, Any]:
+        person_id = clean_text(person_ref.get("person_id"), 80)
+        identity_key = clean_text(person_ref.get("resolved_identity_key"), 96)
+        revision = int(person_ref.get("projection_revision") or 0)
+        assurance = clean_text(person_ref.get("identity_assurance"), 40)
+        status = clean_text(person_ref.get("profile_status"), 40)
+        if (
+            not person_id
+            or not identity_key
+            or revision < 1
+            or assurance not in {"observed", "verified", "explicit_linked"}
+            or status != "active"
+        ):
+            return {"ok": False, "code": "bridge_person_mismatch", "state": "invalid"}
+        now = utc_now()
+        with self._lock:
+            previous = self._conn.execute(
+                "SELECT * FROM portrait_people WHERE person_id=?", (person_id,)
+            ).fetchone()
+            if previous is not None:
+                old_revision = int(previous["projection_revision"] or 0)
+                if old_revision > revision:
+                    return {"ok": False, "code": "bridge_stale_revision", "state": "stale", "projection_revision": old_revision}
+                if old_revision == revision and previous["resolved_identity_key"] != identity_key:
+                    return {"ok": False, "code": "bridge_person_mismatch", "state": "invalid"}
+            portrait_revision = int(previous["portrait_revision"] or 0) if previous is not None else 0
+            self._conn.execute(
+                """
+                INSERT INTO portrait_people(
+                    person_id, resolved_identity_key, projection_revision, identity_assurance,
+                    profile_status, capability_summary, portrait_revision, last_synced_at, updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(person_id) DO UPDATE SET
+                    resolved_identity_key=excluded.resolved_identity_key,
+                    projection_revision=excluded.projection_revision,
+                    identity_assurance=excluded.identity_assurance,
+                    profile_status=excluded.profile_status,
+                    capability_summary=excluded.capability_summary,
+                    last_synced_at=excluded.last_synced_at,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    person_id,
+                    identity_key,
+                    revision,
+                    clean_text(person_ref.get("identity_assurance"), 40),
+                    clean_text(person_ref.get("profile_status"), 40),
+                    json_dumps(capability_summary),
+                    portrait_revision,
+                    now,
+                    now,
+                ),
+            )
+            self._conn.commit()
+        return {"ok": True, "code": "profile_exact", "state": "ready", "portrait_revision": portrait_revision}
+
+    async def portrait_projection_decision(self, person_ref: dict[str, Any]) -> dict[str, Any]:
+        return await asyncio.to_thread(self._portrait_projection_decision_sync, deepcopy(person_ref))
+
+    def _portrait_projection_decision_sync(self, person_ref: dict[str, Any]) -> dict[str, Any]:
+        person_id = clean_text(person_ref.get("person_id"), 80)
+        identity_key = clean_text(person_ref.get("resolved_identity_key"), 96)
+        revision = int(person_ref.get("projection_revision") or 0)
+        assurance = clean_text(person_ref.get("identity_assurance"), 40)
+        if not person_id or not identity_key or revision < 1 or assurance not in {"observed", "verified", "explicit_linked"}:
+            return {"ok": False, "code": "bridge_person_mismatch"}
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT resolved_identity_key, projection_revision, identity_assurance, profile_status FROM portrait_people WHERE person_id=?",
+                (person_id,),
+            ).fetchone()
+        if row is None:
+            return {"ok": False, "code": "bridge_unavailable"}
+        if clean_text(row["resolved_identity_key"], 96) != identity_key:
+            return {"ok": False, "code": "bridge_person_mismatch"}
+        if int(row["projection_revision"] or 0) != revision:
+            return {"ok": False, "code": "bridge_stale_revision"}
+        if clean_text(row["identity_assurance"], 40) not in {"observed", "verified", "explicit_linked"}:
+            return {"ok": False, "code": "bridge_person_mismatch"}
+        if clean_text(row["profile_status"], 40) != "active":
+            return {"ok": False, "code": "bridge_person_mismatch"}
+        return {"ok": True, "code": "profile_exact"}
+
+    async def add_portrait_evidence(self, evidence: dict[str, Any]) -> dict[str, Any]:
+        return await asyncio.to_thread(self._add_portrait_evidence_sync, deepcopy(evidence))
+
+    def _add_portrait_evidence_sync(self, evidence: dict[str, Any]) -> dict[str, Any]:
+        person_id = clean_text(evidence.get("person_id"), 80)
+        evidence_key = clean_text(evidence.get("evidence_hash"), 80)
+        if not person_id or not re.fullmatch(r"[0-9a-f]{64}", evidence_key):
+            return {"ok": False, "code": "portrait_evidence_invalid", "created": False}
+        statement_key = clean_text(evidence.get("statement_fingerprint"), 80)
+        if not re.fullmatch(r"[0-9a-f]{64}", statement_key):
+            statement_key = evidence_key
+        context_refs = evidence.get("context_refs") if isinstance(evidence.get("context_refs"), list) else []
+        now = utc_now()
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                INSERT OR IGNORE INTO portrait_evidence(
+                    evidence_hash, person_id, origin_identity_key, scope, session_id, message_id, statement_fingerprint, context_refs, created_at
+                ) VALUES(?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    evidence_key,
+                    person_id,
+                    clean_text(evidence.get("origin_identity_key"), 96),
+                    clean_text(evidence.get("scope"), 80),
+                    clean_text(evidence.get("session_id"), 200),
+                    clean_text(evidence.get("message_id"), 120),
+                    statement_key,
+                    json_dumps([clean_text(item, 160) for item in context_refs if clean_text(item, 160)][:8]),
+                    now,
+                ),
+            )
+            self._conn.commit()
+        return {"ok": True, "code": "portrait_evidence_recorded", "created": bool(cur.rowcount)}
+
+    def _portrait_suppressed_sync(self, person_id: str, dimension: str, claim_hash: str, scope: str) -> bool:
+        now = utc_now()
+        row = self._conn.execute(
+            """
+            SELECT 1 FROM portrait_suppressions
+            WHERE person_id=? AND dimension=? AND normalized_claim_hash=?
+              AND status IN ('active', 'reconfirmation_pending')
+              AND (scope='' OR scope=?)
+              AND (expires_at='' OR expires_at>?)
+            LIMIT 1
+            """,
+            (person_id, dimension, claim_hash, scope, now),
+        ).fetchone()
+        return row is not None
+
+    @staticmethod
+    def _portrait_timestamp_is_fresh(value: Any, freshness_days: int) -> bool:
+        """Treat malformed or stale inferred timestamps as unusable."""
+        text = clean_text(value, 80)
+        if not text:
+            return False
+        try:
+            observed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            if observed.tzinfo is None:
+                observed = observed.replace(tzinfo=timezone.utc)
+        except (TypeError, ValueError, OverflowError):
+            return False
+        age = datetime.now(timezone.utc) - observed.astimezone(timezone.utc)
+        return age.total_seconds() <= max(1, freshness_days) * 86400
+
+    @staticmethod
+    def _portrait_scope_allows_row(row: sqlite3.Row, requested_scope: str) -> bool:
+        usable_scope = clean_text(row["usable_scope"], 80)
+        source_scope = clean_text(row["source_scope"], 80)
+        if usable_scope == "self_low_global":
+            return True
+        return usable_scope == "source_only" and bool(requested_scope) and source_scope == requested_scope
+
+    def _bump_portrait_revision_sync(self, person_id: str) -> int:
+        self._conn.execute(
+            "UPDATE portrait_people SET portrait_revision=portrait_revision+1, updated_at=? WHERE person_id=?",
+            (utc_now(), person_id),
+        )
+        row = self._conn.execute("SELECT portrait_revision FROM portrait_people WHERE person_id=?", (person_id,)).fetchone()
+        return int(row["portrait_revision"] or 0) if row is not None else 0
+
+    async def upsert_portrait_fact(self, fact: dict[str, Any]) -> dict[str, Any]:
+        return await asyncio.to_thread(self._upsert_portrait_fact_sync, deepcopy(fact))
+
+    def _upsert_portrait_fact_sync(self, fact: dict[str, Any]) -> dict[str, Any]:
+        person_id = clean_text(fact.get("person_id"), 80)
+        dimension = clean_text(fact.get("dimension"), 80)
+        claim_hash = clean_text(fact.get("normalized_claim_hash"), 80)
+        tier = clean_text(fact.get("portrait_tier"), 24)
+        source_scope = clean_text(fact.get("source_scope"), 80)
+        if not person_id or not dimension or not re.fullmatch(r"[0-9a-f]{64}", claim_hash) or tier not in {"base", "intelligent"}:
+            return {"ok": False, "code": "portrait_fact_invalid", "created": False}
+        if not source_scope:
+            source_scope = "private"
+        now = utc_now()
+        evidence_hashes = [
+            clean_text(item, 80) for item in (fact.get("evidence_hashes") or [])
+            if re.fullmatch(r"[0-9a-f]{64}", clean_text(item, 80))
+        ][:16]
+        with self._lock:
+            if self._portrait_suppressed_sync(person_id, dimension, claim_hash, source_scope):
+                return {"ok": False, "code": "portrait_suppressed", "created": False}
+            previous = self._conn.execute(
+                """
+                SELECT * FROM portrait_facts WHERE person_id=? AND dimension=?
+                  AND normalized_claim_hash=? AND portrait_tier=? AND source_scope=?
+                """,
+                (person_id, dimension, claim_hash, tier, source_scope),
+            ).fetchone()
+            previous_hashes = json_loads(previous["evidence_hashes"], []) if previous is not None else []
+            merged_hashes = list(dict.fromkeys([
+                clean_text(item, 80) for item in previous_hashes + evidence_hashes if clean_text(item, 80)
+            ]))[:16]
+            fact_id = clean_text(previous["id"], 120) if previous is not None else f"portrait_{stable_fingerprint(person_id, dimension, claim_hash, tier, source_scope)[:24]}"
+            revision = int(previous["revision"] or 0) + 1 if previous is not None else 1
+            first_at = clean_text(previous["first_evidence_at"], 80) if previous is not None else now
+            sensitivity = clean_text(fact.get("sensitivity"), 24)
+            if sensitivity not in {"low", "sensitive", "high"}:
+                sensitivity = "high"
+            usable_scope = clean_text(fact.get("usable_scope"), 80)
+            if usable_scope == "self_low_global" and cross_scene_whitelisted_fact(
+                dimension=dimension,
+                claim_summary=fact.get("claim_summary"),
+                sensitivity=sensitivity,
+                source_scope=source_scope,
+            ):
+                usable_scope = "self_low_global"
+            else:
+                usable_scope = "source_only"
+            self._conn.execute(
+                """
+                INSERT INTO portrait_facts(
+                    id, person_id, dimension, normalized_claim_hash, claim_summary, portrait_tier,
+                    producer_kind, producer_version, derivation_kind, epistemic_status, source_scope,
+                    usable_scope, confidence, sensitivity, status, evidence_hashes, context_refs,
+                    first_evidence_at, last_evidence_at, expires_at, supersedes_id, revision,
+                    operation_id, created_at, updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(person_id, dimension, normalized_claim_hash, portrait_tier, source_scope) DO UPDATE SET
+                    claim_summary=excluded.claim_summary,
+                    producer_kind=excluded.producer_kind,
+                    producer_version=excluded.producer_version,
+                    derivation_kind=excluded.derivation_kind,
+                    epistemic_status=excluded.epistemic_status,
+                    usable_scope=excluded.usable_scope,
+                    confidence=max(portrait_facts.confidence, excluded.confidence),
+                    sensitivity=excluded.sensitivity,
+                    status=excluded.status,
+                    evidence_hashes=excluded.evidence_hashes,
+                    context_refs=excluded.context_refs,
+                    last_evidence_at=excluded.last_evidence_at,
+                    expires_at=excluded.expires_at,
+                    supersedes_id=excluded.supersedes_id,
+                    revision=excluded.revision,
+                    operation_id=excluded.operation_id,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    fact_id, person_id, dimension, claim_hash, clean_text(fact.get("claim_summary"), 180), tier,
+                    clean_text(fact.get("producer_kind"), 80), clean_text(fact.get("producer_version"), 80),
+                    clean_text(fact.get("derivation_kind"), 80), clean_text(fact.get("epistemic_status"), 80),
+                    source_scope, usable_scope, max(0.0, min(1.0, float(fact.get("confidence") or 0.0))),
+                    sensitivity, clean_text(fact.get("status"), 40) or "active", json_dumps(merged_hashes),
+                    json_dumps([clean_text(item, 160) for item in (fact.get("context_refs") or []) if clean_text(item, 160)][:8]),
+                    first_at, now, clean_text(fact.get("expires_at"), 80), clean_text(fact.get("supersedes_id"), 120),
+                    revision, clean_text(fact.get("operation_id"), 120),
+                    clean_text(previous["created_at"], 80) if previous is not None else now, now,
+                ),
+            )
+            portrait_revision = self._bump_portrait_revision_sync(person_id)
+            self._conn.commit()
+        return {"ok": True, "code": "portrait_fact_upserted", "created": previous is None, "fact_id": fact_id, "portrait_revision": portrait_revision}
+
+    async def list_portrait_evidence(self, person_id: str, *, limit: int = 64) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._list_portrait_evidence_sync, person_id, limit)
+
+    def _list_portrait_evidence_sync(self, person_id: str, limit: int) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM portrait_evidence WHERE person_id=? ORDER BY created_at DESC LIMIT ?",
+                (clean_text(person_id, 80), max(1, min(512, int(limit)))),
+            ).fetchall()
+        return [
+            {
+                "evidence_hash": row["evidence_hash"], "scope": row["scope"], "session_id": row["session_id"],
+                "message_id": row["message_id"], "statement_fingerprint": row["statement_fingerprint"],
+                "context_refs": json_loads(row["context_refs"], []), "created_at": row["created_at"],
+            }
+            for row in rows
+        ]
+
+    async def enqueue_portrait_learning(self, *, person_id: str, fact_id: str, evidence_hash: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self._enqueue_portrait_learning_sync, person_id, fact_id, evidence_hash)
+
+    async def list_pending_portrait_people(self, *, limit: int = 500) -> list[str]:
+        return await asyncio.to_thread(self._list_pending_portrait_people_sync, limit)
+
+    def _list_pending_portrait_people_sync(self, limit: int) -> list[str]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT DISTINCT q.person_id
+                FROM portrait_learning_queue q
+                JOIN portrait_people p ON p.person_id=q.person_id
+                WHERE q.state='pending' AND p.profile_status='active'
+                ORDER BY q.updated_at ASC
+                LIMIT ?
+                """,
+                (max(1, min(2000, int(limit))),),
+            ).fetchall()
+        return [clean_text(row["person_id"], 80) for row in rows if clean_text(row["person_id"], 80)]
+
+    def _enqueue_portrait_learning_sync(self, person_id: str, fact_id: str, evidence_hash: str) -> dict[str, Any]:
+        person_id = clean_text(person_id, 80)
+        fact_id = clean_text(fact_id, 120)
+        evidence_hash = clean_text(evidence_hash, 80)
+        if not person_id or not fact_id or not re.fullmatch(r"[0-9a-f]{64}", evidence_hash):
+            return {"ok": False, "code": "portrait_queue_invalid"}
+        queue_id = f"portrait_queue_{stable_fingerprint(person_id, fact_id, evidence_hash)[:24]}"
+        now = utc_now()
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                INSERT OR IGNORE INTO portrait_learning_queue(queue_id, person_id, fact_id, evidence_hash, state, created_at, updated_at)
+                VALUES(?,?,?,?, 'pending', ?, ?)
+                """,
+                (queue_id, person_id, fact_id, evidence_hash, now, now),
+            )
+            self._conn.commit()
+        return {"ok": True, "code": "portrait_queued", "created": bool(cur.rowcount), "queue_id": queue_id}
+
+    async def run_portrait_daily_batch(
+        self,
+        *,
+        person_id: str,
+        run_day: str,
+        min_independent_evidence: int = 3,
+        success_limit: int = 1,
+        attempt_limit: int = 2,
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._run_portrait_daily_batch_sync,
+            person_id,
+            run_day,
+            min_independent_evidence,
+            success_limit,
+            attempt_limit,
+        )
+
+    def _portrait_distinct_statement_count_sync(self, evidence_hashes: list[Any]) -> int:
+        hashes = list(dict.fromkeys(
+            clean_text(item, 80)
+            for item in evidence_hashes
+            if re.fullmatch(r"[0-9a-f]{64}", clean_text(item, 80))
+        ))[:16]
+        if not hashes:
+            return 0
+        placeholders = ",".join("?" for _ in hashes)
+        rows = self._conn.execute(
+            f"SELECT evidence_hash, statement_fingerprint FROM portrait_evidence WHERE evidence_hash IN ({placeholders})",
+            hashes,
+        ).fetchall()
+        fingerprints = {
+            clean_text(row["statement_fingerprint"], 80) or clean_text(row["evidence_hash"], 80)
+            for row in rows
+            if clean_text(row["statement_fingerprint"], 80) or clean_text(row["evidence_hash"], 80)
+        }
+        return len(fingerprints)
+
+    def _run_portrait_daily_batch_sync(
+        self,
+        person_id: str,
+        run_day: str,
+        min_independent_evidence: int,
+        success_limit: int,
+        attempt_limit: int,
+    ) -> dict[str, Any]:
+        person_id = clean_text(person_id, 80)
+        run_day = clean_text(run_day, 16)
+        if not person_id or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", run_day):
+            return {"ok": False, "code": "invalid_request"}
+        min_independent_evidence = max(1, min(16, int(min_independent_evidence)))
+        success_limit = max(1, min(4, int(success_limit)))
+        attempt_limit = max(success_limit, min(8, int(attempt_limit)))
+        now = utc_now()
+        with self._lock:
+            person = self._conn.execute("SELECT * FROM portrait_people WHERE person_id=?", (person_id,)).fetchone()
+            if person is None:
+                return {"ok": False, "code": "bridge_unavailable"}
+            capabilities = json_loads(person["capability_summary"], {})
+            if not bool(capabilities.get("portrait_learning_enabled")):
+                return {"ok": False, "code": "portrait_learning_disabled"}
+            run = self._conn.execute(
+                "SELECT * FROM portrait_daily_runs WHERE person_id=? AND run_day=?", (person_id, run_day)
+            ).fetchone()
+            attempts = int(run["attempts"] or 0) if run is not None else 0
+            successes = int(run["successes"] or 0) if run is not None else 0
+            if successes >= success_limit:
+                return {"ok": False, "code": "portrait_daily_limit", "attempts": attempts, "successes": successes}
+            if attempts >= attempt_limit:
+                return {"ok": False, "code": "portrait_daily_limit", "attempts": attempts, "successes": successes}
+            attempts += 1
+            self._conn.execute(
+                """
+                INSERT INTO portrait_daily_runs(person_id, run_day, attempts, successes, last_code, updated_at)
+                VALUES(?,?,?,?,?,?)
+                ON CONFLICT(person_id, run_day) DO UPDATE SET attempts=excluded.attempts, updated_at=excluded.updated_at
+                """,
+                (person_id, run_day, attempts, successes, "portrait_insufficient_evidence", now),
+            )
+            rows = self._conn.execute(
+                """
+                SELECT q.queue_id, q.fact_id, f.* FROM portrait_learning_queue q
+                JOIN portrait_facts f ON f.id=q.fact_id
+                WHERE q.person_id=? AND q.state='pending' AND f.status='active' AND f.portrait_tier='base'
+                ORDER BY q.created_at ASC
+                """,
+                (person_id,),
+            ).fetchall()
+            created = 0
+            for row in rows:
+                evidence_hashes = json_loads(row["evidence_hashes"], [])
+                if self._portrait_distinct_statement_count_sync(evidence_hashes) < min_independent_evidence:
+                    continue
+                if self._portrait_suppressed_sync(person_id, row["dimension"], row["normalized_claim_hash"], row["source_scope"]):
+                    self._conn.execute("UPDATE portrait_learning_queue SET state='suppressed', updated_at=? WHERE queue_id=?", (now, row["queue_id"]))
+                    continue
+                inferred = {
+                    "person_id": person_id,
+                    "dimension": row["dimension"],
+                    "normalized_claim_hash": row["normalized_claim_hash"],
+                    "claim_summary": clean_text(f"可能{row['claim_summary']}", 180),
+                    "portrait_tier": "intelligent",
+                    "producer_kind": "daily_evidence_batch",
+                    "producer_version": "req036.batch.v1",
+                    "derivation_kind": "independent_evidence_aggregate",
+                    "epistemic_status": "inferred",
+                    "source_scope": row["source_scope"],
+                    "usable_scope": "source_only" if row["source_scope"] != "private" else "self_low_global",
+                    "confidence": min(0.95, max(0.75, float(row["confidence"] or 0.0))),
+                    "sensitivity": row["sensitivity"],
+                    "evidence_hashes": evidence_hashes,
+                    "context_refs": json_loads(row["context_refs"], []),
+                    "operation_id": f"portrait.daily:{person_id[-12:]}:{run_day}",
+                }
+                result = self._upsert_portrait_fact_sync(inferred)
+                if result.get("ok"):
+                    self._conn.execute("UPDATE portrait_learning_queue SET state='processed', updated_at=? WHERE queue_id=?", (now, row["queue_id"]))
+                    created += 1
+                    break
+            successes += 1 if created else 0
+            code = "portrait_fact_upserted" if created else "portrait_insufficient_evidence"
+            self._conn.execute(
+                "UPDATE portrait_daily_runs SET successes=?, last_code=?, updated_at=? WHERE person_id=? AND run_day=?",
+                (successes, code, now, person_id, run_day),
+            )
+            self._conn.commit()
+        return {"ok": bool(created), "code": code, "attempts": attempts, "successes": successes, "created": created}
+
+    async def portrait_summary(
+        self,
+        person_id: str,
+        *,
+        scope: str = "",
+        limit: int = 8,
+        low_only: bool = True,
+        usage_min_confidence: float = 0.75,
+        inferred_freshness_days: int = 90,
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._portrait_summary_sync,
+            person_id,
+            scope,
+            limit,
+            low_only,
+            usage_min_confidence,
+            inferred_freshness_days,
+        )
+
+    def _portrait_summary_sync(
+        self,
+        person_id: str,
+        scope: str,
+        limit: int,
+        low_only: bool,
+        usage_min_confidence: float,
+        inferred_freshness_days: int,
+    ) -> dict[str, Any]:
+        person_id = clean_text(person_id, 80)
+        scope = clean_text(scope, 80)
+        confidence_floor = max(0.0, min(1.0, float(usage_min_confidence or 0.75)))
+        freshness_days = max(1, min(3650, int(inferred_freshness_days or 90)))
+        with self._lock:
+            person = self._conn.execute("SELECT * FROM portrait_people WHERE person_id=?", (person_id,)).fetchone()
+            if person is None:
+                return {"ok": False, "code": "bridge_unavailable", "items": [], "portrait_revision": 0}
+            capabilities = json_loads(person["capability_summary"], {})
+            if not bool(capabilities.get("portrait_usage_enabled")):
+                return {"ok": False, "code": "portrait_usage_disabled", "items": [], "portrait_revision": int(person["portrait_revision"] or 0)}
+            query = "SELECT * FROM portrait_facts WHERE person_id=? AND status='active'"
+            params: list[Any] = [person_id]
+            if low_only:
+                query += " AND sensitivity='low'"
+            # Read a bounded superset before filtering scope, suppression,
+            # confidence and freshness.  The bridge never sees rejected rows.
+            query += " ORDER BY confidence DESC, updated_at DESC LIMIT ?"
+            params.append(max(16, min(128, int(limit) * 8)))
+            rows = self._conn.execute(query, params).fetchall()
+            items: list[dict[str, Any]] = []
+            for row in rows:
+                if not self._portrait_scope_allows_row(row, scope):
+                    continue
+                if self._portrait_suppressed_sync(person_id, row["dimension"], row["normalized_claim_hash"], row["source_scope"]):
+                    continue
+                confidence = float(row["confidence"] or 0)
+                if confidence < confidence_floor:
+                    continue
+                if row["portrait_tier"] == "intelligent" and not self._portrait_timestamp_is_fresh(row["updated_at"], freshness_days):
+                    continue
+                items.append(
+                    {
+                        "dimension": row["dimension"],
+                        "summary": row["claim_summary"],
+                        "portrait_tier": row["portrait_tier"],
+                        "epistemic_status": row["epistemic_status"],
+                        "confidence": confidence,
+                        "sensitivity": row["sensitivity"],
+                        "usable_scope": row["usable_scope"],
+                        "updated_at": row["updated_at"],
+                    }
+                )
+                if len(items) >= max(1, min(32, int(limit))):
+                    break
+        return {
+            "ok": True,
+            "code": "profile_exact",
+            "items": items,
+            "portrait_revision": int(person["portrait_revision"] or 0),
+            "last_synced_at": clean_text(person["last_synced_at"], 80),
+        }
+
+    async def upsert_portrait_suppression(self, marker: dict[str, Any]) -> dict[str, Any]:
+        return await asyncio.to_thread(self._upsert_portrait_suppression_sync, deepcopy(marker))
+
+    def _upsert_portrait_suppression_sync(self, marker: dict[str, Any]) -> dict[str, Any]:
+        key = clean_text(marker.get("suppression_key"), 80)
+        person_id = clean_text(marker.get("person_id"), 80)
+        status = clean_text(marker.get("status"), 40) or "active"
+        operation_id = clean_text(marker.get("operation_id"), 120)
+        if not key or not person_id or not operation_id or status not in {"active", "reconfirmation_pending", "revoked", "superseded", "expired"}:
+            return {"ok": False, "code": "suppression_invalid"}
+        now = utc_now()
+        with self._lock:
+            previous = self._conn.execute("SELECT * FROM portrait_suppressions WHERE suppression_key=?", (key,)).fetchone()
+            if previous is not None and clean_text(previous["operation_id"], 120) == operation_id:
+                return {"ok": True, "code": "suppression_idempotent_replay", "revision": int(previous["revision"] or 1)}
+            revision = int(previous["revision"] or 0) + 1 if previous is not None else 1
+            self._conn.execute(
+                """
+                INSERT INTO portrait_suppressions(
+                    suppression_key, person_id, dimension, normalized_claim_hash, scope, reason, actor, status,
+                    origin_identity_key, operation_id, revision, created_at, updated_at, expires_at, revoked_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(suppression_key) DO UPDATE SET
+                    reason=excluded.reason, actor=excluded.actor, status=excluded.status,
+                    operation_id=excluded.operation_id, revision=excluded.revision, updated_at=excluded.updated_at,
+                    expires_at=excluded.expires_at, revoked_at=excluded.revoked_at
+                """,
+                (
+                    key, person_id, clean_text(marker.get("dimension"), 80), clean_text(marker.get("normalized_claim_hash"), 80),
+                    clean_text(marker.get("scope"), 80), clean_text(marker.get("reason"), 80), clean_text(marker.get("actor"), 80), status,
+                    clean_text(marker.get("origin_identity_key"), 96), operation_id, revision,
+                    now if previous is None else clean_text(marker.get("created_at"), 80) or now, now,
+                    clean_text(marker.get("expires_at"), 80), clean_text(marker.get("revoked_at"), 80),
+                ),
+            )
+            self._bump_portrait_revision_sync(person_id)
+            self._conn.commit()
+        return {"ok": True, "code": "suppression_upserted", "revision": revision}
+
+    async def list_portrait_people(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._list_portrait_people_sync, limit)
+
+    async def portrait_status(self, person_id: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self._portrait_status_sync, person_id)
+
+    def _portrait_status_sync(self, person_id: str) -> dict[str, Any]:
+        person_id = clean_text(person_id, 80)
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT portrait_revision, last_synced_at, profile_status FROM portrait_people WHERE person_id=?",
+                (person_id,),
+            ).fetchone()
+        if row is None:
+            return {"ok": False, "code": "bridge_unavailable", "person_id": person_id, "last_synced_at": "", "portrait_revision": 0}
+        return {
+            "ok": clean_text(row["profile_status"], 40) == "active",
+            "code": "profile_exact" if clean_text(row["profile_status"], 40) == "active" else "bridge_person_mismatch",
+            "person_id": person_id,
+            "portrait_revision": int(row["portrait_revision"] or 0),
+            "last_synced_at": clean_text(row["last_synced_at"], 80),
+        }
+
+    def _list_portrait_people_sync(self, limit: int) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT p.*, COUNT(DISTINCT f.id) AS fact_count, COUNT(DISTINCT e.evidence_hash) AS evidence_count
+                FROM portrait_people p
+                LEFT JOIN portrait_facts f ON f.person_id=p.person_id
+                LEFT JOIN portrait_evidence e ON e.person_id=p.person_id
+                GROUP BY p.person_id
+                ORDER BY p.updated_at DESC
+                LIMIT ?
+                """,
+                (max(1, min(500, int(limit))),),
+            ).fetchall()
+        return [
+            {
+                "person_id": clean_text(row["person_id"], 80),
+                "identity_assurance": clean_text(row["identity_assurance"], 40),
+                "profile_status": clean_text(row["profile_status"], 40),
+                "projection_revision": int(row["projection_revision"] or 0),
+                "portrait_revision": int(row["portrait_revision"] or 0),
+                "last_synced_at": clean_text(row["last_synced_at"], 80),
+                "updated_at": clean_text(row["updated_at"], 80),
+                "capability_summary": json_loads(row["capability_summary"], {}),
+                "fact_count": int(row["fact_count"] or 0),
+                "evidence_count": int(row["evidence_count"] or 0),
+            }
+            for row in rows
+        ]
+
+    async def portrait_governance_detail(self, person_id: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self._portrait_governance_detail_sync, person_id)
+
+    def _portrait_governance_detail_sync(self, person_id: str) -> dict[str, Any]:
+        person_id = clean_text(person_id, 80)
+        with self._lock:
+            person = self._conn.execute("SELECT * FROM portrait_people WHERE person_id=?", (person_id,)).fetchone()
+            if person is None:
+                return {"ok": False, "code": "bridge_unavailable", "person": {}, "facts": [], "suppressions": []}
+            facts = self._conn.execute(
+                """
+                SELECT id, dimension, normalized_claim_hash, claim_summary, portrait_tier, producer_kind,
+                       derivation_kind, epistemic_status, source_scope, usable_scope, confidence,
+                       sensitivity, status, first_evidence_at, last_evidence_at, expires_at, revision
+                FROM portrait_facts WHERE person_id=? ORDER BY updated_at DESC LIMIT 200
+                """,
+                (person_id,),
+            ).fetchall()
+            suppressions = self._conn.execute(
+                """
+                SELECT suppression_key, dimension, normalized_claim_hash, scope, reason, actor, status,
+                       operation_id, revision, created_at, updated_at, expires_at
+                FROM portrait_suppressions WHERE person_id=? ORDER BY updated_at DESC LIMIT 200
+                """,
+                (person_id,),
+            ).fetchall()
+        return {
+            "ok": True,
+            "code": "profile_exact",
+            "person": {
+                "person_id": person_id,
+                "identity_assurance": clean_text(person["identity_assurance"], 40),
+                "profile_status": clean_text(person["profile_status"], 40),
+                "portrait_revision": int(person["portrait_revision"] or 0),
+                "last_synced_at": clean_text(person["last_synced_at"], 80),
+                "capability_summary": json_loads(person["capability_summary"], {}),
+            },
+            "facts": [dict(row) for row in facts],
+            "suppressions": [dict(row) for row in suppressions],
+        }
+
+    async def govern_portrait_fact(
+        self,
+        *,
+        person_id: str,
+        fact_id: str,
+        action: str,
+        actor: str,
+        operation_id: str,
+        expires_at: str = "",
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._govern_portrait_fact_sync,
+            person_id,
+            fact_id,
+            action,
+            actor,
+            operation_id,
+            expires_at,
+        )
+
+    def _govern_portrait_fact_sync(
+        self,
+        person_id: str,
+        fact_id: str,
+        action: str,
+        actor: str,
+        operation_id: str,
+        expires_at: str,
+    ) -> dict[str, Any]:
+        person_id = clean_text(person_id, 80)
+        fact_id = clean_text(fact_id, 120)
+        action = clean_text(action, 40)
+        actor = clean_text(actor, 80) or "administrator"
+        operation_id = clean_text(operation_id, 120)
+        expires_at = clean_text(expires_at, 80)
+        if not person_id or not fact_id or not operation_id or action not in {"suppress", "freeze", "reconfirmation_pending"}:
+            return {"ok": False, "code": "invalid_request"}
+        if action == "freeze" and not expires_at:
+            return {"ok": False, "code": "suppression_expiry_required"}
+        with self._lock:
+            fact = self._conn.execute(
+                "SELECT * FROM portrait_facts WHERE id=? AND person_id=?", (fact_id, person_id)
+            ).fetchone()
+            if fact is None:
+                return {"ok": False, "code": "portrait_fact_not_found"}
+        reason = {
+            "suppress": "administrator_delete_or_forget",
+            "freeze": "administrator_temporary_freeze",
+            "reconfirmation_pending": "reconfirmation_requested",
+        }[action]
+        status = "reconfirmation_pending" if action == "reconfirmation_pending" else "active"
+        marker = {
+            "suppression_key": stable_fingerprint(
+                "portrait_suppression", person_id, fact["dimension"], fact["normalized_claim_hash"], fact["source_scope"]
+            ),
+            "person_id": person_id,
+            "dimension": clean_text(fact["dimension"], 80),
+            "normalized_claim_hash": clean_text(fact["normalized_claim_hash"], 80),
+            "scope": clean_text(fact["source_scope"], 80),
+            "reason": reason,
+            "actor": actor,
+            "status": status,
+            "operation_id": operation_id,
+            "expires_at": expires_at if action == "freeze" else "",
+        }
+        result = self._upsert_portrait_suppression_sync(marker)
+        return {**result, "fact_id": fact_id, "action": action}
+
+    async def portrait_migration(self, *, operation_id: str, dry_run: bool = True) -> dict[str, Any]:
+        return await asyncio.to_thread(self._portrait_migration_sync, operation_id, dry_run)
+
+    def _portrait_migration_sync(self, operation_id: str, dry_run: bool) -> dict[str, Any]:
+        operation_id = clean_text(operation_id, 120)
+        if not operation_id:
+            return {"ok": False, "code": "invalid_request"}
+        with self._lock:
+            count = int(self._conn.execute(
+                "SELECT COUNT(*) FROM memories WHERE memory_type IN ('user_profile', 'user_preference', 'user_habit')"
+            ).fetchone()[0] or 0)
+            if dry_run:
+                return {"ok": True, "code": "migration_dry_run", "write_count": 0, "legacy_candidate_count": count}
+            prior = self._conn.execute("SELECT * FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
+            if prior is not None:
+                return {"ok": True, "code": "migration_idempotent_replay", "operation_id": operation_id}
+            now = utc_now()
+            self._conn.execute(
+                "INSERT INTO portrait_operations(operation_id, operation_kind, payload_hash, snapshot, state, created_at, updated_at) VALUES(?,?,?,?,?,?,?)",
+                (operation_id, "legacy_portrait_projection", stable_fingerprint("portrait", operation_id, count), json_dumps({"fact_ids": []}), "applied", now, now),
+            )
+            self._conn.commit()
+        return {"ok": True, "code": "migration_applied", "operation_id": operation_id, "legacy_candidate_count": count}
+
+    async def rollback_portrait_migration(self, *, operation_id: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self._rollback_portrait_migration_sync, operation_id)
+
+    def _rollback_portrait_migration_sync(self, operation_id: str) -> dict[str, Any]:
+        operation_id = clean_text(operation_id, 120)
+        with self._lock:
+            row = self._conn.execute("SELECT snapshot FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
+            if row is None:
+                return {"ok": False, "code": "migration_not_found"}
+            snapshot = json_loads(row["snapshot"], {})
+            fact_ids = snapshot.get("fact_ids") if isinstance(snapshot, dict) and isinstance(snapshot.get("fact_ids"), list) else []
+            if fact_ids:
+                self._conn.executemany("DELETE FROM portrait_facts WHERE id=?", [(clean_text(item, 120),) for item in fact_ids if clean_text(item, 120)])
+            self._conn.execute("UPDATE portrait_operations SET state='rolled_back', updated_at=? WHERE operation_id=?", (utc_now(), operation_id))
+            self._conn.commit()
+        return {"ok": True, "code": "migration_rolled_back", "operation_id": operation_id}
 
     def normalize_legacy_manual_visibility(self) -> int:
         """收回早期版本中过宽的手动记忆默认可见性。"""

--- a/core/store.py
+++ b/core/store.py
@@ -6560,7 +6560,9 @@ class MemoryStore:
 
     @staticmethod
     def _emotion_delivery_projection(event: dict[str, Any]) -> dict[str, Any]:
-        return {
+        from .affect_modulation import normalize_affect_modulation
+
+        projection = {
             "event_id": clean_text(event.get("event_id"), 96),
             "revision": max(1, int(event.get("revision") or 1)),
             "trace_id": clean_text(event.get("trace_id"), 96),
@@ -6575,6 +6577,14 @@ class MemoryStore:
             "occurred_at": clean_text(event.get("occurred_at"), 48),
             "expires_at": clean_text(event.get("expires_at"), 48),
         }
+        projection["affect_modulation"] = normalize_affect_modulation({
+            "valence": projection["valence"],
+            "arousal": projection["arousal"],
+            "vulnerability": projection["vulnerability"],
+            "confidence": projection["confidence"],
+            "source_event_ids": [projection["event_id"]],
+        })
+        return projection
 
     @staticmethod
     def _emotion_event_row(row: sqlite3.Row) -> dict[str, Any]:

--- a/core/store.py
+++ b/core/store.py
@@ -596,6 +596,10 @@ class MemoryStore:
                 "CREATE INDEX IF NOT EXISTS idx_emotion_events_session ON emotion_events(bot_id, scope, session_id, occurred_at DESC)"
             )
             self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_emotion_events_delivery_domain "
+                "ON emotion_events(bot_id, scope, platform, occurred_at DESC, event_id DESC, revision DESC)"
+            )
+            self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_emotion_events_dedupe ON emotion_events(dedupe_key, event_type)"
             )
             self._conn.execute(
@@ -6625,23 +6629,61 @@ class MemoryStore:
             bounded_limit = max(1, min(20, int(limit or 10)))
         except (TypeError, ValueError):
             bounded_limit = 10
+        cursor_value = clean_text(cursor, 400)
+        cursor_position = self._parse_emotion_delivery_cursor(cursor_value)
+        if cursor_value and cursor_position is None:
+            return self._empty_emotion_delivery()
         clauses = [
             "e.origin_kind='memory_recall'",
             "e.status NOT IN ('ignored','expired')",
             "COALESCE(d.acked_at, '')=''",
             "e.bot_id=?",
-            "e.scope=?",
+            "LOWER(e.scope)=?",
             "e.platform=?",
+            "json_valid(e.actor_ref)",
+            "json_extract(e.actor_ref, '$.kind')='user'",
+            "CAST(json_extract(e.actor_ref, '$.id') AS TEXT)=?",
+            "json_valid(e.target_ref)",
+            "json_extract(e.target_ref, '$.kind')='bot'",
+            "CAST(json_extract(e.target_ref, '$.id') AS TEXT)=?",
+            """(
+                e.expires_at=''
+                OR (
+                    (instr(e.expires_at, 'Z') > 0 OR substr(e.expires_at, -6, 1) IN ('+', '-'))
+                    AND julianday(e.expires_at) IS NOT NULL
+                    AND julianday(e.expires_at) > julianday('now')
+                )
+            )""",
         ]
         params: list[Any] = [
             domain["consumer_id"],
             domain["bot_id"],
             domain["scope"],
             domain["platform"],
+            domain["user_id"],
+            domain["bot_id"],
         ]
         if not domain["allow_cross_window"]:
             clauses.append("e.session_id=?")
             params.append(domain["session_id"])
+        if cursor_position is not None:
+            occurred_at, event_id, revision = cursor_position
+            clauses.append(
+                """(
+                    e.occurred_at < ?
+                    OR (e.occurred_at=? AND e.event_id < ?)
+                    OR (e.occurred_at=? AND e.event_id=? AND e.revision < ?)
+                )"""
+            )
+            params.extend((
+                occurred_at,
+                occurred_at,
+                event_id,
+                occurred_at,
+                event_id,
+                revision,
+            ))
+        params.append(bounded_limit + 1)
         with self._lock:
             rows = self._conn.execute(
                 f"""
@@ -6656,7 +6698,7 @@ class MemoryStore:
                   ON d.event_id=e.event_id AND d.revision=e.revision AND d.consumer_id=?
                 WHERE {' AND '.join(clauses)}
                 ORDER BY e.occurred_at DESC, e.event_id DESC, e.revision DESC
-                LIMIT 1001
+                LIMIT ?
                 """,
                 params,
             ).fetchall()
@@ -6668,13 +6710,6 @@ class MemoryStore:
                     and not self._emotion_event_is_expired(event)
                 )
             ]
-            cursor_value = clean_text(cursor, 400)
-            if cursor_value:
-                positions = [self._emotion_delivery_cursor(item) for item in events]
-                try:
-                    events = events[positions.index(cursor_value) + 1 :]
-                except ValueError:
-                    events = []
             page = events[:bounded_limit]
             has_more = len(events) > bounded_limit
             delivered_at = utc_now()
@@ -6865,11 +6900,38 @@ class MemoryStore:
 
     @staticmethod
     def _emotion_delivery_cursor(event: dict[str, Any]) -> str:
-        return "|".join((
-            clean_text(event.get("occurred_at"), 48),
-            clean_text(event.get("event_id"), 96),
-            str(max(1, int(event.get("revision") or 1))),
-        ))
+        return json_dumps({
+            "occurred_at": clean_text(event.get("occurred_at"), 48),
+            "event_id": clean_text(event.get("event_id"), 96),
+            "revision": max(1, int(event.get("revision") or 1)),
+        })
+
+    @staticmethod
+    def _parse_emotion_delivery_cursor(value: Any) -> tuple[str, str, int] | None:
+        cursor = clean_text(value, 400)
+        if not cursor:
+            return None
+        payload = json_loads(cursor, {})
+        if isinstance(payload, dict):
+            occurred_at = clean_text(payload.get("occurred_at"), 48)
+            event_id = clean_text(payload.get("event_id"), 96)
+            revision = payload.get("revision")
+            try:
+                normalized_revision = max(1, min(1_000_000, int(revision)))
+            except (TypeError, ValueError):
+                normalized_revision = 0
+            if occurred_at and event_id and normalized_revision:
+                return occurred_at, event_id, normalized_revision
+        legacy = cursor.rsplit("|", 2)
+        if len(legacy) != 3:
+            return None
+        occurred_at = clean_text(legacy[0], 48)
+        event_id = clean_text(legacy[1], 96)
+        try:
+            revision = max(1, min(1_000_000, int(legacy[2])))
+        except (TypeError, ValueError):
+            return None
+        return (occurred_at, event_id, revision) if occurred_at and event_id else None
 
     @staticmethod
     def _emotion_delivery_projection(event: dict[str, Any]) -> dict[str, Any]:

--- a/core/store.py
+++ b/core/store.py
@@ -521,6 +521,20 @@ class MemoryStore:
                     created_at TEXT NOT NULL DEFAULT '',
                     PRIMARY KEY(event_id, revision)
                 );
+
+                CREATE TABLE IF NOT EXISTS emotion_event_deliveries (
+                    event_id TEXT NOT NULL,
+                    revision INTEGER NOT NULL DEFAULT 1,
+                    consumer_id TEXT NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    first_delivered_at TEXT NOT NULL DEFAULT '',
+                    last_delivered_at TEXT NOT NULL DEFAULT '',
+                    acked_at TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY(event_id, revision, consumer_id),
+                    FOREIGN KEY(event_id, revision)
+                        REFERENCES emotion_events(event_id, revision)
+                        ON DELETE CASCADE
+                );
                 """
             )
             self._ensure_memory_columns_sync()
@@ -581,6 +595,10 @@ class MemoryStore:
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_emotion_events_dedupe ON emotion_events(dedupe_key, event_type)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_emotion_event_deliveries_pending "
+                "ON emotion_event_deliveries(consumer_id, acked_at, last_delivered_at)"
             )
             self._conn.commit()
 
@@ -6391,6 +6409,172 @@ class MemoryStore:
                 params,
             ).fetchall()
         return [self._emotion_event_row(row) for row in rows]
+
+    async def list_emotion_event_deliveries(
+        self,
+        *,
+        consumer_id: str,
+        session_id: str = "",
+        exclude_session_id: str = "",
+        cursor: str = "",
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        return await self._run_recoverable_database_operation(
+            self._list_emotion_event_deliveries_sync,
+            consumer_id,
+            session_id,
+            exclude_session_id,
+            cursor,
+            limit,
+        )
+
+    def _list_emotion_event_deliveries_sync(
+        self,
+        consumer_id: str,
+        session_id: str,
+        exclude_session_id: str,
+        cursor: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        consumer = clean_text(consumer_id, 80)
+        if not consumer:
+            return {"schema_version": "emotion_afterglow_delivery.v1", "events": [], "next_cursor": "", "has_more": False}
+        session = clean_text(session_id, 220)
+        excluded = clean_text(exclude_session_id, 220)
+        bounded_limit = max(1, min(20, int(limit or 10)))
+        clauses = [
+            "e.origin_kind='memory_recall'",
+            "e.status NOT IN ('ignored','expired')",
+            "COALESCE(d.acked_at, '')=''",
+        ]
+        params: list[Any] = [consumer]
+        if session:
+            clauses.append("e.session_id=?")
+            params.append(session)
+        if excluded:
+            clauses.append("e.session_id!=?")
+            params.append(excluded)
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT e.*
+                FROM emotion_events e
+                JOIN (
+                    SELECT event_id, MAX(revision) AS revision
+                    FROM emotion_events
+                    GROUP BY event_id
+                ) latest ON latest.event_id=e.event_id AND latest.revision=e.revision
+                LEFT JOIN emotion_event_deliveries d
+                  ON d.event_id=e.event_id AND d.revision=e.revision AND d.consumer_id=?
+                WHERE {' AND '.join(clauses)}
+                ORDER BY e.occurred_at DESC, e.event_id DESC, e.revision DESC
+                LIMIT 201
+                """,
+                params,
+            ).fetchall()
+            events = [self._emotion_event_row(row) for row in rows]
+            cursor_value = clean_text(cursor, 400)
+            if cursor_value:
+                positions = [self._emotion_delivery_cursor(item) for item in events]
+                try:
+                    events = events[positions.index(cursor_value) + 1 :]
+                except ValueError:
+                    events = []
+            page = events[:bounded_limit]
+            has_more = len(events) > bounded_limit
+            delivered_at = utc_now()
+            for event in page:
+                self._conn.execute(
+                    """
+                    INSERT INTO emotion_event_deliveries(
+                        event_id, revision, consumer_id, attempts,
+                        first_delivered_at, last_delivered_at, acked_at
+                    ) VALUES(?,?,?,1,?,?,'')
+                    ON CONFLICT(event_id, revision, consumer_id) DO UPDATE SET
+                        attempts=emotion_event_deliveries.attempts+1,
+                        last_delivered_at=excluded.last_delivered_at
+                    """,
+                    (event["event_id"], event["revision"], consumer, delivered_at, delivered_at),
+                )
+            self._conn.commit()
+        projection = [self._emotion_delivery_projection(event) for event in page]
+        return {
+            "schema_version": "emotion_afterglow_delivery.v1",
+            "events": projection,
+            "next_cursor": self._emotion_delivery_cursor(page[-1]) if page and has_more else "",
+            "has_more": has_more,
+        }
+
+    async def ack_emotion_event_deliveries(
+        self,
+        *,
+        consumer_id: str,
+        event_refs: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return await self._run_recoverable_database_operation(
+            self._ack_emotion_event_deliveries_sync, consumer_id, event_refs
+        )
+
+    def _ack_emotion_event_deliveries_sync(
+        self,
+        consumer_id: str,
+        event_refs: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        consumer = clean_text(consumer_id, 80)
+        if not consumer or not isinstance(event_refs, list):
+            return {"acked": 0, "consumer_id": consumer}
+        unique_refs: set[tuple[str, int]] = set()
+        for item in event_refs[:100]:
+            if not isinstance(item, dict):
+                continue
+            event_id = clean_text(item.get("event_id"), 96)
+            try:
+                revision = max(1, min(1000000, int(item.get("revision") or 1)))
+            except (TypeError, ValueError):
+                continue
+            if event_id:
+                unique_refs.add((event_id, revision))
+        acked_at = utc_now()
+        acked = 0
+        with self._lock:
+            for event_id, revision in unique_refs:
+                result = self._conn.execute(
+                    """
+                    UPDATE emotion_event_deliveries
+                    SET acked_at=?
+                    WHERE event_id=? AND revision=? AND consumer_id=? AND acked_at=''
+                    """,
+                    (acked_at, event_id, revision, consumer),
+                )
+                acked += max(0, int(result.rowcount or 0))
+            self._conn.commit()
+        return {"acked": acked, "consumer_id": consumer, "acked_at": acked_at}
+
+    @staticmethod
+    def _emotion_delivery_cursor(event: dict[str, Any]) -> str:
+        return "|".join((
+            clean_text(event.get("occurred_at"), 48),
+            clean_text(event.get("event_id"), 96),
+            str(max(1, int(event.get("revision") or 1))),
+        ))
+
+    @staticmethod
+    def _emotion_delivery_projection(event: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "event_id": clean_text(event.get("event_id"), 96),
+            "revision": max(1, int(event.get("revision") or 1)),
+            "trace_id": clean_text(event.get("trace_id"), 96),
+            "session_id": clean_text(event.get("session_id"), 220),
+            "event_type": clean_text(event.get("event_type"), 48),
+            "intensity": float(event.get("intensity") or 0.0),
+            "confidence": float(event.get("confidence") or 0.0),
+            "energy_delta": float(event.get("applied_energy_delta") or 0.0),
+            "valence": float(event.get("valence_hint") or 0.0),
+            "arousal": float(event.get("arousal_hint") or 0.0),
+            "vulnerability": float(event.get("vulnerability_hint") or 0.0),
+            "occurred_at": clean_text(event.get("occurred_at"), 48),
+            "expires_at": clean_text(event.get("expires_at"), 48),
+        }
 
     @staticmethod
     def _emotion_event_row(row: sqlite3.Row) -> dict[str, Any]:

--- a/core/store.py
+++ b/core/store.py
@@ -4536,6 +4536,110 @@ class MemoryStore:
             ).fetchall()
         return [MemoryRecord.from_row(row) for row in rows]
 
+    async def read_user_memory_summary_records(
+        self,
+        user_id: str,
+        *,
+        session_id: str = "",
+        limit: int = 8,
+    ) -> dict[str, Any]:
+        """Read a bounded exact-identity private-memory set for a bridge DTO.
+
+        This is deliberately not a general search: it accepts no display name,
+        has no cross-window expansion, and never reads group rows. A supplied
+        session must itself resolve to the same private user identity.
+        """
+
+        return await self._run_recoverable_database_operation(
+            self._read_user_memory_summary_records_sync,
+            user_id,
+            session_id,
+            limit,
+        )
+
+    def _read_user_memory_summary_records_sync(
+        self,
+        user_id: str,
+        session_id: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        identity = clean_text(user_id, 120)
+        requested_session = clean_text(session_id, 200)
+        empty = {"records": [], "total": 0, "type_counts": {}}
+        if not identity:
+            return empty
+        if requested_session:
+            scope, target_id = parse_scope_from_session(requested_session)
+            if scope != "private" or clean_text(target_id, 120) != identity:
+                return empty
+
+        try:
+            safe_limit = max(1, min(12, int(limit or 8)))
+        except (TypeError, ValueError, OverflowError):
+            safe_limit = 8
+        session_filters = [
+            "%:friendmessage:" + self._escape_like_suffix(identity),
+            "%:privatemessage:" + self._escape_like_suffix(identity),
+            "%:friend:" + self._escape_like_suffix(identity),
+            "%:private:" + self._escape_like_suffix(identity),
+        ]
+        identity_clause = " OR ".join(
+            ["subject_id=?", "object_id=?", *("LOWER(session_id) LIKE ? ESCAPE '\\'" for _ in session_filters)]
+        )
+        params: list[Any] = [identity, identity, *session_filters]
+        session_clause = ""
+        if requested_session:
+            session_clause = " AND session_id=?"
+            params.append(requested_session)
+        where = (
+            "scope='private' AND review_status!='pending' "
+            "AND visibility IN ('private_pair', 'shareable') "
+            f"AND ({identity_clause}){session_clause}"
+        )
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT * FROM memories
+                WHERE {where}
+                ORDER BY occurred_at DESC, created_at DESC
+                LIMIT ?
+                """,
+                [*params, safe_limit],
+            ).fetchall()
+            total_row = self._conn.execute(
+                f"SELECT COUNT(*) AS count FROM memories WHERE {where}",
+                params,
+            ).fetchone()
+            type_rows = self._conn.execute(
+                f"SELECT memory_type, COUNT(*) AS count FROM memories WHERE {where} GROUP BY memory_type",
+                params,
+            ).fetchall()
+
+        records: list[MemoryRecord] = []
+        for row in rows:
+            record = MemoryRecord.from_row(row)
+            parsed_scope, parsed_target = parse_scope_from_session(clean_text(record.session_id, 200))
+            direct_identity = identity in {clean_text(record.subject.id, 120), clean_text(record.object.id, 120)}
+            session_identity = parsed_scope == "private" and clean_text(parsed_target, 120) == identity
+            if requested_session and record.session_id != requested_session:
+                continue
+            if direct_identity or session_identity:
+                records.append(record)
+        type_counts = {
+            clean_text(row["memory_type"], 80): max(0, int(row["count"] or 0))
+            for row in type_rows
+            if clean_text(row["memory_type"], 80)
+        }
+        return {
+            "records": records,
+            "total": max(0, int(total_row["count"] or 0)) if total_row else 0,
+            "type_counts": type_counts,
+        }
+
+    @staticmethod
+    def _escape_like_suffix(value: str) -> str:
+        return clean_text(value, 120).lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     async def list_memory_buckets(
         self,
         limit: int | None = 160,

--- a/core/store.py
+++ b/core/store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from contextlib import closing, contextmanager
 from copy import deepcopy
 import re
@@ -6380,6 +6381,166 @@ class MemoryStore:
                 (trace, max(1, min(500, int(limit or 100)))),
             ).fetchall()
         return [self._emotion_event_row(row) for row in rows]
+
+    async def get_emotion_trace_diagnostic(
+        self,
+        trace_id: str,
+        *,
+        bot_id: str = "",
+        scope: str = "",
+        session_id: str = "",
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        return await self._run_recoverable_database_operation(
+            self._get_emotion_trace_diagnostic_sync, trace_id, bot_id, scope, session_id, limit
+        )
+
+    def _get_emotion_trace_diagnostic_sync(
+        self,
+        trace_id: str,
+        bot_id: str,
+        scope: str,
+        session_id: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        trace = clean_text(trace_id, 96)
+        if not trace:
+            return []
+        clauses = ["e.trace_id=?"]
+        params: list[Any] = [trace]
+        for column, value, size in (("bot_id", bot_id, 160), ("scope", scope, 24), ("session_id", session_id, 220)):
+            cleaned = clean_text(value, size)
+            if cleaned:
+                clauses.append(f"e.{column}=?")
+                params.append(cleaned)
+        params.append(max(1, min(100, int(limit or 100))))
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT e.* FROM emotion_events e WHERE {' AND '.join(clauses)} ORDER BY e.revision ASC LIMIT ?",
+                params,
+            ).fetchall()
+            result: list[dict[str, Any]] = []
+            for row in rows:
+                event = self._emotion_event_row(row)
+                deliveries = self._conn.execute(
+                    """
+                    SELECT consumer_id, attempts, first_delivered_at, last_delivered_at, acked_at
+                    FROM emotion_event_deliveries
+                    WHERE event_id=? AND revision=?
+                    ORDER BY consumer_id ASC LIMIT 20
+                    """,
+                    (event["event_id"], event["revision"]),
+                ).fetchall()
+                result.append(self._emotion_diagnostic_projection(event, deliveries))
+        return result
+
+    async def get_emotion_trace_summary(
+        self,
+        *,
+        bot_id: str = "",
+        scope: str = "",
+        session_id: str = "",
+        cursor: str = "",
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        return await self._run_recoverable_database_operation(
+            self._get_emotion_trace_summary_sync, bot_id, scope, session_id, cursor, limit
+        )
+
+    def _get_emotion_trace_summary_sync(
+        self,
+        bot_id: str,
+        scope: str,
+        session_id: str,
+        cursor: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        clauses = ["1=1"]
+        params: list[Any] = []
+        for column, value, size in (("bot_id", bot_id, 160), ("scope", scope, 24), ("session_id", session_id, 220)):
+            cleaned = clean_text(value, size)
+            if cleaned:
+                clauses.append(f"e.{column}=?")
+                params.append(cleaned)
+        try:
+            offset = max(0, min(100000, int(cursor or 0)))
+        except (TypeError, ValueError):
+            offset = 0
+        bounded = max(1, min(100, int(limit or 20)))
+        params.extend((bounded + 1, offset))
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT e.* FROM emotion_events e
+                JOIN (SELECT event_id, MAX(revision) revision FROM emotion_events GROUP BY event_id) latest
+                  ON latest.event_id=e.event_id AND latest.revision=e.revision
+                WHERE {' AND '.join(clauses)}
+                ORDER BY e.occurred_at DESC, e.event_id DESC
+                LIMIT ? OFFSET ?
+                """,
+                params,
+            ).fetchall()
+        page = [self._emotion_event_row(row) for row in rows[:bounded]]
+        return {
+            "items": [{
+                "trace_id": clean_text(item.get("trace_id"), 96),
+                "event_id": clean_text(item.get("event_id"), 96),
+                "revision": int(item.get("revision") or 1),
+                "event_type": clean_text(item.get("event_type"), 48),
+                "status": clean_text(item.get("status"), 24),
+                "occurred_at": clean_text(item.get("occurred_at"), 48),
+                "session_hash": self._diagnostic_hash(item.get("session_id")),
+            } for item in page],
+            "next_cursor": str(offset + bounded) if len(rows) > bounded else "",
+            "has_more": len(rows) > bounded,
+        }
+
+    @classmethod
+    def _emotion_diagnostic_projection(cls, event: dict[str, Any], deliveries: list[sqlite3.Row]) -> dict[str, Any]:
+        return {
+            "schema_version": "emotion_trace_diagnostic.v1",
+            "event_id": clean_text(event.get("event_id"), 96),
+            "trace_id": clean_text(event.get("trace_id"), 96),
+            "revision": int(event.get("revision") or 1),
+            "producer_plugin": clean_text(event.get("producer_plugin"), 80),
+            "origin_kind": clean_text(event.get("origin_kind"), 40),
+            "event_type": clean_text(event.get("event_type"), 48),
+            "intensity": float(event.get("intensity") or 0.0),
+            "confidence": float(event.get("confidence") or 0.0),
+            "status": clean_text(event.get("status"), 24),
+            "source_rule": clean_text(event.get("source_rule"), 80),
+            "occurred_at": clean_text(event.get("occurred_at"), 48),
+            "applied_interaction": clean_text(event.get("applied_interaction"), 32),
+            "applied_energy_delta": float(event.get("applied_energy_delta") or 0.0),
+            "correction_of": clean_text(event.get("correction_of"), 96),
+            "actor": cls._diagnostic_ref(event.get("actor_ref")),
+            "target": cls._diagnostic_ref(event.get("target_ref")),
+            "quoted_target": cls._diagnostic_ref(event.get("quoted_target_ref")),
+            "scope": clean_text(event.get("scope"), 24),
+            "session_hash": cls._diagnostic_hash(event.get("session_id")),
+            "deliveries": [{
+                "consumer_id": clean_text(row["consumer_id"], 80),
+                "attempts": max(0, int(row["attempts"] or 0)),
+                "first_delivered_at": clean_text(row["first_delivered_at"], 48),
+                "last_delivered_at": clean_text(row["last_delivered_at"], 48),
+                "acked": bool(row["acked_at"]),
+                "acked_at": clean_text(row["acked_at"], 48),
+            } for row in deliveries],
+        }
+
+    @classmethod
+    def _diagnostic_ref(cls, value: Any) -> dict[str, str]:
+        source = value if isinstance(value, dict) else {}
+        return {
+            "kind": clean_text(source.get("kind"), 24),
+            "role": clean_text(source.get("role"), 40),
+            "id_hash": cls._diagnostic_hash(source.get("id")),
+        }
+
+    @staticmethod
+    def _diagnostic_hash(value: Any) -> str:
+        cleaned = clean_text(value, 220)
+        return hashlib.sha256(cleaned.encode("utf-8", errors="ignore")).hexdigest()[:12] if cleaned else ""
 
     async def list_emotion_events(
         self,

--- a/core/store.py
+++ b/core/store.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 from contextlib import closing, contextmanager
 from copy import deepcopy
+from datetime import datetime, timezone
 import re
 import sqlite3
 import threading
@@ -6575,16 +6576,24 @@ class MemoryStore:
         self,
         *,
         consumer_id: str,
-        session_id: str = "",
-        exclude_session_id: str = "",
+        bot_id: str,
+        scope: str,
+        platform: str,
+        user_id: str,
+        session_id: str,
+        allow_cross_window: bool = False,
         cursor: str = "",
         limit: int = 10,
     ) -> dict[str, Any]:
         return await self._run_recoverable_database_operation(
             self._list_emotion_event_deliveries_sync,
             consumer_id,
+            bot_id,
+            scope,
+            platform,
+            user_id,
             session_id,
-            exclude_session_id,
+            allow_cross_window,
             cursor,
             limit,
         )
@@ -6592,29 +6601,47 @@ class MemoryStore:
     def _list_emotion_event_deliveries_sync(
         self,
         consumer_id: str,
+        bot_id: str,
+        scope: str,
+        platform: str,
+        user_id: str,
         session_id: str,
-        exclude_session_id: str,
+        allow_cross_window: bool,
         cursor: str,
         limit: int,
     ) -> dict[str, Any]:
-        consumer = clean_text(consumer_id, 80)
-        if not consumer:
-            return {"schema_version": "emotion_afterglow_delivery.v1", "events": [], "next_cursor": "", "has_more": False}
-        session = clean_text(session_id, 220)
-        excluded = clean_text(exclude_session_id, 220)
-        bounded_limit = max(1, min(20, int(limit or 10)))
+        domain = self._emotion_delivery_domain(
+            consumer_id=consumer_id,
+            bot_id=bot_id,
+            scope=scope,
+            platform=platform,
+            user_id=user_id,
+            session_id=session_id,
+            allow_cross_window=allow_cross_window,
+        )
+        if domain is None:
+            return self._empty_emotion_delivery("delivery_domain_required")
+        try:
+            bounded_limit = max(1, min(20, int(limit or 10)))
+        except (TypeError, ValueError):
+            bounded_limit = 10
         clauses = [
             "e.origin_kind='memory_recall'",
             "e.status NOT IN ('ignored','expired')",
             "COALESCE(d.acked_at, '')=''",
+            "e.bot_id=?",
+            "e.scope=?",
+            "e.platform=?",
         ]
-        params: list[Any] = [consumer]
-        if session:
+        params: list[Any] = [
+            domain["consumer_id"],
+            domain["bot_id"],
+            domain["scope"],
+            domain["platform"],
+        ]
+        if not domain["allow_cross_window"]:
             clauses.append("e.session_id=?")
-            params.append(session)
-        if excluded:
-            clauses.append("e.session_id!=?")
-            params.append(excluded)
+            params.append(domain["session_id"])
         with self._lock:
             rows = self._conn.execute(
                 f"""
@@ -6629,11 +6656,18 @@ class MemoryStore:
                   ON d.event_id=e.event_id AND d.revision=e.revision AND d.consumer_id=?
                 WHERE {' AND '.join(clauses)}
                 ORDER BY e.occurred_at DESC, e.event_id DESC, e.revision DESC
-                LIMIT 201
+                LIMIT 1001
                 """,
                 params,
             ).fetchall()
-            events = [self._emotion_event_row(row) for row in rows]
+            events = [
+                event
+                for event in (self._emotion_event_row(row) for row in rows)
+                if (
+                    self._emotion_event_in_delivery_domain(event, domain)
+                    and not self._emotion_event_is_expired(event)
+                )
+            ]
             cursor_value = clean_text(cursor, 400)
             if cursor_value:
                 positions = [self._emotion_delivery_cursor(item) for item in events]
@@ -6655,7 +6689,13 @@ class MemoryStore:
                         attempts=emotion_event_deliveries.attempts+1,
                         last_delivered_at=excluded.last_delivered_at
                     """,
-                    (event["event_id"], event["revision"], consumer, delivered_at, delivered_at),
+                    (
+                        event["event_id"],
+                        event["revision"],
+                        domain["consumer_id"],
+                        delivered_at,
+                        delivered_at,
+                    ),
                 )
             self._conn.commit()
         projection = [self._emotion_delivery_projection(event) for event in page]
@@ -6671,19 +6711,47 @@ class MemoryStore:
         *,
         consumer_id: str,
         event_refs: list[dict[str, Any]],
+        bot_id: str,
+        scope: str,
+        platform: str,
+        user_id: str,
+        session_id: str,
+        allow_cross_window: bool = False,
     ) -> dict[str, Any]:
         return await self._run_recoverable_database_operation(
-            self._ack_emotion_event_deliveries_sync, consumer_id, event_refs
+            self._ack_emotion_event_deliveries_sync,
+            consumer_id,
+            event_refs,
+            bot_id,
+            scope,
+            platform,
+            user_id,
+            session_id,
+            allow_cross_window,
         )
 
     def _ack_emotion_event_deliveries_sync(
         self,
         consumer_id: str,
         event_refs: list[dict[str, Any]],
+        bot_id: str,
+        scope: str,
+        platform: str,
+        user_id: str,
+        session_id: str,
+        allow_cross_window: bool,
     ) -> dict[str, Any]:
-        consumer = clean_text(consumer_id, 80)
-        if not consumer or not isinstance(event_refs, list):
-            return {"acked": 0, "consumer_id": consumer}
+        domain = self._emotion_delivery_domain(
+            consumer_id=consumer_id,
+            bot_id=bot_id,
+            scope=scope,
+            platform=platform,
+            user_id=user_id,
+            session_id=session_id,
+            allow_cross_window=allow_cross_window,
+        )
+        if domain is None or not isinstance(event_refs, list):
+            return {"acked": 0, "consumer_id": clean_text(consumer_id, 80), "error_code": "delivery_domain_required"}
         unique_refs: set[tuple[str, int]] = set()
         for item in event_refs[:100]:
             if not isinstance(item, dict):
@@ -6699,17 +6767,101 @@ class MemoryStore:
         acked = 0
         with self._lock:
             for event_id, revision in unique_refs:
+                row = self._conn.execute(
+                    "SELECT * FROM emotion_events WHERE event_id=? AND revision=?",
+                    (event_id, revision),
+                ).fetchone()
+                if row is None:
+                    continue
+                event = self._emotion_event_row(row)
+                if (
+                    not self._emotion_event_in_delivery_domain(event, domain)
+                    or self._emotion_event_is_expired(event)
+                ):
+                    continue
                 result = self._conn.execute(
                     """
                     UPDATE emotion_event_deliveries
                     SET acked_at=?
                     WHERE event_id=? AND revision=? AND consumer_id=? AND acked_at=''
                     """,
-                    (acked_at, event_id, revision, consumer),
+                    (acked_at, event_id, revision, domain["consumer_id"]),
                 )
                 acked += max(0, int(result.rowcount or 0))
             self._conn.commit()
-        return {"acked": acked, "consumer_id": consumer, "acked_at": acked_at}
+        return {"acked": acked, "consumer_id": domain["consumer_id"], "acked_at": acked_at}
+
+    @staticmethod
+    def _empty_emotion_delivery(error_code: str = "") -> dict[str, Any]:
+        result = {
+            "schema_version": "emotion_afterglow_delivery.v1",
+            "events": [],
+            "next_cursor": "",
+            "has_more": False,
+        }
+        if error_code:
+            result["error_code"] = error_code
+        return result
+
+    @staticmethod
+    def _emotion_delivery_domain(
+        *,
+        consumer_id: Any,
+        bot_id: Any,
+        scope: Any,
+        platform: Any,
+        user_id: Any,
+        session_id: Any,
+        allow_cross_window: Any,
+    ) -> dict[str, Any] | None:
+        domain = {
+            "consumer_id": clean_text(consumer_id, 80),
+            "bot_id": clean_text(bot_id, 160),
+            "scope": clean_text(scope, 24).lower(),
+            "platform": clean_text(platform, 80),
+            "user_id": clean_text(user_id, 160),
+            "session_id": clean_text(session_id, 220),
+            "allow_cross_window": allow_cross_window,
+        }
+        if (
+            not all(domain[key] for key in ("consumer_id", "bot_id", "platform", "user_id", "session_id"))
+            or domain["scope"] != "private"
+            or type(domain["allow_cross_window"]) is not bool
+        ):
+            return None
+        return domain
+
+    @staticmethod
+    def _emotion_event_in_delivery_domain(event: dict[str, Any], domain: dict[str, Any]) -> bool:
+        actor = event.get("actor_ref") if isinstance(event.get("actor_ref"), dict) else {}
+        target = event.get("target_ref") if isinstance(event.get("target_ref"), dict) else {}
+        return (
+            clean_text(event.get("origin_kind"), 40) == "memory_recall"
+            and clean_text(event.get("bot_id"), 160) == domain["bot_id"]
+            and clean_text(event.get("scope"), 24).lower() == domain["scope"]
+            and clean_text(event.get("platform"), 80) == domain["platform"]
+            and clean_text(actor.get("kind"), 24) == "user"
+            and clean_text(actor.get("id"), 160) == domain["user_id"]
+            and clean_text(target.get("kind"), 24) == "bot"
+            and clean_text(target.get("id"), 160) == domain["bot_id"]
+            and (
+                domain["allow_cross_window"]
+                or clean_text(event.get("session_id"), 220) == domain["session_id"]
+            )
+        )
+
+    @staticmethod
+    def _emotion_event_is_expired(event: dict[str, Any], *, now: datetime | None = None) -> bool:
+        expires_at = clean_text(event.get("expires_at"), 48)
+        if not expires_at:
+            return False
+        try:
+            parsed = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            if parsed.tzinfo is None or parsed.utcoffset() is None:
+                return True
+            return parsed.astimezone(timezone.utc) <= (now or datetime.now(timezone.utc))
+        except (TypeError, ValueError, OverflowError):
+            return True
 
     @staticmethod
     def _emotion_delivery_cursor(event: dict[str, Any]) -> str:
@@ -6727,7 +6879,6 @@ class MemoryStore:
             "event_id": clean_text(event.get("event_id"), 96),
             "revision": max(1, int(event.get("revision") or 1)),
             "trace_id": clean_text(event.get("trace_id"), 96),
-            "session_id": clean_text(event.get("session_id"), 220),
             "event_type": clean_text(event.get("event_type"), 48),
             "intensity": float(event.get("intensity") or 0.0),
             "confidence": float(event.get("confidence") or 0.0),

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ class MemoryCompanionPlugin(Star):
             data_dir=data_dir,
         )
         self.memory_companion = MemoryCompanionBridge(self.service)
-        self.bot_personal_capabilities = self.memory_companion.probe_bot_personal_memory_capabilities()
+        self.bot_personal_capabilities = self.memory_companion.probe_capability_snapshot()
         if not self.bot_personal_capabilities.get("available", False):
             logger.warning(
                 "[MemoryCompanion] Bot Personal capability probe degraded: %s",

--- a/main.py
+++ b/main.py
@@ -100,8 +100,9 @@ class MemoryCompanionPlugin(Star):
     async def memory_companion_recall_tool(self, event: AstrMessageEvent, **kwargs: Any) -> str:
         """从 MemoryCompanion 中主动回忆当前会话可见的长期记忆。
 
-        返回内容只是与当前问题相关的候选，不代表必须在回复中提及。群聊中标记为 acl_allowed 的私聊候选，
-        仅在当前发言者的核心意图确实需要其本人事实时使用；普通陈述、转述、反问或意图不清时忽略，禁止主动公开。
+        返回内容只是与当前问题相关的候选，不代表必须在回复中提及。REQ-036 下，私聊原始记忆、
+        个人档案和 ACL 标记都不能作为群聊回忆候选；群聊中的低敏本人画像仅能经 Companion 的
+        精确身份和专用画像 Bridge 在检索前裁决后提供。
 
         Args:
             query(string): 要回忆的关键词或自然语言问题。

--- a/main.py
+++ b/main.py
@@ -54,14 +54,23 @@ class MemoryCompanionPlugin(Star):
             data_dir=data_dir,
         )
         self.memory_companion = MemoryCompanionBridge(self.service)
+        self.bot_personal_capabilities = self.memory_companion.probe_bot_personal_memory_capabilities()
+        if not self.bot_personal_capabilities.get("available", False):
+            logger.warning(
+                "[MemoryCompanion] Bot Personal capability probe degraded: %s",
+                ";".join(str(item) for item in self.bot_personal_capabilities.get("warnings", [])),
+            )
         self.commands = MemoryCompanionCommandHandler(self.service, PLUGIN_VERSION)
         self.page_api = None
 
         global _ACTIVE_BRIDGE
-        _ACTIVE_BRIDGE = self.memory_companion if self.service.config.bool("private_companion_bridge.enabled", True) else None
+        _ACTIVE_BRIDGE = self.memory_companion if self.service.config.bridge_enabled() else None
         self._register_page_api_if_available()
 
         logger.info("[MemoryCompanion] 我会牢牢记住你 已启动，数据目录=%s", self.service.data_dir)
+
+    def bot_personal_capability_status(self) -> dict[str, Any]:
+        return dict(self.bot_personal_capabilities)
 
     def _register_page_api_if_available(self) -> None:
         if not hasattr(self.context, "register_web_api"):

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ class MemoryCompanionPlugin(Star):
         self.page_api = None
 
         global _ACTIVE_BRIDGE
-        _ACTIVE_BRIDGE = self.memory_companion if self.service.config.bridge_enabled() else None
+        _ACTIVE_BRIDGE = self.memory_companion if self.service.config.bool("private_companion_bridge.enabled", True) else None
         self._register_page_api_if_available()
 
         logger.info("[MemoryCompanion] 我会牢牢记住你 已启动，数据目录=%s", self.service.data_dir)

--- a/page_api.py
+++ b/page_api.py
@@ -79,6 +79,8 @@ class PluginPageApi:
             ("/config/module/update", self.config_module_update, ["POST"], "MemoryCompanion Page config module update"),
             ("/retrieval/config/update", self.retrieval_config_update, ["POST"], "MemoryCompanion Page retrieval config update"),
             ("/operations/diagnostics", self.operations_diagnostics, ["GET"], "MemoryCompanion operations diagnostics"),
+            ("/emotion/trace", self.emotion_trace, ["GET"], "MemoryCompanion redacted emotion trace"),
+            ("/emotion/traces", self.emotion_traces, ["GET"], "MemoryCompanion redacted emotion trace list"),
             ("/coordination/status", self.coordination_status, ["GET"], "MemoryCompanion safe coordination status"),
             ("/operations/preset", self.operations_preset, ["GET", "POST"], "MemoryCompanion operations preset"),
             ("/data/export", self.data_export, ["POST"], "MemoryCompanion portable data export"),
@@ -196,6 +198,39 @@ class PluginPageApi:
             return self._ok({"diagnostics": await self.plugin.service.operational_report()})
         except Exception as exc:
             return self._err(f"运维诊断失败: {exc}", 500)
+
+    async def emotion_trace(self):
+        trace_id = clean_text(request.args.get("trace_id", ""), 96)
+        if not trace_id:
+            return self._err("缺少 trace_id", 400)
+        context = {
+            "is_admin": True,
+            "bot_id": clean_text(request.args.get("bot_id", ""), 160),
+            "scope": clean_text(request.args.get("scope", ""), 24),
+            "session_id": clean_text(request.args.get("session_id", ""), 220),
+        }
+        bridge = getattr(self.plugin, "memory_companion", None)
+        getter = getattr(bridge, "get_emotion_trace_diagnostic", None)
+        if not callable(getter):
+            return self._ok({"result": {"state": "degraded", "read_only": True, "items": [], "error_code": "bridge_method_unavailable"}})
+        return self._ok({"result": await getter(trace_id, context, limit=100)})
+
+    async def emotion_traces(self):
+        context = {
+            "is_admin": True,
+            "bot_id": clean_text(request.args.get("bot_id", ""), 160),
+            "scope": clean_text(request.args.get("scope", ""), 24),
+            "session_id": clean_text(request.args.get("session_id", ""), 220),
+        }
+        bridge = getattr(self.plugin, "memory_companion", None)
+        getter = getattr(bridge, "get_emotion_trace_summary", None)
+        if not callable(getter):
+            return self._ok({"result": {"state": "degraded", "read_only": True, "items": [], "error_code": "bridge_method_unavailable"}})
+        return self._ok({"result": await getter(
+            context,
+            cursor=clean_text(request.args.get("cursor", ""), 20),
+            limit=max(1, min(100, self._int(request.args.get("limit", "20"), 20))),
+        )})
 
     async def coordination_status(self):
         """Expose a fixed, read-only coordination projection."""

--- a/page_api.py
+++ b/page_api.py
@@ -17,6 +17,11 @@ from zoneinfo import ZoneInfo
 
 from quart import jsonify, request, send_file
 
+try:
+    from astrbot.api.web import request as astrbot_web_request
+except Exception:  # pragma: no cover - optional in isolated page tests.
+    astrbot_web_request = None
+
 from .core.bridge import serialize_memory
 from .core.coordination_status import build_coordination_status, project_p6_status
 from .core.identity import normalize_session_context_fields, parse_scope_from_session
@@ -51,6 +56,14 @@ DEFAULT_THEME_KEY = THEME_NAME_TO_KEY[DEFAULT_THEME_NAME]
 class PluginPageApi:
     def __init__(self, plugin: Any) -> None:
         self.plugin = plugin
+        self._emotion_page_admin_capability = None
+        bridge = getattr(plugin, "memory_companion", None)
+        binder = getattr(bridge, "bind_emotion_page_api", None)
+        if callable(binder):
+            try:
+                self._emotion_page_admin_capability = binder(self)
+            except Exception:
+                self._emotion_page_admin_capability = None
 
     def register_routes(self) -> None:
         register = self.plugin.context.register_web_api
@@ -200,15 +213,12 @@ class PluginPageApi:
             return self._err(f"运维诊断失败: {exc}", 500)
 
     async def emotion_trace(self):
+        context = self._trusted_emotion_admin_context()
+        if context is None:
+            return self._err("admin_required", 403)
         trace_id = clean_text(request.args.get("trace_id", ""), 96)
         if not trace_id:
             return self._err("缺少 trace_id", 400)
-        context = {
-            "is_admin": True,
-            "bot_id": clean_text(request.args.get("bot_id", ""), 160),
-            "scope": clean_text(request.args.get("scope", ""), 24),
-            "session_id": clean_text(request.args.get("session_id", ""), 220),
-        }
         bridge = getattr(self.plugin, "memory_companion", None)
         getter = getattr(bridge, "get_emotion_trace_diagnostic", None)
         if not callable(getter):
@@ -216,12 +226,9 @@ class PluginPageApi:
         return self._ok({"result": await getter(trace_id, context, limit=100)})
 
     async def emotion_traces(self):
-        context = {
-            "is_admin": True,
-            "bot_id": clean_text(request.args.get("bot_id", ""), 160),
-            "scope": clean_text(request.args.get("scope", ""), 24),
-            "session_id": clean_text(request.args.get("session_id", ""), 220),
-        }
+        context = self._trusted_emotion_admin_context()
+        if context is None:
+            return self._err("admin_required", 403)
         bridge = getattr(self.plugin, "memory_companion", None)
         getter = getattr(bridge, "get_emotion_trace_summary", None)
         if not callable(getter):
@@ -231,6 +238,50 @@ class PluginPageApi:
             cursor=clean_text(request.args.get("cursor", ""), 20),
             limit=max(1, min(100, self._int(request.args.get("limit", "20"), 20))),
         )})
+
+    def _trusted_emotion_admin_context(self) -> Any | None:
+        """Construct diagnostic authority only from AstrBot's bound dashboard user."""
+
+        if not self._is_bound_dashboard_admin():
+            return None
+        bridge = getattr(self.plugin, "memory_companion", None)
+        creator = getattr(bridge, "create_emotion_admin_context", None)
+        if not callable(creator) or self._emotion_page_admin_capability is None:
+            return None
+        try:
+            return creator(
+                self._emotion_page_admin_capability,
+                bot_id=clean_text(request.args.get("bot_id", ""), 160),
+                scope=clean_text(request.args.get("scope", ""), 24),
+                session_id=clean_text(request.args.get("session_id", ""), 220),
+            )
+        except Exception:
+            return None
+
+    def _is_bound_dashboard_admin(self) -> bool:
+        """Accept only the framework-injected dashboard user, never request claims."""
+
+        bound_request = astrbot_web_request
+        if bound_request is None:
+            return False
+        try:
+            username = clean_text(bound_request.username, 160)
+        except Exception:
+            return False
+        context = getattr(self.plugin, "context", None)
+        config_getter = getattr(context, "get_config", None)
+        if not callable(config_getter):
+            return False
+        try:
+            config = config_getter()
+        except Exception:
+            return False
+        dashboard = config.get("dashboard") if isinstance(config, dict) else None
+        expected_username = clean_text(
+            dashboard.get("username") if isinstance(dashboard, dict) else "",
+            160,
+        )
+        return bool(username and expected_username and username == expected_username)
 
     async def coordination_status(self):
         """Expose a fixed, read-only coordination projection."""

--- a/page_api.py
+++ b/page_api.py
@@ -94,6 +94,8 @@ class PluginPageApi:
             ("/conversation-import/resume", self.conversation_import_resume, ["POST"], "MemoryCompanion historical chat resume"),
             ("/conversation-import/rebind", self.conversation_import_rebind, ["POST"], "MemoryCompanion historical chat rebind"),
             ("/conversation-import/rollback", self.conversation_import_rollback, ["POST"], "MemoryCompanion historical chat rollback"),
+            ("/profiles", self.profiles, ["GET"], "MemoryCompanion Bot Profiles"),
+            ("/capabilities/bot-personal", self.bot_personal_capabilities, ["GET"], "MemoryCompanion Bot Personal capability"),
             ("/companion/personal-memory", self.companion_personal_memory, ["GET"], "MemoryCompanion Page companion personal memory"),
             ("/companion/personal-photo", self.companion_personal_photo, ["GET"], "MemoryCompanion Page companion personal photo"),
             ("/companion/personal-photo-data", self.companion_personal_photo_data, ["GET"], "MemoryCompanion Page companion personal photo data"),
@@ -115,6 +117,35 @@ class PluginPageApi:
         stats = await self.plugin.service.store.stats()
         stats.pop("pending_review", None)
         return self._ok({"stats": stats})
+
+    async def profiles(self):
+        profile = clean_text(request.args.get("profile", ""), 80)
+        query = clean_text(request.args.get("query", ""), 240)
+        current_date = clean_text(request.args.get("date", ""), 20)
+        current_window = clean_text(request.args.get("window", ""), 40)
+        try:
+            limit = max(1, min(100, int(request.args.get("limit", "10"))))
+        except (TypeError, ValueError):
+            limit = 10
+        result = await self.plugin.service.read_bot_profile(
+            profile,
+            query=query,
+            limit=limit,
+            current_date=current_date,
+            current_window=current_window,
+            authorized=False,
+        )
+        return self._ok({"result": result})
+
+    async def bot_personal_capabilities(self):
+        getter = getattr(self.plugin, "bot_personal_capability_status", None)
+        result = getter() if callable(getter) else {
+            "available": False,
+            "state": "degraded",
+            "degraded": True,
+            "warnings": ["capability_status_unavailable"],
+        }
+        return self._ok({"result": result if isinstance(result, dict) else {}})
 
     async def operations_diagnostics(self):
         try:

--- a/page_api.py
+++ b/page_api.py
@@ -111,6 +111,10 @@ class PluginPageApi:
             ("/conversation-import/rollback", self.conversation_import_rollback, ["POST"], "MemoryCompanion historical chat rollback"),
             ("/profiles", self.profiles, ["GET"], "MemoryCompanion Bot Profiles"),
             ("/user-memory-summary", self.user_memory_summary, ["GET"], "MemoryCompanion User Memory workspace summary"),
+            ("/portrait/profiles", self.portrait_profiles, ["GET"], "MemoryCompanion unified portrait profiles"),
+            ("/portrait/profile", self.portrait_profile, ["GET"], "MemoryCompanion unified portrait governance detail"),
+            ("/portrait/govern", self.portrait_govern, ["POST"], "MemoryCompanion unified portrait governance"),
+            ("/portrait/migration", self.portrait_migration, ["POST"], "MemoryCompanion portrait migration control"),
             ("/capabilities/bot-personal", self.bot_personal_capabilities, ["GET"], "MemoryCompanion Bot Personal capability"),
             ("/companion/personal-memory", self.companion_personal_memory, ["GET"], "MemoryCompanion Page companion personal memory"),
             ("/companion/personal-photo", self.companion_personal_photo, ["GET"], "MemoryCompanion Page companion personal photo"),
@@ -194,6 +198,77 @@ class PluginPageApi:
                     "workspace": {"kind": "memory_user_workspace", "route_hint": "user_memory", "user_id": user_id},
                     "error_code": "summary_unavailable",
                 }
+        return self._ok({"result": result})
+
+    async def portrait_profiles(self):
+        try:
+            limit = max(1, min(500, int(request.args.get("limit", "100"))))
+        except (TypeError, ValueError):
+            limit = 100
+        portraits = getattr(getattr(self.plugin, "service", None), "portraits", None)
+        if portraits is None:
+            return self._ok({"items": [], "state": "bridge_unavailable"})
+        try:
+            items = await portraits.list_governance_profiles(limit=limit)
+        except Exception:
+            logger.exception("统一画像列表读取失败")
+            return self._err("统一画像列表读取失败", 500)
+        return self._ok({"items": items, "state": "ready"})
+
+    async def portrait_profile(self):
+        person_id = clean_text(request.args.get("person_id", ""), 80)
+        if not person_id:
+            return self._err("缺少 person_id", 400)
+        portraits = getattr(getattr(self.plugin, "service", None), "portraits", None)
+        if portraits is None:
+            return self._ok({"result": {"ok": False, "code": "bridge_unavailable", "person": {}, "facts": [], "suppressions": []}})
+        try:
+            result = await portraits.governance_detail(person_id)
+        except Exception:
+            logger.exception("统一画像详情读取失败")
+            return self._err("统一画像详情读取失败", 500)
+        return self._ok({"result": result})
+
+    async def portrait_govern(self):
+        payload = await self._json()
+        portraits = getattr(getattr(self.plugin, "service", None), "portraits", None)
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        try:
+            result = await portraits.govern_fact(
+                person_id=clean_text(payload.get("person_id"), 80),
+                fact_id=clean_text(payload.get("fact_id"), 120),
+                action=clean_text(payload.get("action"), 40),
+                actor="page_administrator",
+                operation_id=clean_text(payload.get("operation_id"), 120),
+                expires_at=clean_text(payload.get("expires_at"), 80),
+            )
+        except Exception:
+            logger.exception("统一画像治理失败")
+            return self._err("统一画像治理失败", 500)
+        return self._ok({"result": result})
+
+    async def portrait_migration(self):
+        payload = await self._json()
+        mode = clean_text(payload.get("mode"), 40) or "dry_run"
+        operation_id = clean_text(payload.get("operation_id"), 120)
+        portraits = getattr(getattr(self.plugin, "service", None), "portraits", None)
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        if not operation_id:
+            return self._err("缺少 operation_id", 400)
+        try:
+            if mode == "dry_run":
+                result = await portraits.migrate_legacy(operation_id=operation_id, dry_run=True)
+            elif mode == "apply":
+                result = await portraits.migrate_legacy(operation_id=operation_id, dry_run=False)
+            elif mode == "rollback":
+                result = await portraits.rollback_legacy_migration(operation_id=operation_id)
+            else:
+                return self._err("无效的迁移模式", 400)
+        except Exception:
+            logger.exception("统一画像迁移操作失败")
+            return self._err("统一画像迁移操作失败", 500)
         return self._ok({"result": result})
 
     async def bot_personal_capabilities(self):

--- a/page_api.py
+++ b/page_api.py
@@ -845,7 +845,7 @@ class PluginPageApi:
             return self._ok({"items": rows})
         except Exception as exc:
             logger.warning("[MemoryCompanion] timeline 端点异常: %s", exc, exc_info=True)
-            return self._ok({"items": []})
+            return self._err("timeline_unavailable", 500)
 
     async def relations(self):
         try:
@@ -859,7 +859,7 @@ class PluginPageApi:
             return self._ok({"items": rows})
         except Exception as exc:
             logger.warning("[MemoryCompanion] relations 端点异常: %s", exc, exc_info=True)
-            return self._ok({"items": []})
+            return self._err("relations_unavailable", 500)
 
     async def graph(self):
         try:
@@ -873,7 +873,7 @@ class PluginPageApi:
             return self._ok({"items": rows})
         except Exception as exc:
             logger.warning("[MemoryCompanion] graph 端点异常: %s", exc, exc_info=True)
-            return self._ok({"items": []})
+            return self._err("graph_unavailable", 500)
 
     async def threads(self):
         try:
@@ -885,7 +885,7 @@ class PluginPageApi:
             return self._ok({"items": rows})
         except Exception as exc:
             logger.warning("[MemoryCompanion] threads 端点异常: %s", exc, exc_info=True)
-            return self._ok({"items": []})
+            return self._err("threads_unavailable", 500)
 
     async def thread_status(self):
         payload = await self._json()
@@ -916,7 +916,7 @@ class PluginPageApi:
             return self._ok({"items": rows})
         except Exception as exc:
             logger.warning("[MemoryCompanion] logs 端点异常: %s", exc, exc_info=True)
-            return self._ok({"items": []})
+            return self._err("logs_unavailable", 500)
 
     async def context_config(self):
         config = self.plugin.service.config

--- a/page_api.py
+++ b/page_api.py
@@ -18,6 +18,7 @@ from zoneinfo import ZoneInfo
 from quart import jsonify, request, send_file
 
 from .core.bridge import serialize_memory
+from .core.coordination_status import build_coordination_status, project_p6_status
 from .core.identity import normalize_session_context_fields, parse_scope_from_session
 from .core.models import SessionContext, clean_text
 
@@ -78,6 +79,7 @@ class PluginPageApi:
             ("/config/module/update", self.config_module_update, ["POST"], "MemoryCompanion Page config module update"),
             ("/retrieval/config/update", self.retrieval_config_update, ["POST"], "MemoryCompanion Page retrieval config update"),
             ("/operations/diagnostics", self.operations_diagnostics, ["GET"], "MemoryCompanion operations diagnostics"),
+            ("/coordination/status", self.coordination_status, ["GET"], "MemoryCompanion safe coordination status"),
             ("/operations/preset", self.operations_preset, ["GET", "POST"], "MemoryCompanion operations preset"),
             ("/data/export", self.data_export, ["POST"], "MemoryCompanion portable data export"),
             ("/data/import/preview", self.data_import_preview, ["GET"], "MemoryCompanion portable data preview"),
@@ -119,6 +121,56 @@ class PluginPageApi:
             return self._ok({"diagnostics": await self.plugin.service.operational_report()})
         except Exception as exc:
             return self._err(f"运维诊断失败: {exc}", 500)
+
+    async def coordination_status(self):
+        """Expose a fixed, read-only coordination projection."""
+        try:
+            service = getattr(self.plugin, "service", None)
+            p6_raw, bridge = self._companion_p6_status(service)
+            status = build_coordination_status(
+                config=getattr(service, "config", None),
+                runtime={"compatibility_level": "full"},
+                bridge=bridge,
+                p6_raw=p6_raw,
+            )
+        except Exception:
+            status = build_coordination_status(
+                config=None,
+                runtime=None,
+                bridge={"health": "unverifiable", "reason_code": "bridge_status_unavailable"},
+                p6_raw=None,
+            )
+        return self._ok({"status": status})
+
+    def _companion_p6_status(self, service: Any) -> tuple[Any, dict[str, str]]:
+        config = getattr(service, "config", None)
+        getter = getattr(config, "bool", None)
+        if not callable(getter):
+            return None, {"health": "unverifiable", "reason_code": "bridge_config_unavailable"}
+        try:
+            enabled = getter("private_companion_bridge.enabled", True)
+        except Exception:
+            return None, {"health": "unverifiable", "reason_code": "bridge_config_unreadable"}
+        if type(enabled) is not bool:
+            return None, {"health": "unverifiable", "reason_code": "bridge_config_invalid"}
+        if not enabled:
+            return None, {"health": "degraded", "reason_code": "bridge_disabled"}
+        companion = self._private_companion_status()
+        if type(companion) is not dict or companion.get("available") is not True:
+            return None, {"health": "unverifiable", "reason_code": "companion_api_unavailable"}
+        plugin = companion.get("plugin")
+        extension_api = getattr(plugin, "extension_api", None)
+        status_getter = getattr(extension_api, "get_p6_readonly_status", None)
+        if not callable(status_getter):
+            return None, {"health": "unverifiable", "reason_code": "companion_p6_producer_unavailable"}
+        try:
+            p6_raw = status_getter()
+        except Exception:
+            return None, {"health": "unverifiable", "reason_code": "companion_p6_producer_unreadable"}
+        p6 = project_p6_status(p6_raw)
+        if p6["health"] == "ready":
+            return p6_raw, {"health": "ready", "reason_code": "companion_bridge_available"}
+        return p6_raw, {"health": "degraded", "reason_code": "companion_p6_unverifiable"}
 
     async def operations_preset(self):
         if request.method == "GET":

--- a/page_api.py
+++ b/page_api.py
@@ -95,6 +95,7 @@ class PluginPageApi:
             ("/conversation-import/rebind", self.conversation_import_rebind, ["POST"], "MemoryCompanion historical chat rebind"),
             ("/conversation-import/rollback", self.conversation_import_rollback, ["POST"], "MemoryCompanion historical chat rollback"),
             ("/profiles", self.profiles, ["GET"], "MemoryCompanion Bot Profiles"),
+            ("/user-memory-summary", self.user_memory_summary, ["GET"], "MemoryCompanion User Memory workspace summary"),
             ("/capabilities/bot-personal", self.bot_personal_capabilities, ["GET"], "MemoryCompanion Bot Personal capability"),
             ("/companion/personal-memory", self.companion_personal_memory, ["GET"], "MemoryCompanion Page companion personal memory"),
             ("/companion/personal-photo", self.companion_personal_photo, ["GET"], "MemoryCompanion Page companion personal photo"),
@@ -135,6 +136,49 @@ class PluginPageApi:
             current_window=current_window,
             authorized=False,
         )
+        return self._ok({"result": result})
+
+    async def user_memory_summary(self):
+        user_id = clean_text(request.args.get("user_id", ""), 120)
+        session_id = clean_text(request.args.get("session_id", ""), 200)
+        try:
+            limit = max(1, min(8, int(request.args.get("limit", "6"))))
+        except (TypeError, ValueError):
+            limit = 6
+        reader = getattr(getattr(self.plugin, "service", None), "read_user_memory_summary", None)
+        if not callable(reader):
+            result = {
+                "contract": "memory.user_memory_summary.v1",
+                "ok": False,
+                "read_only": True,
+                "state": "degraded",
+                "degraded": True,
+                "pending": True,
+                "user_id": user_id,
+                "session_id": session_id,
+                "counts": {"profile": 0, "preference": 0, "relationship": 0, "private_conversation": 0, "other": 0, "total": 0},
+                "summaries": [],
+                "workspace": {"kind": "memory_user_workspace", "route_hint": "user_memory", "user_id": user_id},
+                "error_code": "bridge_method_unavailable",
+            }
+        else:
+            try:
+                result = await reader(user_id, session_id=session_id, limit=limit)
+            except Exception:
+                result = {
+                    "contract": "memory.user_memory_summary.v1",
+                    "ok": False,
+                    "read_only": True,
+                    "state": "degraded",
+                    "degraded": True,
+                    "pending": True,
+                    "user_id": user_id,
+                    "session_id": session_id,
+                    "counts": {"profile": 0, "preference": 0, "relationship": 0, "private_conversation": 0, "other": 0, "total": 0},
+                    "summaries": [],
+                    "workspace": {"kind": "memory_user_workspace", "route_hint": "user_memory", "user_id": user_id},
+                    "error_code": "summary_unavailable",
+                }
         return self._ok({"result": result})
 
     async def bot_personal_capabilities(self):

--- a/page_api.py
+++ b/page_api.py
@@ -377,10 +377,10 @@ class PluginPageApi:
             return self._err(f"历史对话导入回滚失败: {exc}", 500)
 
     async def persona_state(self):
-        """Return persona state: relationship phases, emotional events, address evolution, cross-window state."""
+        """Return read-only expression coordination and memory-touch diagnostics."""
         try:
             service = self.plugin.service
-            phases: list[dict[str, Any]] = []
+            touch_trends: list[dict[str, Any]] = []
             phase_state = getattr(service, "_relationship_phase_state", None)
             if isinstance(phase_state, dict):
                 for key, state in phase_state.items():
@@ -396,19 +396,19 @@ class PluginPageApi:
                     member_id = clean_text(identity.get("member_id"), 120)
                     if member_id:
                         identity_parts.append(f"member={member_id}")
-                    phases.append({
+                    raw_momentum = state.get("momentum", 0.0)
+                    momentum = float(raw_momentum) if type(raw_momentum) in {int, float} else 0.0
+                    trend_band = "rising" if momentum >= 0.08 else "cooling" if momentum <= -0.08 else "steady"
+                    touch_trends.append({
                         "session_key": key,
                         "session_label": " / ".join(part for part in identity_parts if part) or key,
-                        "phase": state.get("phase", "acquaintance"),
-                        "momentum": round(state.get("momentum", 0.0), 3),
+                        "trend_band": trend_band,
                         "touch_count": state.get("touch_count", 0),
-                        "last_transition_at": state.get("last_transition_at", ""),
+                        "legacy_context": clean_text(state.get("phase"), 40),
                         "updated_at": state.get("updated_at", ""),
-                        "current_address_phase": state.get("current_address_phase", ""),
-                        "address_log": (state.get("address_log") or [])[-5:],
                     })
-            phases.sort(key=lambda p: p.get("updated_at", ""), reverse=True)
-            pending_emotional_events: list[dict[str, Any]] = []
+            touch_trends.sort(key=lambda item: item.get("updated_at", ""), reverse=True)
+            memory_touch_events: list[dict[str, Any]] = []
             event_queue = getattr(service, "_emotional_event_queue", None)
             if isinstance(event_queue, dict):
                 for session_id, queue in event_queue.items():
@@ -417,7 +417,7 @@ class PluginPageApi:
                     for event in queue[-3:]:
                         if not isinstance(event, dict):
                             continue
-                        pending_emotional_events.append({
+                        memory_touch_events.append({
                             "session_id": session_id,
                             "event_type": event.get("event_type"),
                             "energy_delta": event.get("energy_delta"),
@@ -431,24 +431,18 @@ class PluginPageApi:
             cross_window_state: dict[str, Any] = {"total": 0, "scar_count": 0, "warm_count": 0, "vulnerable_count": 0}
             if hasattr(service, "_get_cross_window_emotional_state"):
                 cross_window_state = service._get_cross_window_emotional_state()
-            phases_list = getattr(service, "_PHASES", ["acquaintance", "familiar", "close", "intimate", "deeply_bonded"])
-            thresholds = getattr(service, "_PHASE_THRESHOLDS", [0.0, 0.20, 0.45, 0.65, 0.85])
-            bot_suggestions = getattr(service, "_BOT_ADDRESS_SUGGESTIONS", {})
             return self._ok({
-                "phases": phases[:20],
-                "pending_emotional_events": pending_emotional_events[:15],
+                "expression_coordination": {
+                    "contract": "companion_interaction_expression.v1",
+                    "mode": "request_scoped_read_only",
+                    "expression_authority": "private_companion",
+                    "memory_role": "recall_visibility_and_mention_cap",
+                    "persistent": False,
+                },
+                "memory_touch_trends": touch_trends[:20],
+                "memory_touch_events": memory_touch_events[:15],
                 "time_of_day": time_of_day,
-                "phase_definitions": {
-                    "phases": phases_list,
-                    "thresholds": thresholds,
-                },
                 "cross_window_emotional_state": cross_window_state,
-                "address_phase_labels": {
-                    "formal": "正式",
-                    "casual": "随意",
-                    "intimate": "亲密",
-                    "playful": "玩笑",
-                },
                 "time_of_day_labels": {
                     "late_night": "深夜",
                     "dawn": "凌晨",
@@ -457,8 +451,7 @@ class PluginPageApi:
                     "evening": "傍晚",
                     "night": "夜间",
                 },
-                "bot_address_suggestions": bot_suggestions,
-                "phase_labels": {
+                "legacy_context_labels": {
                     "acquaintance": "初识",
                     "familiar": "熟悉",
                     "close": "亲近",
@@ -467,7 +460,7 @@ class PluginPageApi:
                 },
             })
         except Exception as exc:
-            return self._err(f"拟人维度数据读取失败: {exc}", 500)
+            return self._err(f"互动协同数据读取失败: {exc}", 500)
 
     async def acl_matrix(self):
         """Return all windows, ACL rules and policies in one shot for topology visualization."""

--- a/pages/记忆面板/app.css
+++ b/pages/记忆面板/app.css
@@ -1493,6 +1493,33 @@ pre{white-space:pre-wrap;overflow-wrap:anywhere}
   align-items:center;
   gap:8px;
 }
+
+.user-memory-filter{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin:0 0 14px;
+  padding:8px;
+  border:1px solid var(--line);
+  border-radius:14px;
+  background:color-mix(in srgb,var(--panel) 88%,transparent);
+}
+.user-memory-filter button{
+  min-height:34px;
+  padding:7px 13px;
+  border:1px solid transparent;
+  border-radius:999px;
+  background:transparent;
+  color:var(--muted);
+  cursor:pointer;
+}
+.user-memory-filter button:hover,
+.user-memory-filter button.is-active{
+  border-color:color-mix(in srgb,var(--accent) 42%,var(--line));
+  background:color-mix(in srgb,var(--accent) 13%,var(--panel));
+  color:var(--text);
+}
+.compatibility-note{color:var(--muted);font-size:13px}
 .scoped-clear-actions{
   max-width:520px;
 }

--- a/pages/记忆面板/app.js
+++ b/pages/记忆面板/app.js
@@ -194,6 +194,8 @@ const state = {
   historicalChatTargetContextId: "",
   historicalChatTargetBuckets: [],
   historicalChatPollTimer: 0,
+  historicalChatPollAttempts: 0,
+  historicalChatPollStartedAt: 0,
   historicalChatFile: null,
   conversationImportSource: "qq",
   qqHistoryCapabilities: null,
@@ -495,7 +497,21 @@ async function httpRequest(path, method, body) {
     headers: body ? { "Content-Type": "application/json" } : undefined,
     body: body ? JSON.stringify(body) : undefined,
   });
-  return response.json();
+  let data = null;
+  try {
+    data = await response.json();
+  } catch (error) {
+    if (!response.ok) {
+      throw new Error(`请求失败（HTTP ${response.status}）`);
+    }
+    throw new Error("页面 API 返回了无效 JSON");
+  }
+  if (!response.ok || data?.success === false) {
+    const error = new Error(data?.error || `请求失败（HTTP ${response.status}）`);
+    error.status = response.status;
+    throw error;
+  }
+  return data;
 }
 
 function sleep(ms) {
@@ -2076,20 +2092,34 @@ async function loadContextPanel() {
       apiGet(`/timeline?${params.toString()}`),
       apiGet(`/logs?${params.toString()}`),
     ]);
-    const settled = (idx) => results[idx].status === "fulfilled" ? (results[idx].value?.items || []) : [];
-    const failures = results.filter(r => r.status === "rejected");
+    const settled = (idx) => {
+      const result = results[idx];
+      if (result.status === "fulfilled") {
+        return { items: Array.isArray(result.value?.items) ? result.value.items : [], error: "" };
+      }
+      return { items: [], error: result.reason?.message || "读取失败，请稍后重试" };
+    };
+    const sections = results.map((_, idx) => settled(idx));
+    const failures = sections.filter((item) => item.error);
     if (failures.length === results.length) {
       throw results[0].reason || new Error("所有知识图谱 API 请求失败");
     }
     target.innerHTML = renderKnowledgeOverview({
-      graph: settled(0),
-      relations: settled(1),
-      threads: settled(2),
-      timeline: settled(3),
-      logs: settled(4),
+      graph: sections[0].items,
+      relations: sections[1].items,
+      threads: sections[2].items,
+      timeline: sections[3].items,
+      logs: sections[4].items,
+      errors: {
+        graph: sections[0].error,
+        relations: sections[1].error,
+        threads: sections[2].error,
+        timeline: sections[3].error,
+        logs: sections[4].error,
+      },
     });
     if (failures.length > 0) {
-      const failedNames = ["图谱边", "身份关系", "跨窗口线程", "时间线", "注入日志"].filter((_, i) => results[i].status === "rejected");
+      const failedNames = ["图谱边", "身份关系", "跨窗口线程", "时间线", "注入日志"].filter((_, i) => sections[i].error);
       showToast(`${failedNames.join("、")}加载失败，已显示可用数据`, "error");
     }
   }
@@ -2109,7 +2139,16 @@ function rawAttr(value) {
   return escapeHtml(JSON.stringify(value || {}));
 }
 
-function renderKnowledgeOverview({ graph = [], relations = [], threads = [], timeline = [], logs = [] } = {}) {
+function renderContextPanelErrors(errors = {}) {
+  const labels = { graph: "图谱边", relations: "身份关系", threads: "跨窗口线程", timeline: "时间线", logs: "注入日志" };
+  const rows = Object.entries(errors)
+    .filter(([, message]) => message)
+    .map(([key, message]) => `<div class="empty-state error-state"><b>${escapeHtml(labels[key] || key)}读取失败</b><span>${escapeHtml(message)}</span></div>`)
+    .join("");
+  return rows ? `<section class="context-section film-panel"><h4>部分数据暂不可用</h4>${rows}</section>` : "";
+}
+
+function renderKnowledgeOverview({ graph = [], relations = [], threads = [], timeline = [], logs = [], errors = {} } = {}) {
   const activeThreads = threads.filter((item) => (item.status || "open") === "open").length;
   return `
     <section class="context-section film-panel">
@@ -2121,6 +2160,7 @@ function renderKnowledgeOverview({ graph = [], relations = [], threads = [], tim
         ${configCard("时间线节点", `${timeline.length} 条`, "最近记录的事件、消息和整理结果", "blue", "时间")}
       </div>
     </section>
+    ${renderContextPanelErrors(errors)}
     ${renderKnowledgeGraphEdges(graph, "最近图谱边")}
     ${renderKnowledgeRelations(relations, "最近身份关系")}
     ${renderKnowledgeThreads(threads, "最近跨窗口线程")}
@@ -5793,7 +5833,16 @@ async function refreshHistoricalChatStatus() {
 
 function scheduleHistoricalChatPoll() {
   stopHistoricalChatPoll();
+  state.historicalChatPollAttempts = 0;
+  state.historicalChatPollStartedAt = Date.now();
   state.historicalChatPollTimer = window.setInterval(() => {
+    state.historicalChatPollAttempts += 1;
+    const elapsed = Date.now() - state.historicalChatPollStartedAt;
+    if (state.historicalChatPollAttempts > 120 || elapsed > 10 * 60 * 1000) {
+      stopHistoricalChatPoll();
+      showToast("历史导入轮询已达到上限，请手动刷新任务状态", "error");
+      return;
+    }
     refreshHistoricalChatStatus().catch(() => stopHistoricalChatPoll());
   }, 3000);
 }
@@ -5801,6 +5850,7 @@ function scheduleHistoricalChatPoll() {
 function stopHistoricalChatPoll() {
   if (state.historicalChatPollTimer) window.clearInterval(state.historicalChatPollTimer);
   state.historicalChatPollTimer = 0;
+  state.historicalChatPollStartedAt = 0;
 }
 
 function historicalChatSegmentStatusLabel(value) {

--- a/pages/记忆面板/app.js
+++ b/pages/记忆面板/app.js
@@ -160,6 +160,9 @@ const state = {
   activeView: "objects",
   activeBucketId: "all",
   userMemoryFilter: "all",
+  portraitProfiles: [],
+  selectedPortraitPersonId: "",
+  portraitGovernanceDetail: null,
   microscopeBucketId: "all",
   microscopeSearchToken: 0,
   bucketLoadToken: 0,
@@ -2454,6 +2457,7 @@ async function loadUserMemory() {
   if (!target) return;
   syncUserMemoryFilterControls();
   target.innerHTML = loadingState("正在读取用户档案与记忆...");
+  await loadPortraitGovernance();
   const types = relationTypesForSecondary();
   const { params, incompatible } = scopedMemoryParams("private", { limit: 180 });
   if (incompatible) {
@@ -2471,6 +2475,110 @@ async function loadUserMemory() {
     memories = allMemories.filter((memory) => memory.scope === 'private');
   }
   renderMemoryList("#relationList", memories, "当前用户在这个分类下还没有记忆。");
+}
+
+function portraitModeText(value) {
+  return {
+    disabled: "关闭",
+    use_existing: "仅使用已有",
+    learn_and_use: "学习并使用",
+  }[String(value || "")] || "关闭";
+}
+
+function renderPortraitProfileList(items) {
+  if (!items.length) return '<p class="persona-empty">尚无已同步的统一画像。画像不会从昵称猜测创建，需由 Companion 提供精确身份投影。</p>';
+  return `<div class="row-list compact portrait-profile-list">${items.map((item) => {
+    const selected = String(item.person_id || "") === state.selectedPortraitPersonId;
+    const capabilities = item.capability_summary && typeof item.capability_summary === "object" ? item.capability_summary : {};
+    return `<button type="button" class="memory-row ${selected ? "is-selected" : ""}" data-portrait-person="${escapeHtml(item.person_id || "")}"><div><b>${escapeHtml(shortId(item.person_id || ""))}</b><small>身份 ${escapeHtml(item.identity_assurance || "unknown")} · 同步 ${escapeHtml(formatTime(item.last_synced_at || ""))}</small></div><span class="memory-type-pill">事实 ${number(item.fact_count || 0)} · 证据 ${number(item.evidence_count || 0)} · ${escapeHtml(portraitModeText(capabilities.portrait_mode))}</span></button>`;
+  }).join("")}</div>`;
+}
+
+function renderPortraitGovernanceDetail(detail) {
+  if (!detail?.ok) return '<p class="persona-empty">选择画像后可查看脱敏事实摘要、证据计数和抑制记录。</p>';
+  const facts = Array.isArray(detail.facts) ? detail.facts : [];
+  const suppressions = Array.isArray(detail.suppressions) ? detail.suppressions : [];
+  const person = detail.person && typeof detail.person === "object" ? detail.person : {};
+  return `
+    <section class="context-section film-panel portrait-governance-detail">
+      <div class="section-head compact"><div><h4>画像治理</h4><p>管理员可冻结或忘记一条结论。操作立即在写入和读取前生效，不保存聊天正文。</p></div><span class="memory-type-pill">r${escapeHtml(person.portrait_revision || 0)}</span></div>
+      <div class="config-grid">
+        ${configCard("低敏事实", `${facts.filter((item) => item.sensitivity === "low").length} 条`, "事实与推断分层保留", "teal", "画像")}
+        ${configCard("抑制标记", `${suppressions.length} 条`, "删除和否认优先于旧证据", "violet", "治理")}
+      </div>
+      <div class="row-list compact portrait-fact-list">
+        ${facts.length ? facts.map((fact) => `<article class="memory-row"><div><b>${escapeHtml(fact.claim_summary || fact.dimension || "未命名结论")}</b><small>${escapeHtml(fact.portrait_tier || "")} · ${escapeHtml(fact.epistemic_status || "")} · ${escapeHtml(fact.source_scope || "source_only")} · 置信 ${escapeHtml(Number(fact.confidence || 0).toFixed(2))}</small></div><div class="memory-row-actions"><button type="button" class="danger subtle" data-portrait-govern="suppress" data-portrait-fact-id="${escapeHtml(fact.id || "")}">忘记</button><button type="button" class="subtle" data-portrait-govern="freeze" data-portrait-fact-id="${escapeHtml(fact.id || "")}">冻结 7 天</button></div></article>`).join("") : '<p class="persona-empty">暂无画像事实。</p>'}
+      </div>
+      <details class="context-section"><summary>抑制与待确认记录 ${escapeHtml(suppressions.length)}</summary><div class="row-list compact">${suppressions.map((item) => `<article class="memory-row"><div><b>${escapeHtml(item.dimension || "结论")}</b><small>${escapeHtml(item.status || "active")} · ${escapeHtml(item.reason || "")} · ${escapeHtml(formatTime(item.updated_at || ""))}</small></div></article>`).join("") || '<p class="persona-empty">暂无抑制记录。</p>'}</div></details>
+    </section>`;
+}
+
+async function loadPortraitGovernance() {
+  const target = $("#portraitGovernance");
+  if (!target) return;
+  target.innerHTML = loadingState("正在读取统一画像治理状态...");
+  try {
+    const data = await apiGet("/portrait/profiles?limit=100");
+    const items = Array.isArray(data.items) ? data.items : [];
+    state.portraitProfiles = items;
+    if (state.selectedPortraitPersonId && !items.some((item) => String(item.person_id || "") === state.selectedPortraitPersonId)) {
+      state.selectedPortraitPersonId = "";
+      state.portraitGovernanceDetail = null;
+    }
+    target.innerHTML = `<section class="context-section film-panel"><div class="section-head compact"><div><h4>统一用户画像</h4><p>事实、证据、敏感等级、作用域、纠错和遗忘由 Memory 管理；关系和私聊权限仍由 Companion 管理。</p></div><span class="memory-type-pill">${escapeHtml(items.length)} 人</span></div>${renderPortraitProfileList(items)}${renderPortraitGovernanceDetail(state.portraitGovernanceDetail)}</section>`;
+    target.querySelectorAll("[data-portrait-person]").forEach((button) => {
+      button.addEventListener("click", async () => {
+        state.selectedPortraitPersonId = String(button.dataset.portraitPerson || "");
+        state.portraitGovernanceDetail = null;
+        await loadPortraitGovernanceDetail();
+      });
+    });
+    bindPortraitGovernanceActions(target);
+  } catch (error) {
+    target.innerHTML = `<div class="empty-state error-state"><b>统一画像暂不可用</b><span>${escapeHtml(error?.message || "bridge_unavailable")}</span></div>`;
+  }
+}
+
+async function loadPortraitGovernanceDetail() {
+  if (!state.selectedPortraitPersonId) return;
+  try {
+    const data = await apiGet(`/portrait/profile?person_id=${encodeURIComponent(state.selectedPortraitPersonId)}`);
+    state.portraitGovernanceDetail = data.result || null;
+  } catch (error) {
+    state.portraitGovernanceDetail = { ok: false, code: error?.message || "bridge_unavailable" };
+  }
+  await loadPortraitGovernance();
+}
+
+function bindPortraitGovernanceActions(target) {
+  target.querySelectorAll("[data-portrait-govern]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const action = String(button.dataset.portraitGovern || "");
+      const factId = String(button.dataset.portraitFactId || "");
+      if (!factId || !state.selectedPortraitPersonId) return;
+      if (action === "suppress" && button.dataset.portraitConfirmed !== "1") {
+        button.dataset.portraitConfirmed = "1";
+        button.textContent = "再次确认忘记";
+        return;
+      }
+      button.disabled = true;
+      try {
+        const result = await apiPost("/portrait/govern", {
+          person_id: state.selectedPortraitPersonId,
+          fact_id: factId,
+          action,
+          operation_id: `portrait.page:${Date.now()}:${factId.slice(-12)}`,
+          expires_at: action === "freeze" ? new Date(Date.now() + 7 * 86400000).toISOString() : "",
+        });
+        if (!result?.result?.ok) throw new Error(result?.result?.code || "操作未完成");
+        showToast(action === "freeze" ? "已冻结该画像结论 7 天" : "已抑制该画像结论");
+        await loadPortraitGovernanceDetail();
+      } catch (error) {
+        button.disabled = false;
+        showToast(error?.message || "画像治理失败", "error");
+      }
+    });
+  });
 }
 
 async function loadPersonalMemory() {

--- a/pages/记忆面板/app.js
+++ b/pages/记忆面板/app.js
@@ -6,7 +6,7 @@ const VIEWS = {
   objects: { title: "知识图谱", hint: "查看关系边、跨窗口线程、时间线、记忆节点和互动协同概览。" },
   film: { title: "群聊记忆", hint: "查看群聊范围内可召回、可管理的结构化记忆。" },
   microscope: { title: "记忆显微镜", hint: "对比全库管理检索与指定会话中的实际召回和过滤。" },
-  relations: { title: "用户记忆", hint: "聚焦用户画像、偏好、称呼和关系声明。" },
+  relations: { title: "用户档案与记忆", hint: "按用户统一查看私聊、画像、偏好、称呼和关系记忆。" },
   review: { title: "个人记忆", hint: "查看 Bot 自身的每日生活日程、相册、主观记忆和细化片段。" },
   archive: { title: "维护 / 迁移 / 配置", hint: "执行维护、迁移、清理和导入修复。" },
   maintain: { title: "私聊记忆", hint: "查看私聊范围内的对话、偏好、事实和稳定记忆。" },
@@ -42,13 +42,6 @@ const SECONDARY_NAV = {
     { id: "query", label: "召回测试", sublabel: "输入一句话模拟检索", badge: "测试" },
     { id: "hits", label: "命中记忆", sublabel: "查看检索结果", badge: "命中" },
     { id: "blocked", label: "过滤原因", sublabel: "查看被挡下的记忆", badge: "过滤" },
-  ],
-  relations: [
-    { id: "all", label: "全部用户记忆", sublabel: "画像、偏好与关系", badge: "全部" },
-    { id: "profile", label: "用户画像", sublabel: "稳定画像片段", badge: "画像" },
-    { id: "preference", label: "偏好", sublabel: "喜好、习惯、倾向", badge: "偏好" },
-    { id: "relationship", label: "关系声明", sublabel: "身份和关系线索", badge: "关系" },
-    { id: "explicit", label: "明确记住", sublabel: "用户主动要求记住", badge: "记住" },
   ],
   archive: [
     { id: "maintenance", label: "维护 / 迁移 / 清理", sublabel: "维护、修复、导入与清理", badge: "维护" },
@@ -166,6 +159,7 @@ const state = {
   overviewLayout: document.documentElement.dataset.overviewLayout === "cinema" ? "cinema" : "standard",
   activeView: "objects",
   activeBucketId: "all",
+  userMemoryFilter: "all",
   microscopeBucketId: "all",
   microscopeSearchToken: 0,
   bucketLoadToken: 0,
@@ -1225,18 +1219,21 @@ function bindBucketListInteractions() {
 
 function currentRailScope() {
   if (state.activeView === "film") return "group";
+  if (state.activeView === "relations") return "private";
   if (state.activeView === "maintain") return "private";
   return "";
 }
 
 function scopedViewScope(view = state.activeView) {
   if (view === "film") return "group";
+  if (view === "relations") return "private";
   if (view === "maintain") return "private";
   return "";
 }
 
 function scopedViewTarget(view = state.activeView) {
   if (view === "film") return "#groupMemoryList";
+  if (view === "relations") return "#relationList";
   if (view === "maintain") return "#privateMemoryList";
   return "";
 }
@@ -1244,15 +1241,15 @@ function scopedViewTarget(view = state.activeView) {
 function renderScopedModeControls(view = state.activeView) {
   const scope = scopedViewScope(view);
   if (!scope) return;
-  const title = view === "film" ? $("#groupMemoryTitle") : $("#privateMemoryTitle");
-  const hint = view === "film" ? $("#groupMemoryHint") : $("#privateMemoryHint");
-  if (title) title.textContent = `${windowKindLabel(scope)}记忆`;
+  const title = view === "film" ? $("#groupMemoryTitle") : view === "relations" ? $("#userMemoryTitle") : $("#privateMemoryTitle");
+  const hint = view === "film" ? $("#groupMemoryHint") : view === "relations" ? $("#userMemoryHint") : $("#privateMemoryHint");
+  if (title) title.textContent = view === "relations" ? "用户档案与记忆" : `${windowKindLabel(scope)}记忆`;
   if (hint) hint.textContent = VIEWS[view]?.hint || "";
   updateScopedClearButton(view);
 }
 
 function updateScopedClearButton(view = state.activeView) {
-  const button = view === "film" ? $("#clearCurrentGroupMemoryBtn") : view === "maintain" ? $("#clearCurrentPrivateMemoryBtn") : null;
+  const button = view === "film" ? $("#clearCurrentGroupMemoryBtn") : ["relations", "maintain"].includes(view) ? $("#clearCurrentPrivateMemoryBtn") : null;
   const bucket = activeBucket();
   const scope = scopedViewScope(view);
   const canClear = Boolean(bucket && bucket.id !== "all" && bucket.scope === scope && bucket.target_id);
@@ -1738,6 +1735,11 @@ async function playRailRefreshTransition(task) {
 }
 
 async function openView(view, { preserveBucket = false } = {}) {
+  if (view === "maintain") {
+    view = "relations";
+    state.userMemoryFilter = "private";
+    preserveBucket = true;
+  }
   const app = $("#app");
   const wasWorkspace = app.classList.contains("is-workspace");
   const switchingWorkspaceView = wasWorkspace && state.activeView !== view;
@@ -1777,7 +1779,7 @@ async function openView(view, { preserveBucket = false } = {}) {
   renderScopedModeControls(view);
   if (view === "film") {
     renderScopedBucketRail("group");
-  } else if (view === "maintain") {
+  } else if (view === "relations" || view === "maintain") {
     renderScopedBucketRail("private");
   } else if (view !== "review") {
     renderSecondaryNav(view, !switchingWorkspaceView);
@@ -2009,14 +2011,30 @@ function renderMemoryList(selector, memories, emptyText) {
 }
 
 function relationTypesForSecondary() {
-  const active = activeSecondaryNav("relations");
+  const active = state.userMemoryFilter || "all";
   const map = {
     profile: ["user_profile"],
     preference: ["user_preference"],
     relationship: ["relationship_claim"],
     explicit: ["explicit_memory"],
   };
-  return map[active] || ["user_profile", "user_preference", "explicit_memory", "relationship_claim"];
+  return map[active] || [];
+}
+
+function syncUserMemoryFilterControls() {
+  $$('[data-user-memory-filter]').forEach((button) => {
+    if (!button.closest('#view-relations')) return;
+    const active = button.dataset.userMemoryFilter === state.userMemoryFilter;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+}
+
+async function selectUserMemoryFilter(filter) {
+  const allowed = new Set(['all', 'profile', 'preference', 'relationship', 'explicit', 'private']);
+  state.userMemoryFilter = allowed.has(filter) ? filter : 'all';
+  syncUserMemoryFilterControls();
+  if (state.activeView === 'relations') await loadUserMemory();
 }
 
 async function loadScopedMemories(selector, scope, loadingText, emptyText, extra = {}) {
@@ -2434,10 +2452,25 @@ function renderContextLogs(logs) {
 async function loadUserMemory() {
   const target = $("#relationList");
   if (!target) return;
-  target.innerHTML = loadingState("正在读取用户记忆...");
+  syncUserMemoryFilterControls();
+  target.innerHTML = loadingState("正在读取用户档案与记忆...");
   const types = relationTypesForSecondary();
-  const memories = (await loadMemories({ limit: 160 })).filter((memory) => hasMemoryType(memory, types));
-  renderMemoryList("#relationList", memories, "当前范围还没有用户画像、偏好或关系声明。");
+  const { params, incompatible } = scopedMemoryParams("private", { limit: 180 });
+  if (incompatible) {
+    target.innerHTML = '<div class="empty-state">当前对象不是私聊用户，请从左侧选择用户。</div>';
+    return;
+  }
+  // 用户工作区按精确用户身份聚合其全部私聊窗口；会话 ID 只用于旧私聊入口，
+  // 不能把同一用户在其他私聊窗口中的画像/偏好切掉。
+  if (activeBucket()?.target_id) params.delete("session_id");
+  const data = await apiGet(`/memories?${params.toString()}`);
+  const allMemories = data.memories || [];
+  let memories = allMemories;
+  if (types.length) memories = allMemories.filter((memory) => hasMemoryType(memory, types));
+  if (state.userMemoryFilter === 'private') {
+    memories = allMemories.filter((memory) => memory.scope === 'private');
+  }
+  renderMemoryList("#relationList", memories, "当前用户在这个分类下还没有记忆。");
 }
 
 async function loadPersonalMemory() {
@@ -6331,6 +6364,7 @@ function bindActions() {
     if (!button || !$("#standardOverview").contains(button)) return;
     const view = button.dataset.overviewView;
     if (!VIEWS[view]) return;
+    if (button.dataset.userMemoryFilter) state.userMemoryFilter = button.dataset.userMemoryFilter;
     const bucketId = button.dataset.overviewBucket || "";
     if (bucketId && state.buckets.some((bucket) => bucket.id === bucketId)) {
       state.activeBucketId = bucketId;
@@ -6376,7 +6410,10 @@ function bindActions() {
       strip.style.transition = "transform .95s cubic-bezier(.18,.88,.22,1)";
       strip.style.transform  = `rotate(${ang}deg) translateY(${off}px) translateX(${initialAxis}px)`;
     });
-    strip.addEventListener("click", () => openView(strip.dataset.view));
+    strip.addEventListener("click", () => {
+      if (strip.dataset.userMemoryFilter) state.userMemoryFilter = strip.dataset.userMemoryFilter;
+      openView(strip.dataset.view);
+    });
   });
   $("#backHomeBtn").addEventListener("click", returnHome);
   $("#refreshBtn").addEventListener("click", () => playRailRefreshTransition(refreshAll));
@@ -6393,6 +6430,10 @@ function bindActions() {
     }
   });
   $("#runSearchBtn").addEventListener("click", runSearch);
+  $$('[data-user-memory-filter]').forEach((button) => {
+    if (!button.closest('#view-relations')) return;
+    button.addEventListener('click', () => selectUserMemoryFilter(button.dataset.userMemoryFilter));
+  });
   $("#microscopeContext")?.addEventListener("change", (event) => {
     state.microscopeBucketId = event.currentTarget.value || "all";
     updateMicroscopeContextMeta();

--- a/pages/记忆面板/app.js
+++ b/pages/记忆面板/app.js
@@ -3,7 +3,7 @@ const PAGE_ENDPOINT_PREFIX = "page";
 const TRANSPARENT_IMAGE = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 
 const VIEWS = {
-  objects: { title: "知识图谱", hint: "查看关系边、跨窗口线程、时间线、记忆节点和拟人维度概览。" },
+  objects: { title: "知识图谱", hint: "查看关系边、跨窗口线程、时间线、记忆节点和互动协同概览。" },
   film: { title: "群聊记忆", hint: "查看群聊范围内可召回、可管理的结构化记忆。" },
   microscope: { title: "记忆显微镜", hint: "对比全库管理检索与指定会话中的实际召回和过滤。" },
   relations: { title: "用户记忆", hint: "聚焦用户画像、偏好、称呼和关系声明。" },
@@ -36,7 +36,7 @@ const SECONDARY_NAV = {
     { id: "relations", label: "图谱边", sublabel: "人物、话题、事实与记忆关联", badge: "图谱" },
     { id: "threads", label: "跨窗口线程", sublabel: "不同私聊/群聊之间的待办线索", badge: "线程" },
     { id: "timeline", label: "时间线", sublabel: "最近记录的事件节点", badge: "时间" },
-    { id: "persona", label: "拟人维度", sublabel: "关系阶段 · 情绪连续性 · 称呼演进", badge: "拟人" },
+    { id: "persona", label: "互动协同", sublabel: "表达权威 · 记忆触动 · 情绪连续性", badge: "协同" },
   ],
   microscope: [
     { id: "query", label: "召回测试", sublabel: "输入一句话模拟检索", badge: "测试" },
@@ -4494,7 +4494,7 @@ function renderMemoryStructuredMetadata(memory) {
           <div class="memory-diagnostics-grid">
             ${policy ? `<span><em>策略</em><strong>${escapeHtml(mentionPolicyLabel(policy))}</strong></span>` : ""}
             ${mentionability !== undefined && mentionability !== null ? `<span><em>可提及性</em><strong>${escapeHtml(percentLabel(mentionability))}</strong></span>` : ""}
-            ${phase ? `<span><em>关系阶段</em><strong>${escapeHtml(phase)}</strong></span>` : ""}
+            ${phase ? `<span><em>当时关系情境</em><strong>${escapeHtml(phase)}</strong></span>` : ""}
             ${decayMode ? `<span><em>衰减</em><strong>${escapeHtml(decayModeLabel(decayMode))}</strong></span>` : ""}
             ${feedback.last_reaction ? `<span><em>上次反馈</em><strong>${escapeHtml(reactionLabel(feedback.last_reaction))}</strong></span>` : ""}
           </div>
@@ -6017,7 +6017,7 @@ function renderHistoricalChatStatus(result) {
           <span>重要事件 ${number(memoryCounts.important_event)}</span>
           <span>日摘要 ${number(memoryCounts.daily_digest)}</span>
           <span>稳定事实 ${number(memoryCounts.stable_fact)}</span>
-          <span>阶段摘要 ${number(memoryCounts.relationship_phase_summary)}</span>
+          <span>相处经历摘要 ${number(memoryCounts.relationship_phase_summary)}</span>
         </div>
       ` : ""}
       ${batch.stats?.embedding?.enabled ? `<small class="chat-import-embedding-note">向量索引 ${number(batch.stats.embedding.indexed)}/${number(batch.stats.embedding.eligible)} · ${escapeHtml(batch.stats.embedding.status || "处理中")}</small>` : ""}
@@ -6491,7 +6491,7 @@ function bindActions() {
 async function loadPersonaState() {
   const panel = $("#personaStatePanel");
   if (!panel) return;
-  panel.innerHTML = `<div class="persona-loading">正在读取拟人维度数据...</div>`;
+  panel.innerHTML = `<div class="persona-loading">正在读取互动协同数据...</div>`;
   let data;
   try {
     data = await apiGet("/persona-state");
@@ -6503,17 +6503,13 @@ async function loadPersonaState() {
 }
 
 function renderPersonaState(d) {
-  const phases = d.phases || [];
-  const events = d.pending_emotional_events || [];
+  const coordination = d.expression_coordination || {};
+  const trends = d.memory_touch_trends || [];
+  const events = d.memory_touch_events || [];
   const crossState = d.cross_window_emotional_state || {};
   const timeOfDay = d.time_of_day || "";
-  const phaseLabels = d.phase_labels || {};
-  const addressLabels = d.address_phase_labels || {};
+  const legacyLabels = d.legacy_context_labels || {};
   const timeLabels = d.time_of_day_labels || {};
-  const botAddress = d.bot_address_suggestions || {};
-  const phaseDefs = d.phase_definitions || {};
-  const allPhases = phaseDefs.phases || ["acquaintance", "familiar", "close", "intimate", "deeply_bonded"];
-  const thresholds = phaseDefs.thresholds || [0.0, 0.20, 0.45, 0.65, 0.85];
 
   const timeLabel = timeLabels[timeOfDay] || timeOfDay || "未知";
   const crossTotal = crossState.total || 0;
@@ -6523,7 +6519,26 @@ function renderPersonaState(d) {
 
   let html = '<div class="persona-grid">';
 
-  // 1. Time-of-day and cross-window summary card
+  html += `
+    <div class="persona-card persona-card-wide">
+      <div class="persona-card-head">
+        <b>陪伴表达协同状态</b>
+        <span class="persona-badge">只读</span>
+      </div>
+      <div class="persona-card-body">
+        <div class="persona-cross-window">
+          <span class="persona-cw-label">最终语气、称呼、互动档位由陪伴插件统一决定</span>
+          <div class="persona-cw-stats">
+            <span class="persona-cw-stat is-active">${escapeHtml(coordination.contract || "未检测到合同")}</span>
+            <span class="persona-cw-stat">请求级消费</span>
+            <span class="persona-cw-stat">不持久化表达状态</span>
+          </div>
+          <small class="persona-cw-empty">记忆插件只负责事实、可见性、召回和记忆提及上限，不会建立第二套好感度、互动状态或称呼系统。</small>
+        </div>
+      </div>
+    </div>
+  `;
+
   html += `
     <div class="persona-card persona-card-wide">
       <div class="persona-card-head">
@@ -6545,38 +6560,37 @@ function renderPersonaState(d) {
     </div>
   `;
 
-  // 2. Relationship phases
-  if (phases.length === 0) {
+  if (trends.length === 0) {
     html += `
       <div class="persona-card persona-card-wide">
-        <div class="persona-card-head"><b>关系阶段</b></div>
+        <div class="persona-card-head"><b>记忆触动趋势</b></div>
         <div class="persona-card-body">
-          <p class="persona-empty">还没有足够的关系互动数据。随着对话积累，关系阶段会自然演进。</p>
+          <p class="persona-empty">暂无历史记忆触动记录。该区域只反映记忆被触动的趋势，不代表当前好感度或互动状态。</p>
         </div>
       </div>
     `;
   } else {
     html += `
       <div class="persona-card persona-card-wide">
-        <div class="persona-card-head"><b>关系阶段演进</b><span class="persona-badge">${phases.length} 个会话</span></div>
+        <div class="persona-card-head"><b>记忆触动趋势</b><span class="persona-badge">${trends.length} 个会话</span></div>
         <div class="persona-card-body">
           <div class="persona-phase-list">
-            ${phases.map(p => renderPersonaPhaseItem(p, allPhases, thresholds, phaseLabels, addressLabels, botAddress)).join('')}
+            ${trends.map(item => renderMemoryTouchTrend(item, legacyLabels)).join('')}
           </div>
         </div>
       </div>
     `;
   }
 
-  // 3. Pending emotional events
   if (events.length > 0) {
     html += `
       <div class="persona-card persona-card-wide">
-        <div class="persona-card-head"><b>情绪事件队列</b><span class="persona-badge">${events.length} 条待处理</span></div>
+        <div class="persona-card-head"><b>记忆触动事件</b><span class="persona-badge">${events.length} 条待处理</span></div>
         <div class="persona-card-body">
           <div class="persona-event-list">
             ${events.map(e => renderPersonaEventItem(e)).join('')}
           </div>
+          <small class="persona-cw-empty">这些事件只作为陪伴插件 Bot 心情与精力的输入，最终表达仍由陪伴插件裁决。</small>
         </div>
       </div>
     `;
@@ -6586,80 +6600,38 @@ function renderPersonaState(d) {
   return html;
 }
 
-function renderPersonaPhaseItem(p, allPhases, thresholds, phaseLabels, addressLabels, botAddress) {
-  const phase = p.phase || 'acquaintance';
-  const momentum = p.momentum || 0;
-  const phaseLabel = phaseLabels[phase] || phase;
+function renderMemoryTouchTrend(p, legacyLabels) {
+  const trend = p.trend_band || 'steady';
+  const trendLabels = { rising: '升温触动', steady: '平稳触动', cooling: '降温触动' };
+  const trendLabel = trendLabels[trend] || trend;
+  const trendPercent = trend === 'rising' ? 82 : trend === 'cooling' ? 24 : 52;
+  const trendClass = trend === 'rising' ? 'is-high' : trend === 'cooling' ? 'is-low' : 'is-mid';
   const touchCount = p.touch_count || 0;
-  const addressPhase = p.current_address_phase || '';
-  const addressLabel = addressLabels[addressPhase] || '';
+  const legacyContext = p.legacy_context || '';
+  const legacyLabel = legacyLabels[legacyContext] || legacyContext;
   const updatedAt = p.updated_at || '';
   const sessionKey = p.session_label || p.session_key || '';
   const shortSession = sessionKey.length > 40 ? sessionKey.slice(0, 37) + '...' : sessionKey;
-
-  // Find current phase index for progress bar
-  const phaseIdx = allPhases.indexOf(phase);
-  const phasePercent = phaseIdx >= 0 ? ((phaseIdx + 1) / allPhases.length) * 100 : 20;
-
-  // Momentum bar: map [-0.3, 1.0] to [0%, 100%]
-  const momentumPercent = Math.max(0, Math.min(100, ((momentum + 0.3) / 1.3) * 100));
-  const momentumClass = momentum >= 0.45 ? 'is-high' : momentum >= 0.15 ? 'is-mid' : momentum < 0 ? 'is-low' : '';
-
-  // Bot address suggestion
-  const botSuggestion = botAddress[phase] || {};
-  const botTone = botSuggestion.tone || '';
-  const botHint = botSuggestion.hint || '';
-
-  // Address log
-  const addressLog = p.address_log || [];
-  const hasAddressLog = addressLog.length > 0;
 
   return `
     <div class="persona-phase-item">
       <div class="persona-phase-header">
         <div class="persona-phase-info">
-          <span class="persona-phase-name">${escapeHtml(phaseLabel)}</span>
+          <span class="persona-phase-name">${escapeHtml(trendLabel)}</span>
           <small class="persona-phase-session">${escapeHtml(shortSession)}</small>
         </div>
         <div class="persona-phase-meta">
           <span class="persona-phase-touch">${touchCount} 次触动</span>
-          ${addressLabel ? `<span class="persona-phase-address">称呼：${escapeHtml(addressLabel)}</span>` : ''}
-        </div>
-      </div>
-      <div class="persona-phase-progress">
-        <div class="persona-phase-bar">
-          <div class="persona-phase-bar-fill" style="width:${phasePercent}%"></div>
-        </div>
-        <div class="persona-phase-steps">
-          ${allPhases.map((ph, i) => `<span class="persona-phase-step ${i <= phaseIdx ? 'is-active' : ''}">${escapeHtml(phaseLabels[ph] || ph)}</span>`).join('')}
+          ${legacyLabel ? `<span class="persona-phase-address">历史情境：${escapeHtml(legacyLabel)}</span>` : ''}
         </div>
       </div>
       <div class="persona-momentum">
-        <span class="persona-momentum-label">动量</span>
+        <span class="persona-momentum-label">触动趋势</span>
         <div class="persona-momentum-bar">
-          <div class="persona-momentum-fill ${momentumClass}" style="width:${momentumPercent}%"></div>
+          <div class="persona-momentum-fill ${trendClass}" style="width:${trendPercent}%"></div>
         </div>
-        <span class="persona-momentum-value">${momentum.toFixed(3)}</span>
+        <span class="persona-momentum-value">${escapeHtml(trendLabel)}</span>
       </div>
-      ${botTone ? `
-        <div class="persona-bot-address">
-          <span class="persona-bot-tone">${escapeHtml(botTone)}</span>
-          ${botHint ? `<small class="persona-bot-hint">${escapeHtml(botHint)}</small>` : ''}
-        </div>
-      ` : ''}
-      ${hasAddressLog ? `
-        <details class="persona-address-log">
-          <summary>称呼演变记录 (${addressLog.length})</summary>
-          <div class="persona-address-timeline">
-            ${addressLog.map(log => `
-              <div class="persona-address-entry">
-                <span class="persona-address-time">${escapeHtml((log.ts || '').slice(0, 16))}</span>
-                <span class="persona-address-change">${escapeHtml(addressLabels[log.previous] || log.previous || '—')} → ${escapeHtml(addressLabels[log.phase] || log.phase || '')}</span>
-              </div>
-            `).join('')}
-          </div>
-        </details>
-      ` : ''}
       ${updatedAt ? `<small class="persona-phase-updated">更新于 ${escapeHtml(updatedAt.slice(0, 16))}</small>` : ''}
     </div>
   `;

--- a/pages/记忆面板/app.js
+++ b/pages/记忆面板/app.js
@@ -60,7 +60,7 @@ const SECONDARY_NAV = {
     { id: "retrieval", label: "检索召回", sublabel: "候选、Embedding、Rerank", badge: "召回" },
     { id: "config:memory_injection", label: "记忆注入", sublabel: "注入数量、字数与日志", badge: "注入" },
     { id: "config:context_orchestration", label: "注入编排", sublabel: "分槽调度与当前状态保护", badge: "编排" },
-    { id: "config:private_companion_bridge", label: "陪伴协同", sublabel: "桥接、去重与提示清理", badge: "联动" },
+    { id: "config:private_companion_bridge", label: "记忆插件协同", sublabel: "与陪伴插件桥接、去重和清理提示", badge: "联动" },
     { id: "config:visibility", label: "可见性", sublabel: "跨窗口默认边界", badge: "权限" },
     { id: "topology", label: "权限拓扑", sublabel: "可视化记忆权限矩阵", badge: "拓扑" },
     { id: "config:knowledge_graph", label: "图谱关联", sublabel: "节点、边与检索扩展", badge: "图谱" },

--- a/pages/记忆面板/app.js
+++ b/pages/记忆面板/app.js
@@ -6536,11 +6536,32 @@ async function loadPersonaState() {
   let data;
   try {
     data = await apiGet("/persona-state");
+    try {
+      const traces = await apiGet("/emotion/traces?scope=private&limit=20");
+      data.emotion_trace_diagnostics = traces?.result || traces || {};
+    } catch (_) {
+      data.emotion_trace_diagnostics = { state: "degraded", items: [], error_code: "trace_summary_unavailable" };
+    }
   } catch (err) {
     panel.innerHTML = `<div class="persona-error">读取失败：${escapeHtml(err?.message || "未知错误")}</div>`;
     return;
   }
   panel.innerHTML = renderPersonaState(data || {});
+  panel.querySelectorAll("[data-memory-emotion-trace]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const traceId = String(button.dataset.memoryEmotionTrace || "");
+      const target = panel.querySelector("[data-memory-emotion-trace-detail]");
+      if (!traceId || !target) return;
+      target.textContent = "正在读取脱敏链路...";
+      try {
+        const response = await apiGet(`/emotion/trace?trace_id=${encodeURIComponent(traceId)}&scope=private`);
+        const result = response?.result || response || {};
+        target.textContent = JSON.stringify(result, null, 2);
+      } catch (error) {
+        target.textContent = `degraded: ${error?.message || "trace unavailable"}`;
+      }
+    });
+  });
 }
 
 function renderPersonaState(d) {
@@ -6551,6 +6572,8 @@ function renderPersonaState(d) {
   const timeOfDay = d.time_of_day || "";
   const legacyLabels = d.legacy_context_labels || {};
   const timeLabels = d.time_of_day_labels || {};
+  const traceDiagnostics = d.emotion_trace_diagnostics || {};
+  const traceItems = Array.isArray(traceDiagnostics.items) ? traceDiagnostics.items.slice(0, 20) : [];
 
   const timeLabel = timeLabels[timeOfDay] || timeOfDay || "未知";
   const crossTotal = crossState.total || 0;
@@ -6559,6 +6582,18 @@ function renderPersonaState(d) {
   const crossVuln = crossState.vulnerable_count || 0;
 
   let html = '<div class="persona-grid">';
+
+  html += `
+    <div class="persona-card persona-card-wide">
+      <div class="persona-card-head"><b>情绪链路诊断</b><span class="persona-badge">${escapeHtml(traceDiagnostics.state || "degraded")}</span></div>
+      <div class="persona-card-body">
+        <div class="persona-event-list">
+          ${traceItems.map((item) => `<button type="button" class="persona-event-item" data-memory-emotion-trace="${escapeHtml(item.trace_id || "")}"><b>${escapeHtml(item.event_type || "neutral")} · r${escapeHtml(item.revision || 1)}</b><small>${escapeHtml(item.status || "observed")} · ${escapeHtml(item.occurred_at || "")}</small></button>`).join("") || '<p class="persona-empty">暂无可展示的脱敏 trace。</p>'}
+        </div>
+        <pre class="json-box" data-memory-emotion-trace-detail>选择一条 trace 查看事件 revision 与投递确认状态。</pre>
+      </div>
+    </div>
+  `;
 
   html += `
     <div class="persona-card persona-card-wide">

--- a/pages/记忆面板/index.html
+++ b/pages/记忆面板/index.html
@@ -17,7 +17,7 @@
       document.documentElement.dataset.overviewLayout = layout;
     })();
   </script>
-  <link rel="stylesheet" href="./app.css?v=1.7.1" />
+  <link rel="stylesheet" href="./app.css?v=1.7.1-user-workspace" />
 </head>
 <body>
   <main id="app" class="film-app">
@@ -65,12 +65,12 @@
               <p class="eyebrow">Workspace</p>
               <h2 id="overviewDestinationsTitle">功能入口</h2>
             </div>
-            <span>7 个工作区</span>
+            <span>6 个工作区 · 1 个兼容入口</span>
           </div>
           <div class="overview-entry-grid">
-            <button class="overview-entry is-private" data-overview-view="maintain" type="button">
+            <button class="overview-entry is-private" data-overview-view="relations" data-user-memory-filter="private" type="button">
               <span class="overview-entry-index">01</span>
-              <span class="overview-entry-copy"><b>私聊记忆</b><small>对话 · 偏好 · 稳定事实</small></span>
+              <span class="overview-entry-copy"><b>用户档案与记忆</b><small>私聊 · 画像 · 偏好 · 关系</small></span>
               <span class="overview-entry-arrow" aria-hidden="true">&rsaquo;</span>
             </button>
             <button class="overview-entry is-group" data-overview-view="film" type="button">
@@ -78,9 +78,9 @@
               <span class="overview-entry-copy"><b>群聊记忆</b><small>群聊 · 成员 · 上下文</small></span>
               <span class="overview-entry-arrow" aria-hidden="true">&rsaquo;</span>
             </button>
-            <button class="overview-entry is-user" data-overview-view="relations" type="button">
+            <button class="overview-entry is-user" data-overview-view="relations" data-user-memory-filter="all" type="button">
               <span class="overview-entry-index">03</span>
-              <span class="overview-entry-copy"><b>用户记忆</b><small>画像 · 偏好 · 关系</small></span>
+              <span class="overview-entry-copy"><b>用户档案与记忆</b><small>按用户统一查看全部记忆</small></span>
               <span class="overview-entry-arrow" aria-hidden="true">&rsaquo;</span>
             </button>
             <button class="overview-entry is-personal" data-overview-view="review" type="button">
@@ -140,10 +140,10 @@
       <button class="filmstrip" style="--a:-18deg;--z:2;--off:240px"  data-view="objects"    data-tip-title="知识图谱" data-tip-sub="关系 · 线程 · 时间线"     type="button"><span class="strip-label"><b>知识图谱</b><small>关系 · 节点</small></span></button>
       <button class="filmstrip" style="--a:76deg; --z:4;--off:-200px" data-view="film"       data-tip-title="群聊记忆" data-tip-sub="群聊范围内的记忆"      type="button"><span class="strip-label"><b>群聊记忆</b><small>群聊 · 记忆</small></span></button>
       <button class="filmstrip" style="--a:44deg; --z:7;--off:260px"  data-view="microscope" data-tip-title="记忆显微镜" data-tip-sub="模拟召回 · 检查注入"     type="button"><span class="strip-label" style="--label-edge:-260px"><b>记忆显微镜</b><small>模拟召回</small></span></button>
-      <button class="filmstrip" style="--a:14deg; --z:5;--off:-225px;--tx:-440px" data-view="relations"  data-tip-title="用户记忆"     data-tip-sub="用户画像 · 偏好 · 关系"     type="button"><span class="strip-label" style="--label-edge:380px"><b>用户记忆</b><small>画像 · 偏好</small></span></button>
+      <button class="filmstrip" style="--a:14deg; --z:5;--off:-225px;--tx:-440px" data-view="relations" data-user-memory-filter="all" data-tip-title="用户档案与记忆" data-tip-sub="私聊 · 画像 · 偏好 · 关系" type="button"><span class="strip-label" style="--label-edge:380px"><b>用户档案与记忆</b><small>按用户统一查看</small></span></button>
       <button class="filmstrip" style="--a:162deg;--z:1;--off:215px;--tx:-260px" data-view="review"     data-tip-title="个人记忆"       data-tip-sub="Bot 日程 · 生活细化"         type="button"><span class="strip-label is-flipped"><b>个人记忆</b><small>日程 · 细化</small></span></button>
       <button class="filmstrip" style="--a:136deg;--z:3;--off:-390px" data-view="archive"    data-tip-title="维护/迁移/配置"   data-tip-sub="工具 · 迁移 · 配置"        type="button"><span class="strip-label is-flipped"><b>维护/迁移/配置</b><small>工具 · 配置</small></span></button>
-      <button class="filmstrip" style="--a:106deg;--z:6;--off:220px"  data-view="maintain"   data-tip-title="私聊记忆"  data-tip-sub="私聊范围内的记忆" type="button"><span class="strip-label is-flipped"><b>私聊记忆</b><small>私聊 · 记忆</small></span></button>
+      <button class="filmstrip" style="--a:106deg;--z:6;--off:220px" data-view="relations" data-user-memory-filter="private" data-tip-title="私聊记忆（兼容入口）" data-tip-sub="进入用户档案与记忆" type="button"><span class="strip-label is-flipped"><b>私聊记忆</b><small>进入统一工作区</small></span></button>
 
       <section class="overview-core" aria-live="polite">
         <div class="core-ring"></div>
@@ -242,8 +242,19 @@
 
           <section id="view-relations" class="view">
             <div class="section-head">
-              <h3>用户记忆</h3>
-              <p>聚焦用户画像、偏好、称呼、关系声明等以用户为核心的记忆。</p>
+              <div>
+                <h3 id="userMemoryTitle">用户档案与记忆</h3>
+                <p id="userMemoryHint">选择左侧用户后，在同一工作区查看私聊、画像、偏好和关系记忆。</p>
+              </div>
+              <button id="clearCurrentPrivateMemoryBtn" class="danger subtle" type="button" disabled>清空当前用户</button>
+            </div>
+            <div class="user-memory-filter" role="tablist" aria-label="用户记忆分类">
+              <button class="is-active" data-user-memory-filter="all" type="button" role="tab" aria-selected="true">全部</button>
+              <button data-user-memory-filter="profile" type="button" role="tab" aria-selected="false">画像</button>
+              <button data-user-memory-filter="preference" type="button" role="tab" aria-selected="false">偏好</button>
+              <button data-user-memory-filter="relationship" type="button" role="tab" aria-selected="false">关系</button>
+              <button data-user-memory-filter="explicit" type="button" role="tab" aria-selected="false">明确记住</button>
+              <button data-user-memory-filter="private" type="button" role="tab" aria-selected="false">私聊记忆</button>
             </div>
             <div id="relationList" class="row-list"></div>
           </section>
@@ -262,7 +273,7 @@
                 <h3 id="privateMemoryTitle">私聊记忆</h3>
                 <p id="privateMemoryHint">查看私聊范围内的对话、偏好、事实和稳定记忆。</p>
               </div>
-              <button id="clearCurrentPrivateMemoryBtn" class="danger subtle" type="button" disabled>清空当前用户</button>
+              <span class="compatibility-note">此旧入口已合并到“用户档案与记忆”。</span>
             </div>
             <div id="privateMemoryList" class="row-list"></div>
           </section>
@@ -461,6 +472,6 @@ Bot: 12-14 15:10:30
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
   </main>
   <script src="/api/plugin/page/bridge-sdk.js"></script>
-  <script src="./app.js?v=1.7.1"></script>
+  <script src="./app.js?v=1.7.1-user-workspace"></script>
 </body>
 </html>

--- a/pages/记忆面板/index.html
+++ b/pages/记忆面板/index.html
@@ -256,6 +256,7 @@
               <button data-user-memory-filter="explicit" type="button" role="tab" aria-selected="false">明确记住</button>
               <button data-user-memory-filter="private" type="button" role="tab" aria-selected="false">私聊记忆</button>
             </div>
+            <section id="portraitGovernance" class="page-panel-stack" aria-label="统一用户画像治理"></section>
             <div id="relationList" class="row-list"></div>
           </section>
 

--- a/tests/emotion_eval_cases.py
+++ b/tests/emotion_eval_cases.py
@@ -1,0 +1,58 @@
+"""Deterministic synthetic emotion-evaluation matrix shared by both repositories."""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+EMOTION_EVAL_SCHEMA_VERSION = "emotion_eval_case.v1"
+EVENT_TEMPLATES = (
+    {"key": "hurt", "event_type": "hurt", "intensity": 90, "confidence": 0.92, "target": "bot"},
+    {"key": "apology", "event_type": "apology", "intensity": 68, "confidence": 0.86, "target": "bot"},
+    {"key": "comfort", "event_type": "comfort", "intensity": 48, "confidence": 0.82, "target": "bot"},
+    {"key": "praise", "event_type": "praise", "intensity": 38, "confidence": 0.78, "target": "bot"},
+    {"key": "self_low", "event_type": "comfort_need", "intensity": 62, "confidence": 0.88, "target": "self"},
+    {"key": "third_party", "event_type": "external_negative", "intensity": 54, "confidence": 0.80, "target": "other"},
+    {"key": "play", "event_type": "play", "intensity": 35, "confidence": 0.75, "target": "bot"},
+    {"key": "intimacy", "event_type": "intimacy", "intensity": 55, "confidence": 0.80, "target": "bot"},
+    {"key": "boundary", "event_type": "boundary", "intensity": 80, "confidence": 0.90, "target": "bot"},
+    {"key": "neutral", "event_type": "neutral", "intensity": 0, "confidence": 0.95, "target": "none"},
+)
+STATE_VARIANTS = (
+    {"key": "friend_normal", "role": "friend", "mode": "normal", "score": 100, "energy": 70, "mood": "平稳", "busy": False, "boundary": False},
+    {"key": "friend_tired", "role": "friend", "mode": "normal", "score": 300, "energy": 20, "mood": "疲惫", "busy": False, "boundary": False},
+    {"key": "friend_close", "role": "friend", "mode": "normal", "score": 800, "energy": 75, "mood": "轻快", "busy": False, "boundary": False},
+    {"key": "owner", "role": "owner", "mode": "owner_exclusive", "score": 1200, "energy": 80, "mood": "温柔", "busy": False, "boundary": False},
+    {"key": "contact_boundary", "role": "friend", "mode": "normal", "score": 600, "energy": 70, "mood": "平稳", "busy": False, "boundary": True},
+    {"key": "busy", "role": "friend", "mode": "normal", "score": 600, "energy": 65, "mood": "平稳", "busy": True, "boundary": False},
+)
+
+
+def build_emotion_eval_cases() -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    for event in EVENT_TEMPLATES:
+        for state in STATE_VARIANTS:
+            cases.append({
+                "schema_version": EMOTION_EVAL_SCHEMA_VERSION,
+                "case_id": f"{event['key']}__{state['key']}",
+                "event": dict(event),
+                "state": dict(state),
+                "clock": "2026-08-04T12:00:00+08:00",
+            })
+    return cases
+
+
+def emotion_eval_fingerprint() -> str:
+    payload = json.dumps(build_emotion_eval_cases(), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "EMOTION_EVAL_SCHEMA_VERSION",
+    "EVENT_TEMPLATES",
+    "STATE_VARIANTS",
+    "build_emotion_eval_cases",
+    "emotion_eval_fingerprint",
+]
+

--- a/tests/emotion_eval_cases.py
+++ b/tests/emotion_eval_cases.py
@@ -18,6 +18,16 @@ EVENT_TEMPLATES = (
     {"key": "intimacy", "event_type": "intimacy", "intensity": 55, "confidence": 0.80, "target": "bot"},
     {"key": "boundary", "event_type": "boundary", "intensity": 80, "confidence": 0.90, "target": "bot"},
     {"key": "neutral", "event_type": "neutral", "intensity": 0, "confidence": 0.95, "target": "none"},
+    {"key": "quoted_hurt", "event_type": "external_negative", "intensity": 45, "confidence": 0.92, "target": "other"},
+    {"key": "code_negative", "event_type": "neutral", "intensity": 0, "confidence": 0.98, "target": "none"},
+    {"key": "log_negative", "event_type": "neutral", "intensity": 0, "confidence": 0.98, "target": "none"},
+    {"key": "roleplay_negative", "event_type": "neutral", "intensity": 0, "confidence": 0.60, "target": "ambiguous"},
+    {"key": "sarcasm", "event_type": "neutral", "intensity": 0, "confidence": 0.55, "target": "ambiguous"},
+    {"key": "group_reply_other", "event_type": "external_negative", "intensity": 50, "confidence": 0.88, "target": "other"},
+    {"key": "nickname_changed", "event_type": "neutral", "intensity": 0, "confidence": 0.50, "target": "ambiguous"},
+    {"key": "direct_bot_hurt", "event_type": "hurt", "intensity": 92, "confidence": 0.94, "target": "bot"},
+    {"key": "self_denial", "event_type": "comfort_need", "intensity": 62, "confidence": 0.94, "target": "self"},
+    {"key": "prompt_injection", "event_type": "neutral", "intensity": 0, "confidence": 0.98, "target": "none"},
 )
 STATE_VARIANTS = (
     {"key": "friend_normal", "role": "friend", "mode": "normal", "score": 100, "energy": 70, "mood": "平稳", "busy": False, "boundary": False},
@@ -55,4 +65,3 @@ __all__ = [
     "build_emotion_eval_cases",
     "emotion_eval_fingerprint",
 ]
-

--- a/tests/test_active_reconstruction.py
+++ b/tests/test_active_reconstruction.py
@@ -272,7 +272,7 @@ class ActiveReconstructionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([], result["navigation_hints"])
         self.assertNotIn("blocked", result)
 
-    async def test_acl_owner_can_navigate_but_other_speaker_cannot(self) -> None:
+    async def test_acl_cannot_navigate_private_memory_from_group_for_any_speaker(self) -> None:
         service = self.make_service()
         await self.insert_indexed(service, self.summary_memory())
         await service.store.upsert_acl_rule(
@@ -298,11 +298,13 @@ class ActiveReconstructionTests(unittest.IsolatedAsyncioTestCase):
             tag="饮食偏好",
         )
 
-        self.assertEqual("evidence_found", owner["status"])
+        self.assertEqual("no_visible_evidence", owner["status"])
+        self.assertEqual([], owner["evidence"])
+        self.assertEqual([], owner["navigation_hints"])
         self.assertEqual("no_visible_evidence", other["status"])
         self.assertEqual([], other["evidence"])
 
-    async def test_acl_revocation_is_rechecked_on_later_step(self) -> None:
+    async def test_acl_rule_cannot_create_group_navigation_state(self) -> None:
         service = self.make_service()
         await self.insert_indexed(service, self.summary_memory())
         rule = await service.store.upsert_acl_rule(
@@ -324,7 +326,9 @@ class ActiveReconstructionTests(unittest.IsolatedAsyncioTestCase):
         await service.store.delete_acl_rule(rule["id"])
         revoked = await service.tool_navigate(event, "reverse_cues", memory_ids=["summary-1"])
 
-        self.assertEqual("evidence_found", first["status"])
+        self.assertEqual("no_visible_evidence", first["status"])
+        self.assertEqual([], first["evidence"])
+        self.assertEqual([], first["navigation_hints"])
         self.assertEqual("no_visible_evidence", revoked["status"])
         self.assertEqual([], revoked["evidence"])
         self.assertEqual([], revoked["navigation_hints"])

--- a/tests/test_c1_bridge_probe.py
+++ b/tests/test_c1_bridge_probe.py
@@ -44,13 +44,15 @@ class C1BridgeProbeTests(unittest.TestCase):
         self.assertEqual(list(bot_personal_contract.WINDOW_SLUGS), result["windows"])
         self.assertEqual(list(bot_personal_contract.BOT_PERSONAL_MEMORY_TYPES), result["memory_types"])
         self.assertEqual(bot_personal_contract.BOT_PERSONAL_MAX_PAYLOAD_BYTES, result["max_payload_bytes"])
+        self.assertEqual({"state": "unprobed", "error_code": "p5_status_not_probed"}, result["p5"])
 
     def test_probe_returns_stable_degraded_shape_when_contract_self_check_fails(self) -> None:
         with patch.object(bot_personal_contract, "contract_self_check", return_value=["contract_fingerprint_stale: hidden"]):
             result = MemoryCompanionBridge(_PluginMustNotBeTouched()).probe_bot_personal_memory_capabilities()
 
         self.assertFalse(result["available"])
-        self.assertEqual("degraded", result["state"])
+        self.assertEqual("negative", result["state"])
+        self.assertEqual("negative", result["capability_state"])
         self.assertTrue(result["degraded"])
         self.assertIn("contract_self_check_failed", result["warnings"])
         self.assertIn("contract_fingerprint_stale", result["warnings"])
@@ -65,7 +67,8 @@ class C1BridgeProbeTests(unittest.TestCase):
             result = MemoryCompanionBridge(_PluginMustNotBeTouched()).probe_bot_personal_memory_capabilities()
 
         self.assertFalse(result["available"])
-        self.assertEqual("degraded", result["state"])
+        self.assertEqual("negative", result["state"])
+        self.assertEqual("negative", result["capability_state"])
         self.assertTrue(result["degraded"])
         self.assertEqual(["contract_self_check_exception"], result["warnings"])
         for secret in ("raw prompt", "user identity", "database object"):

--- a/tests/test_c1_bridge_probe.py
+++ b/tests/test_c1_bridge_probe.py
@@ -17,6 +17,8 @@ if str(ROOT.parent) not in sys.path:
 
 from astrabot_plugin_remember_you.core import bot_personal_contract
 from astrabot_plugin_remember_you.core.bridge import MemoryCompanionBridge
+from astrabot_plugin_remember_you.core.config import ConfigView
+from astrabot_plugin_remember_you.core.service import MemoryCompanionService
 
 
 class _PluginMustNotBeTouched:
@@ -68,3 +70,17 @@ class C1BridgeProbeTests(unittest.TestCase):
         self.assertEqual(["contract_self_check_exception"], result["warnings"])
         for secret in ("raw prompt", "user identity", "database object"):
             self.assertNotIn(secret, str(result))
+
+    def test_official_bridge_switch_is_not_overridden_by_legacy_flat_flag(self) -> None:
+        service = object.__new__(MemoryCompanionService)
+        service.config = ConfigView(
+            {
+                "enable_memory_companion_bridge": True,
+                "private_companion_bridge": {"enabled": False},
+            }
+        )
+
+        status = service.companion_coordination_status()
+
+        self.assertFalse(status["bridge_enabled"])
+        self.assertEqual("local_only", status["state"])

--- a/tests/test_c1_bridge_probe.py
+++ b/tests/test_c1_bridge_probe.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if "astrabot_plugin_remember_you" not in sys.modules:
+    package = types.ModuleType("astrabot_plugin_remember_you")
+    package.__path__ = [str(ROOT)]
+    sys.modules["astrabot_plugin_remember_you"] = package
+if str(ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(ROOT.parent))
+
+from astrabot_plugin_remember_you.core import bot_personal_contract
+from astrabot_plugin_remember_you.core.bridge import MemoryCompanionBridge
+
+
+class _PluginMustNotBeTouched:
+    def __getattr__(self, name: str):
+        raise AssertionError(f"probe touched plugin capability: {name}")
+
+
+class C1BridgeProbeTests(unittest.TestCase):
+    def test_probe_returns_ready_contract_snapshot_without_plugin_or_database_access(self) -> None:
+        result = MemoryCompanionBridge(_PluginMustNotBeTouched()).probe_bot_personal_memory_capabilities()
+
+        self.assertTrue(result["available"])
+        self.assertFalse(result["read_only"])
+        self.assertEqual("ready", result["state"])
+        self.assertFalse(result["degraded"])
+        self.assertEqual([], result["warnings"])
+        self.assertEqual(bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN, result["memory_domain"])
+        self.assertEqual(bot_personal_contract.CONTRACT_NAME, result["contract_name"])
+        self.assertEqual(bot_personal_contract.CONTRACT_REVISION, result["contract_revision"])
+        self.assertEqual(bot_personal_contract.CONTRACT_FINGERPRINT, result["contract_fingerprint"])
+        self.assertEqual(bot_personal_contract.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION, result["capability_schema_version"])
+        self.assertEqual(bot_personal_contract.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION, result["payload_schema_version"])
+        self.assertEqual(list(bot_personal_contract.WINDOW_SLUGS), result["windows"])
+        self.assertEqual(list(bot_personal_contract.BOT_PERSONAL_MEMORY_TYPES), result["memory_types"])
+        self.assertEqual(bot_personal_contract.BOT_PERSONAL_MAX_PAYLOAD_BYTES, result["max_payload_bytes"])
+
+    def test_probe_returns_stable_degraded_shape_when_contract_self_check_fails(self) -> None:
+        with patch.object(bot_personal_contract, "contract_self_check", return_value=["contract_fingerprint_stale: hidden"]):
+            result = MemoryCompanionBridge(_PluginMustNotBeTouched()).probe_bot_personal_memory_capabilities()
+
+        self.assertFalse(result["available"])
+        self.assertEqual("degraded", result["state"])
+        self.assertTrue(result["degraded"])
+        self.assertIn("contract_self_check_failed", result["warnings"])
+        self.assertIn("contract_fingerprint_stale", result["warnings"])
+        self.assertNotIn("hidden", result["warnings"])
+
+    def test_probe_converts_contract_check_exception_to_degraded_result(self) -> None:
+        with patch.object(
+            bot_personal_contract,
+            "contract_self_check",
+            side_effect=RuntimeError("raw prompt, user identity, session content, database object"),
+        ):
+            result = MemoryCompanionBridge(_PluginMustNotBeTouched()).probe_bot_personal_memory_capabilities()
+
+        self.assertFalse(result["available"])
+        self.assertEqual("degraded", result["state"])
+        self.assertTrue(result["degraded"])
+        self.assertEqual(["contract_self_check_exception"], result["warnings"])
+        for secret in ("raw prompt", "user identity", "database object"):
+            self.assertNotIn(secret, str(result))

--- a/tests/test_c1_contract.py
+++ b/tests/test_c1_contract.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if "astrabot_plugin_remember_you" not in sys.modules:
+    package = types.ModuleType("astrabot_plugin_remember_you")
+    package.__path__ = [str(ROOT)]
+    sys.modules["astrabot_plugin_remember_you"] = package
+if str(ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(ROOT.parent))
+
+from astrabot_plugin_remember_you.core import bot_personal_contract as contract
+
+
+class C1ContractTests(unittest.TestCase):
+    def test_frozen_contract_values_and_self_check(self) -> None:
+        self.assertEqual("5b8a97c1527dcc62", contract.CONTRACT_FINGERPRINT)
+        self.assertEqual(1, contract.CONTRACT_REVISION)
+        self.assertEqual("1.1", contract.BOT_PERSONAL_CAPABILITY_SCHEMA_VERSION)
+        self.assertEqual("1.0", contract.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION)
+        self.assertEqual("bot_self_schedule", contract.BOT_PERSONAL_MEMORY_DOMAIN)
+        self.assertEqual(12, len(contract.BOT_PERSONAL_MEMORY_TYPES))
+        self.assertEqual(set(contract.TYPE_CONTRACTS), set(contract.BOT_PERSONAL_MEMORY_TYPES))
+        self.assertEqual([], contract.contract_self_check())
+        self.assertEqual(contract.CONTRACT_FINGERPRINT, contract.compute_contract_fingerprint())
+
+    def test_five_window_boundaries_and_midnight_wrap(self) -> None:
+        expected = {
+            0: "late_night",
+            359: "late_night",
+            360: "morning",
+            659: "morning",
+            660: "noon",
+            869: "noon",
+            870: "afternoon",
+            1079: "afternoon",
+            1080: "evening",
+            1259: "evening",
+            1260: "late_night",
+            1439: "late_night",
+        }
+        for minutes, slug in expected.items():
+            self.assertEqual(slug, contract.window_for_minutes(minutes))
+        self.assertEqual("late_night", contract.window_for_minutes(-1))
+        self.assertEqual("late_night", contract.window_for_minutes(24 * 60))
+
+    def test_normalize_window_and_legacy_migration_never_guesses_without_timestamp(self) -> None:
+        self.assertEqual("morning", contract.normalize_window(" MORNING "))
+        self.assertEqual("late_night", contract.normalize_window("凌晨"))
+        self.assertEqual("", contract.normalize_window("unknown"))
+        self.assertEqual("late_night", contract.migrate_legacy_window("late_night"))
+        self.assertEqual("", contract.migrate_legacy_window("morning"))
+        self.assertEqual("", contract.migrate_legacy_window("afternoon"))
+        self.assertEqual("", contract.migrate_legacy_window("evening"))
+        self.assertEqual("noon", contract.migrate_legacy_window("morning", 11 * 60))
+
+    def test_descriptor_fields_are_self_consistent(self) -> None:
+        descriptor = contract.capability_descriptor()
+        self.assertTrue(descriptor["available"])
+        self.assertFalse(descriptor["read_only"])
+        self.assertEqual("5b8a97c1527dcc62", descriptor["contract_fingerprint"])
+        self.assertEqual(1, descriptor["contract_revision"])
+        self.assertEqual("1.1", descriptor["capability_schema_version"])
+        self.assertEqual("1.0", descriptor["payload_schema_version"])
+        self.assertEqual("bot_self_schedule", descriptor["memory_domain"])
+        self.assertEqual(list(contract.WINDOW_SLUGS), descriptor["windows"])
+        self.assertEqual(12, len(descriptor["memory_types"]))

--- a/tests/test_c2_memory_consumer.py
+++ b/tests/test_c2_memory_consumer.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.context_consumer import consume_context_projection
+from core.person_context_contract import (
+    P3_SLOT_NAMES,
+    build_context_projection,
+    build_identity_key,
+    build_person_projection,
+    empty_person_store,
+    make_context_slot,
+    person_id_for_identity,
+)
+from core.person_projection import consume_person_projection
+
+
+IDENTITY = {
+    "companion_instance_id": "companion-test",
+    "bot_account_id": "bot-1",
+    "adapter_instance_id": "adapter-1",
+    "subject_namespace": "qq",
+    "platform_subject_id": "user-42",
+}
+
+
+def _projection():
+    store = {"unified_person": empty_person_store()}
+    person_id = person_id_for_identity(IDENTITY)
+    identity_key = build_identity_key(IDENTITY)
+    store["unified_person"]["profiles"][person_id] = {
+        "person_id": person_id,
+        "resolved_identity_key": identity_key,
+        "identity_assurance": "verified",
+        "profile_status": "active",
+        "display_name": "Alice",
+        "aliases": ["A"],
+        "owner_mode": "not_owner",
+        "affinity_score": 12,
+        "projection_revision": 3,
+        "relation_policy_id": "default_friend",
+        "group_overlay_ref": "",
+        "updated_at": "2026-07-30T00:00:00+00:00",
+    }
+    store["unified_person"]["identity_links"][identity_key] = {"person_id": person_id}
+    return build_person_projection(store, person_id), store, person_id, identity_key
+
+
+def _context(*, revision=4, person_id="person_abc", scope="private"):
+    slots = {
+        name: make_context_slot(
+            name,
+            {"person_id": person_id, "scope": scope, "label": name, "raw_prompt": "do not leak"},
+            revision=revision,
+        )
+        for name in P3_SLOT_NAMES
+    }
+    context = build_context_projection(slots, revision=revision)
+    context["person_id"] = person_id
+    context["scope"] = scope
+    return context
+
+
+class C2MemoryConsumerTests(unittest.TestCase):
+    def test_projection_is_resolved_and_only_returns_safe_reference(self) -> None:
+        projection, store, person_id, identity_key = _projection()
+        result = consume_person_projection(
+            projection,
+            expected_identity_key=identity_key,
+            expected_person_id=person_id,
+            identity_store=store,
+            identity=IDENTITY,
+        )
+        self.assertEqual("resolved", result["state"])
+        self.assertEqual(person_id, result["projection_ref"]["person_id"])
+        self.assertNotIn("display_name", result["projection_ref"])
+        self.assertTrue(result["read_only"])
+
+    def test_projection_rejects_version_fingerprint_and_expected_identity_mismatch(self) -> None:
+        projection, _, person_id, identity_key = _projection()
+        bad = deepcopy(projection)
+        bad["contract_fingerprint"] = "wrong"
+        self.assertEqual("invalid", consume_person_projection(bad)["state"])
+        self.assertIn("contract_fingerprint_mismatch", consume_person_projection(bad)["errors"])
+        mismatch = consume_person_projection(projection, "wrong", person_id)
+        self.assertEqual("invalid", mismatch["state"])
+        self.assertIn("identity_key_mismatch", mismatch["errors"])
+        self.assertEqual(
+            "invalid",
+            consume_person_projection(projection, identity_key, "person_000000000000000000000000")["state"],
+        )
+
+    def test_projection_unavailable_is_explicitly_degraded(self) -> None:
+        projection, _, _, _ = _projection()
+        result = consume_person_projection(projection, companion_available=False)
+        self.assertEqual("degraded", result["state"])
+        self.assertTrue(result["degraded"])
+
+    def test_context_consumes_four_owned_slots_and_strips_raw_text(self) -> None:
+        result = consume_context_projection(_context(), "person_abc", "private")
+        self.assertEqual("ready", result["state"])
+        self.assertEqual(set(P3_SLOT_NAMES), set(result["context_ref"]["slots"]))
+        for slot in result["context_ref"]["slots"].values():
+            self.assertNotIn("raw_prompt", slot["payload"])
+            self.assertTrue(slot["owner"])
+
+    def test_context_rejects_wrong_owner_and_domain_projection(self) -> None:
+        context = _context()
+        context["slots"]["person"]["owner"] = "companion"
+        result = consume_context_projection(context, "person_abc", "private")
+        self.assertEqual("invalid", result["state"])
+        self.assertIn("person", result["rejected_slots"])
+
+        context = _context(scope="group:one")
+        self.assertEqual("invalid", consume_context_projection(context, "person_abc", "group:two")["state"])
+
+    def test_context_deduplicates_by_revision_and_handles_legacy_or_bridge_degraded(self) -> None:
+        self.assertEqual("legacy_local", consume_context_projection(None)["state"])
+        self.assertEqual("degraded", consume_context_projection({}, companion_available=False)["state"])
+        newer_result = consume_context_projection(_context(revision=7), "person_abc", "private")
+        older_result = consume_context_projection(_context(revision=2), "person_abc", "private")
+        self.assertEqual(7, newer_result["context_ref"]["revision"])
+        self.assertEqual(2, older_result["context_ref"]["revision"])
+
+    def test_context_preserves_explicit_degraded_pending_and_invalid_states(self) -> None:
+        degraded = _context()
+        degraded["state"] = "degraded"
+        degraded["slots"]["runtime"]["state"] = "degraded"
+        self.assertEqual("degraded", consume_context_projection(degraded, "person_abc", "private")["state"])
+
+        pending = _context()
+        pending["state"] = "pending"
+        pending["slots"]["person"]["state"] = "pending"
+        self.assertEqual("pending", consume_context_projection(pending, "person_abc", "private")["state"])
+
+        invalid = _context()
+        invalid["slots"]["person"]["state"] = "invalid"
+        result = consume_context_projection(invalid, "person_abc", "private")
+        self.assertEqual("invalid", result["state"])
+        self.assertIn("person_state_invalid", result["errors"])

--- a/tests/test_c3_bot_personal.py
+++ b/tests/test_c3_bot_personal.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import tempfile
+
+from core.bot_personal_consumer import BotPersonalConsumer
+from core.bot_personal_contract import BOT_PERSONAL_MEMORY_DOMAIN, BOT_PERSONAL_MEMORY_TYPES, TYPE_CONTRACTS, WINDOW_SLUGS
+from core.bot_personal_dto import BotPersonalValidationError, build_bot_personal_archive
+from core.bridge import MemoryCompanionBridge
+from core.models import MemoryRecord
+from core.service import MemoryCompanionService
+from core.store import MemoryStore
+
+
+def envelope(index: str = "1", **overrides):
+    value = {
+        "memory_type": "bot_observed_activity",
+        "memory_domain": BOT_PERSONAL_MEMORY_DOMAIN,
+        "subject": "bot_self",
+        "date": "2026-07-30",
+        "window": "afternoon",
+        "occurred_at": "2026-07-30T15:00:00+08:00",
+        "source_kind": "wrong_input_is_corrected",
+        "source_refs": [f"companion:event:{index}"],
+        "certainty": 0.9,
+        "evidence_level": "L0",
+        "status": "wrong_input_is_corrected",
+        "version": 1,
+        "idempotency_key": f"c3:test:{index}",
+        "payload_schema_version": "1.0",
+        "payload": {"summary": "safe archive summary", "activity": "rest"},
+    }
+    value.update(overrides)
+    return value
+
+
+def make_service(tmp_path: Path):
+    service = object.__new__(MemoryCompanionService)
+    service.store = MemoryStore(tmp_path / "memory.db")
+    service.store.initialize()
+    service._schedule_memory_embedding = lambda *args, **kwargs: None
+    return service
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_contract_windows_and_types_are_imported_from_single_contract():
+    dto = build_bot_personal_archive(envelope())
+    assert tuple(WINDOW_SLUGS) == ("late_night", "morning", "noon", "afternoon", "evening")
+    assert set(BOT_PERSONAL_MEMORY_TYPES) == set(TYPE_CONTRACTS)
+    assert dto.window in WINDOW_SLUGS
+    assert dto.source_kind == TYPE_CONTRACTS[dto.memory_type][0]
+    assert dto.evidence_level == TYPE_CONTRACTS[dto.memory_type][1]
+
+
+def test_privacy_rejects_raw_prompt_credentials_binary_path_and_unsafe_key():
+    for update in (
+        {"payload": {"raw_prompt": "do not accept"}},
+        {"payload": {"auth_token": "secret-value"}},
+        {"payload": {"media_bytes": b"binary"}},
+        {"payload": {"photo": "C:\\private\\photo.png"}},
+        {"idempotency_key": "photo:C:\\private\\photo.png"},
+    ):
+        try:
+            build_bot_personal_archive({**envelope(), **update})
+        except BotPersonalValidationError as exc:
+            assert exc.error_code == "privacy_rejected"
+        else:
+            raise AssertionError("privacy input was accepted")
+
+    for update in (
+        {"source_refs": [{"token": "secret-value"}]},
+        {"idempotency_key": {"token": "secret-value"}},
+        {"record_id": "unexpected-record-id"},
+    ):
+        try:
+            build_bot_personal_archive({**envelope(), **update})
+        except BotPersonalValidationError as exc:
+            assert exc.error_code == "invalid"
+        else:
+            raise AssertionError("structured reference input was accepted")
+
+
+def test_service_success_idempotency_version_conflict_and_stale(tmp_path):
+    service = make_service(tmp_path)
+    try:
+        first = run(service.record_bot_personal_archive(envelope("same")))
+        duplicate = run(service.record_bot_personal_archive(envelope("same")))
+        conflict = run(service.record_bot_personal_archive(envelope("same", payload={"summary": "changed"})))
+        stale = run(service.record_bot_personal_archive(envelope("same", version=0)))
+        newer = run(service.record_bot_personal_archive(envelope("same", version=2, payload={"summary": "new"})))
+        assert first["ok"] and first["state"] == "sent"
+        assert duplicate["ok"] and duplicate["deduplicated"] and duplicate["state"] == "deduplicated"
+        assert conflict["error_code"] == "version_conflict"
+        assert stale["error_code"] == "invalid"
+        assert newer["ok"] and newer["version"] == 2
+        stored = run(service.store.get_memory(first["record_id"]))
+        assert stored.metadata["memory_domain"] == BOT_PERSONAL_MEMORY_DOMAIN
+        assert stored.metadata["subject"] == "bot_self"
+        assert stored.metadata["source_kind"] == TYPE_CONTRACTS["bot_observed_activity"][0]
+        assert stored.metadata["evidence_level"] == TYPE_CONTRACTS["bot_observed_activity"][1]
+    finally:
+        service.store.close()
+
+
+def test_bridge_missing_or_exception_degrades_and_consumer_dead_letters():
+    missing = run(MemoryCompanionBridge(object()).record_bot_personal_archive(envelope()))
+    assert missing["state"] == "degraded"
+    assert missing["error_code"] == "bridge_method_unavailable"
+
+    class Broken:
+        async def record_bot_personal_archive(self, _envelope):
+            raise RuntimeError("unavailable")
+
+    consumer = BotPersonalConsumer(MemoryCompanionBridge(Broken()), max_attempts=2)
+    first = run(consumer.consume_bot_personal_archive(envelope(), attempt=1))
+    last = run(consumer.consume_bot_personal_archive(envelope(), attempt=2))
+    assert first["state"] == "retry"
+    assert last["state"] == "dead_letter"
+
+    class BrokenLookup:
+        def __getattr__(self, _name):
+            raise RuntimeError("unavailable")
+
+    lookup_failure = run(
+        BotPersonalConsumer(BrokenLookup(), max_attempts=1).consume_bot_personal_archive(envelope())
+    )
+    assert lookup_failure["state"] == "dead_letter"
+    assert lookup_failure["error_code"] == "bridge_method_unavailable"
+
+
+def test_domain_isolation_and_read_only_profile_does_not_leak_payload(tmp_path):
+    service = make_service(tmp_path)
+    try:
+        bot = run(service.record_bot_personal_archive(envelope("bot")))
+        user = MemoryRecord(id="user-1", memory_type="user_fact", scope="private", session_id="private:user", visibility="private_pair", content="user record", metadata={"memory_domain": "user_memory"})
+        group = MemoryRecord(id="group-1", memory_type="group_memory", scope="group", session_id="group:g", visibility="group", content="group record", metadata={"memory_domain": "group_memory"})
+        run(service.store.insert_memory(user))
+        run(service.store.insert_memory(group))
+        profile = run(service.read_bot_personal_profile(limit=10))
+        assert profile["read_only"] is True
+        assert [item["record_id"] for item in profile["items"]] == [bot["record_id"]]
+        assert all("payload" not in item and "content" not in item for item in profile["items"])
+        assert "safe archive summary" not in str(profile)
+    finally:
+        service.store.close()
+
+
+def test_distinct_bot_personal_idempotency_keys_remain_distinct_rows(tmp_path):
+    service = make_service(tmp_path)
+    try:
+        first = run(service.record_bot_personal_archive(envelope("one")))
+        second = run(service.record_bot_personal_archive(envelope("two")))
+        assert first["record_id"] != second["record_id"]
+        profile = run(service.read_bot_personal_profile(limit=10))
+        assert {item["record_id"] for item in profile["items"]} == {first["record_id"], second["record_id"]}
+    finally:
+        service.store.close()
+
+
+def test_profile_drops_unsafe_legacy_source_references(tmp_path):
+    service = make_service(tmp_path)
+    try:
+        legacy = MemoryRecord(
+            id="legacy-bot-ref",
+            memory_type="bot_observed_activity",
+            scope="private",
+            session_id="bot_personal",
+            visibility="bot_self",
+            content="legacy bot record",
+            metadata={
+                "memory_domain": BOT_PERSONAL_MEMORY_DOMAIN,
+                "source_refs": ["Bearer leaked-token", "companion:event:safe"],
+                "payload": {"summary": "legacy summary"},
+            },
+        )
+        run(service.store.insert_memory(legacy))
+
+        profile = run(service.read_bot_personal_profile(limit=10))
+
+        item = next(value for value in profile["items"] if value["record_id"] == legacy.id)
+        assert item["source_refs"] == ["companion:event:safe"]
+        assert "leaked-token" not in str(profile)
+    finally:
+        service.store.close()

--- a/tests/test_c4_capability_probe.py
+++ b/tests/test_c4_capability_probe.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from core import bot_personal_contract
+from core.capability_probe import (
+    CAPABILITY_STATES,
+    PROFILE_NAMES,
+    CapabilityCache,
+    build_capability_snapshot,
+)
+
+
+def test_snapshot_uses_contract_fingerprint_windows_and_types():
+    snapshot = build_capability_snapshot()
+    assert snapshot["contract_fingerprint"] == bot_personal_contract.CONTRACT_FINGERPRINT
+    assert snapshot["windows"] == list(bot_personal_contract.WINDOW_SLUGS)
+    assert snapshot["memory_types"] == list(bot_personal_contract.BOT_PERSONAL_MEMORY_TYPES)
+    assert set(snapshot) == {
+        "available", "state", "degraded", "pending", "contract_fingerprint",
+        "contract_version", "schema_version", "windows", "memory_types", "domains",
+        "profiles", "methods", "warnings", "error_code",
+    }
+
+
+def test_initial_cache_is_unprobed_and_pending():
+    snapshot = CapabilityCache().snapshot()
+    assert snapshot["state"] == "unprobed"
+    assert snapshot["pending"] is True
+    assert snapshot["available"] is False
+
+
+def test_available_degraded_and_negative_states_are_observable():
+    cache = CapabilityCache()
+    available = cache.mark_available({"methods": ["search", "search"], "profiles": PROFILE_NAMES})
+    assert available["state"] == "available"
+    assert available["available"] is True
+    assert available["degraded"] is False
+
+    degraded = cache.mark_degraded("contract_invalid")
+    assert degraded["state"] == "degraded"
+    assert degraded["degraded"] is True
+    assert degraded["error_code"] == "contract_invalid"
+
+    negative = cache.mark_negative("bridge_missing")
+    assert negative["state"] == "negative"
+    assert negative["available"] is False
+    assert negative["pending"] is False
+    assert negative["degraded"] is True
+    assert negative["error_code"] == "bridge_missing"
+
+
+def test_negative_ttl_returns_to_unprobed_after_expiry():
+    now = [10.0]
+    cache = CapabilityCache(negative_ttl=5, clock=lambda: now[0])
+    cache.mark_negative("not_ready")
+    assert cache.snapshot()["state"] == "negative"
+    now[0] = 14.99
+    assert cache.snapshot()["state"] == "negative"
+    now[0] = 15.0
+    assert cache.snapshot()["state"] == "unprobed"
+
+
+def test_snapshot_is_a_deep_copy():
+    cache = CapabilityCache()
+    value = cache.snapshot()
+    value["windows"].append("mutated")
+    value["warnings"].append("mutated")
+    fresh = cache.snapshot()
+    assert "mutated" not in fresh["windows"]
+    assert "mutated" not in fresh["warnings"]
+
+
+def test_malformed_contract_module_is_safe():
+    class Broken:
+        def __getattribute__(self, _name):
+            raise RuntimeError("broken contract")
+
+    snapshot = build_capability_snapshot(
+        available=True,
+        contract_module=Broken(),
+        profiles=[*PROFILE_NAMES, "not-a-profile", "not-a-profile"],
+        methods=["search", "search", object()],
+    )
+    assert snapshot["state"] == "available"
+    assert snapshot["available"] is True
+    assert snapshot["profiles"] == list(PROFILE_NAMES)
+    assert all(isinstance(value, (str, int, float, bool, list, dict)) or value is None
+               for value in snapshot.values())
+
+
+def test_public_state_constants_are_closed():
+    assert set(CAPABILITY_STATES) == {"unprobed", "available", "degraded", "negative"}
+    assert len(PROFILE_NAMES) == 5
+    assert len(set(PROFILE_NAMES)) == 5

--- a/tests/test_c4_profile_api.py
+++ b/tests/test_c4_profile_api.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass, field
+
+from core.profile_api import PROFILE_MEMORY_TYPES, PROFILE_NAMES, build_profile_result
+
+
+@dataclass
+class Record:
+    id: str
+    memory_type: str
+    metadata: dict = field(default_factory=dict)
+    scope: str = "private"
+    visibility: str = "bot_self"
+    content: str = "RAW CONTENT MUST NOT ESCAPE"
+    evidence: str = "RAW EVIDENCE MUST NOT ESCAPE"
+    occurred_at: str = ""
+
+
+def rec(record_id, memory_type, *, date="2026-07-30", window="afternoon", domain="bot_self_schedule", **metadata):
+    data = {
+        "memory_domain": domain,
+        "date": date,
+        "window": window,
+        "occurred_at": f"{date}T15:00:00+08:00",
+        "source_kind": "observed",
+        "source_refs": [f"safe:{record_id}"],
+        "evidence_level": "L2",
+        "status": "active",
+        "version": 1,
+    }
+    data.update(metadata)
+    return Record(record_id, memory_type, data)
+
+
+def test_contract_exports_and_five_profiles_have_fixed_shape():
+    assert PROFILE_NAMES == (
+        "bot_schedule_current", "bot_schedule_history", "bot_creative",
+        "bot_subjective", "locked_frame_personal",
+    )
+    assert {
+        "bot_schedule_plan", "bot_observed_activity", "bot_schedule_reconciliation",
+        "bot_window_snapshot", "bot_daily_diary", "bot_creative_work", "bot_media_memory",
+        "bot_subjective_memory", "bot_shared_activity", "bot_detail_fragment",
+        "bot_calendar_event", "bot_proactive_message",
+    }.issubset(PROFILE_MEMORY_TYPES)
+    assert set(PROFILE_MEMORY_TYPES["bot_creative_work"]) == {"bot_creative", "locked_frame_personal"}
+    records = [
+        rec("plan", "bot_schedule_plan"), rec("creative", "bot_creative_work"),
+        rec("subjective", "bot_subjective_memory"),
+    ]
+    for profile in PROFILE_NAMES[:4]:
+        result = build_profile_result(records, profile, current_date="2026-07-30", current_window="afternoon")
+        assert set(result) == {"ok", "read_only", "state", "degraded", "pending", "profile", "items", "warnings"}
+        assert result["read_only"] is True
+
+
+def test_bot_user_group_isolation_and_bot_personal_flag():
+    records = [
+        rec("bot", "bot_observed_activity"),
+        rec("user", "bot_observed_activity", domain="user_memory"),
+        rec("group", "bot_observed_activity", domain="bot_self_schedule", scope="group", visibility="group"),
+        Record("flag", "bot_observed_activity", {"bot_personal": True, "date": "2026-07-30", "window": "afternoon"}),
+    ]
+    result = build_profile_result(records, "bot_schedule_current", current_date="2026-07-30", current_window="afternoon")
+    assert {item["record_id"] for item in result["items"]} == {"bot", "flag"}
+
+
+def test_current_and_history_partition_by_date_and_window():
+    records = [
+        rec("current", "bot_schedule_plan", date="2026-07-30", window="afternoon"),
+        rec("old-window", "bot_schedule_plan", date="2026-07-30", window="morning"),
+        rec("old-date", "bot_schedule_plan", date="2026-07-29", window="afternoon"),
+    ]
+    current = build_profile_result(records, "bot_schedule_current", current_date="2026-07-30", current_window="afternoon")
+    history = build_profile_result(records, "bot_schedule_history", current_date="2026-07-30", current_window="afternoon")
+    assert [item["record_id"] for item in current["items"]] == ["current"]
+    assert {item["record_id"] for item in history["items"]} == {"old-window", "old-date"}
+
+
+def test_locked_profile_requires_authorization_and_returns_all_bot_types_when_allowed():
+    records = [rec("creative", "bot_creative_work"), rec("subjective", "bot_subjective_memory")]
+    denied = build_profile_result(records, "locked_frame_personal", authorized=False)
+    allowed = build_profile_result(records, "locked_frame_personal", authorized=True)
+    assert denied["ok"] is False and denied["state"] == "forbidden" and denied["items"] == []
+    assert {item["record_id"] for item in allowed["items"]} == {"creative", "subjective"}
+
+
+def test_no_payload_content_or_evidence_leak_and_query_only_safe_fields():
+    record = rec("safe", "bot_creative_work", summary="SECRET PAYLOAD SHOULD NOT BE USED")
+    result = build_profile_result([record], "bot_creative", query="creative work")
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert set(item) == {
+        "record_id", "memory_domain", "memory_type", "subject", "date", "window", "occurred_at",
+        "source_kind", "source_refs", "evidence_level", "status", "version", "summary", "reference",
+    }
+    assert "RAW CONTENT" not in str(result)
+    assert "RAW EVIDENCE" not in str(result)
+    assert "SECRET PAYLOAD" not in str(result)
+    assert build_profile_result([record], "bot_creative", query="RAW CONTENT")["items"] == []
+
+
+def test_unknown_profile_limit_and_malformed_input_degrade_safely():
+    invalid = build_profile_result([], "unknown")
+    assert invalid["ok"] is False and invalid["state"] == "invalid"
+    assert len(build_profile_result([rec(str(i), "bot_creative_work") for i in range(120)], "bot_creative", limit=100)["items"]) == 100
+    assert len(build_profile_result([rec("one", "bot_creative_work")], "bot_creative", limit="bad")["items"]) == 1
+    malformed = build_profile_result(None, "bot_creative")
+    assert malformed["state"] == "ready" and malformed["items"] == []
+    malformed_records = build_profile_result(42, "bot_creative")
+    assert malformed_records["state"] == "degraded" and malformed_records["ok"] is True

--- a/tests/test_c4_service_profile.py
+++ b/tests/test_c4_service_profile.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from core.bridge import MemoryCompanionBridge
+from core.models import MemoryRecord
+from core.service import MemoryCompanionService
+from core.store import MemoryStore
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_service(tmp_path: Path):
+    service = object.__new__(MemoryCompanionService)
+    service.store = MemoryStore(tmp_path / "memory.db")
+    service.store.initialize()
+    service._schedule_memory_embedding = lambda *args, **kwargs: None
+    return service
+
+
+def envelope(memory_type: str, key: str, *, date: str = "2026-07-30", window: str = "afternoon"):
+    return {
+        "memory_type": memory_type,
+        "date": date,
+        "window": window,
+        "occurred_at": f"{date}T15:00:00+08:00",
+        "source_refs": [f"companion:c4:{key}"],
+        "idempotency_key": f"c4:{key}",
+        "payload": {"summary": "private raw payload must stay hidden", "topic": key},
+    }
+
+
+def test_service_profiles_partition_domains_and_hide_raw_fields(tmp_path):
+    service = make_service(tmp_path)
+    try:
+        current = run(service.record_bot_personal_archive(envelope("bot_schedule_plan", "current")))
+        old_window = run(service.record_bot_personal_archive(envelope("bot_schedule_plan", "old-window", window="morning")))
+        old_date = run(service.record_bot_personal_archive(envelope("bot_schedule_plan", "old-date", date="2026-07-29")))
+        creative = run(service.record_bot_personal_archive(envelope("bot_creative_work", "creative")))
+        subjective = run(service.record_bot_personal_archive(envelope("bot_subjective_memory", "subjective")))
+
+        run(service.store.insert_memory(MemoryRecord(
+            id="user-leak",
+            memory_type="bot_creative_work",
+            scope="private",
+            session_id="bot_personal",
+            visibility="bot_self",
+            content="raw user content",
+            metadata={"memory_domain": "user_memory", "bot_personal": True},
+        )))
+        run(service.store.insert_memory(MemoryRecord(
+            id="group-leak",
+            memory_type="bot_creative_work",
+            scope="group",
+            session_id="bot_personal",
+            visibility="group",
+            content="raw group content",
+            metadata={"memory_domain": "bot_self_schedule", "bot_personal": True},
+        )))
+
+        current_profile = run(service.read_bot_profile(
+            "bot_schedule_current",
+            current_date="2026-07-30",
+            current_window="afternoon",
+        ))
+        history_profile = run(service.read_bot_profile(
+            "bot_schedule_history",
+            current_date="2026-07-30",
+            current_window="afternoon",
+        ))
+        creative_profile = run(service.read_bot_profile("bot_creative", query="creative"))
+        subjective_profile = run(service.read_bot_profile("bot_subjective"))
+        locked_denied = run(service.read_bot_profile("locked_frame_personal"))
+        locked_allowed = run(service.read_bot_profile("locked_frame_personal", authorized=True))
+        unsafe_query = run(service.read_bot_profile("bot_creative", query="C:\\private\\secret.txt"))
+
+        assert [item["record_id"] for item in current_profile["items"]] == [current["record_id"]]
+        assert {item["record_id"] for item in history_profile["items"]} == {old_window["record_id"], old_date["record_id"]}
+        assert [item["record_id"] for item in creative_profile["items"]] == [creative["record_id"]]
+        assert [item["record_id"] for item in subjective_profile["items"]] == [subjective["record_id"]]
+        assert locked_denied["state"] == "forbidden" and locked_denied["items"] == []
+        assert {item["record_id"] for item in locked_allowed["items"]} == {
+            current["record_id"], old_window["record_id"], old_date["record_id"],
+            creative["record_id"], subjective["record_id"],
+        }
+        assert unsafe_query["items"] == []
+        assert "unsafe_query_rejected" in unsafe_query["warnings"]
+        for result in (current_profile, history_profile, creative_profile, subjective_profile, locked_allowed):
+            for item in result["items"]:
+                assert "payload" not in item and "content" not in item and "evidence" not in item
+                assert "private raw payload" not in str(item)
+        assert "user-leak" not in str(locked_allowed)
+        assert "group-leak" not in str(locked_allowed)
+    finally:
+        service.store.close()
+
+
+def test_bridge_profile_and_capability_compatibility(tmp_path):
+    service = make_service(tmp_path)
+    try:
+        run(service.record_bot_personal_archive(envelope("bot_creative_work", "bridge")))
+        bridge = MemoryCompanionBridge(service)
+        snapshot = bridge.probe_capability_snapshot()
+        legacy = bridge.probe_bot_personal_memory_capabilities()
+        profile = run(bridge.read_bot_profile("bot_creative", query="bridge"))
+        missing = run(MemoryCompanionBridge(object()).read_bot_profile("bot_creative"))
+
+        assert snapshot["state"] == "available"
+        assert snapshot["capability_state"] == "available"
+        assert snapshot["profiles"] == [
+            "bot_schedule_current", "bot_schedule_history", "bot_creative",
+            "bot_subjective", "locked_frame_personal",
+        ]
+        assert legacy["state"] == "ready"
+        assert legacy["capability_state"] == "available"
+        assert profile["ok"] and profile["read_only"] is True
+        assert len(profile["items"]) == 1
+        assert missing["state"] == "degraded"
+        assert missing["error_code"] == "bridge_method_unavailable"
+    finally:
+        service.store.close()

--- a/tests/test_c5_bridge_gate.py
+++ b/tests/test_c5_bridge_gate.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from pathlib import Path
+import tempfile
+import unittest
+
+from core.config import ConfigView
+from core.provenance import (
+    ATTESTATION_SCHEMA_VERSION,
+    COMPANION_ATTESTATION_ISSUER,
+    P3_CONTRACT_FINGERPRINT,
+    P3_CONTRACT_NAME,
+    P3_CONTRACT_VERSION,
+    PROVENANCE_CONTRACT_NAME,
+    PROVENANCE_CONTRACT_VERSION,
+    contract_fingerprint,
+)
+from core.provenance_store import ProvenanceLedger
+from core.service import MemoryCompanionService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_service(*, bridge_gate: bool = True, recall_gate: bool = True):
+    service = object.__new__(MemoryCompanionService)
+    service.config = ConfigView(
+        {
+            "private_companion_bridge": {
+                "enable_p5_b1_bridge_gate": bridge_gate,
+                "enable_p5_b1_recall_gate": recall_gate,
+            }
+        }
+    )
+    service._last_p5_gate_status = {}
+    return service
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def mint(*, source_kind="current_user_intent", trust="T2", disposition="allow", sink="bridge_serialization"):
+    """Provide a self-contained opaque, one-shot attestation consumer.
+
+    The Memory side must only consume an opaque handle and inspect the returned
+    redacted snapshot.  This fixture exercises that boundary without depending
+    on a sibling plugin path in the repository test environment.
+    """
+
+    handle = object()
+    consumed = False
+    snapshot = {
+        "schema_version": ATTESTATION_SCHEMA_VERSION,
+        "contract_name": PROVENANCE_CONTRACT_NAME,
+        "contract_version": PROVENANCE_CONTRACT_VERSION,
+        "contract_fingerprint": contract_fingerprint(),
+        "issuer": COMPANION_ATTESTATION_ISSUER,
+        "issuer_epoch": _hash("issuer-epoch"),
+        "p3_contract_name": P3_CONTRACT_NAME,
+        "p3_contract_version": P3_CONTRACT_VERSION,
+        "p3_contract_fingerprint": P3_CONTRACT_FINGERPRINT,
+        "source_kind": source_kind,
+        "source_trust": trust,
+        "firewall_status": "allowed",
+        "disposition": disposition,
+        "reason_codes": ("evidence_only_nonexecuting",) if disposition == "allow" else ("untrusted_source_shadowed", "p5_nonexecuting"),
+        "source_event_ref_hash": _hash("source-event"),
+        "authority_attestation_ref_hash": _hash("authority-attestation"),
+        "request_hash": _hash("request"),
+        "session_hash": _hash("session"),
+        "derived_from_ref_hash": "",
+        "provenance_state": "observed",
+        "sink": sink,
+    }
+
+    def consume(candidate, requested_sink):
+        nonlocal consumed
+        if candidate is not handle or consumed or requested_sink != sink:
+            return None
+        consumed = True
+        return dict(snapshot)
+
+    return handle, consume
+
+
+class C5BridgeGateTests(unittest.TestCase):
+    def test_bridge_gate_accepts_current_user_attestation_and_rejects_replay(self):
+        service = make_service()
+        handle, consumer = mint()
+        allowed = run(service._p5_gate(sink="bridge_serialization", attestation=handle, consumer=consumer))
+        replay = run(service._p5_gate(sink="bridge_serialization", attestation=handle, consumer=consumer))
+        self.assertTrue(allowed["ok"])
+        self.assertEqual(allowed["state"], "allowed")
+        self.assertFalse(replay["ok"])
+        self.assertEqual(replay["error_code"], "p5_attestation_invalid")
+
+    def test_shadow_source_is_not_allowed_to_expand_recall(self):
+        service = make_service()
+        handle, consumer = mint(
+            source_kind="forwarded_text",
+            trust="T3",
+            disposition="shadow_quarantine",
+        )
+        result = run(service._p5_gate(sink="bridge_serialization", attestation=handle, consumer=consumer))
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["state"], "shadow")
+
+    def test_disabled_gate_preserves_legacy_behavior(self):
+        service = make_service(bridge_gate=False, recall_gate=False)
+        result = run(service._p5_gate(sink="memory_recall"))
+        self.assertEqual(result, {"ok": True, "state": "legacy", "legacy": True, "enabled": False})
+
+    def test_ledger_preview_apply_backup_and_cas_rollback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            ledger = ProvenanceLedger(Path(directory) / "provenance_ledger.json")
+            preview = ledger.preview_legacy(
+                [{"memory_id": "memory-1", "record_revision": 0}],
+                operation_ref_hash="d" * 64,
+            )
+            self.assertTrue(preview["readonly"])
+            self.assertEqual(preview["write_count"], 0)
+            operation = preview["operations"][0]
+            applied = ledger.apply(operation)
+            self.assertTrue(applied["ok"])
+            self.assertEqual(applied["status"], "applied")
+            self.assertTrue(ledger.backup()["created"])
+            self.assertEqual(ledger.snapshot()["records"]["memory-1"]["provenance_state"], "legacy_unresolved")
+            conflict = ledger.rollback({**operation, "after_record_digest": "e" * 64})
+            self.assertFalse(conflict["ok"])
+            rolled_back = ledger.rollback(operation)
+            self.assertTrue(rolled_back["ok"])
+            self.assertEqual(rolled_back["status"], "rolled_back")
+
+    def test_dual_plugin_snapshot_is_recorded_without_raw_payload(self):
+        service = make_service(bridge_gate=True, recall_gate=False)
+        with tempfile.TemporaryDirectory() as directory:
+            service.provenance_ledger = ProvenanceLedger(Path(directory) / "provenance_ledger.json")
+            handle, consumer = mint()
+            gate = run(service._p5_gate(sink="bridge_serialization", attestation=handle, consumer=consumer))
+            result = run(service._p5_record_observed(["memory-1"], gate["snapshot"]))
+            snapshot = service.provenance_snapshot()
+            self.assertTrue(result["ok"])
+            self.assertEqual(snapshot["records"]["memory-1"]["provenance_state"], "observed")
+            self.assertNotIn("content", str(snapshot))
+            self.assertNotIn("prompt", str(snapshot))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_c5_provenance.py
+++ b/tests/test_c5_provenance.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import unittest
+
+from core.provenance import (
+    ATTESTATION_SCHEMA_VERSION,
+    COMPANION_ATTESTATION_ISSUER,
+    P3_CONTRACT_FINGERPRINT,
+    P3_CONTRACT_NAME,
+    P3_CONTRACT_VERSION,
+    PROVENANCE_CONTRACT_NAME,
+    PROVENANCE_CONTRACT_VERSION,
+    apply_planned_operation,
+    contract_descriptor,
+    contract_fingerprint,
+    legacy_unresolved,
+    observed_from_companion_snapshot,
+    plan_legacy_migration,
+    rollback_planned_operation,
+    validate_provenance_record,
+)
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _snapshot(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": ATTESTATION_SCHEMA_VERSION,
+        "contract_name": PROVENANCE_CONTRACT_NAME,
+        "contract_version": PROVENANCE_CONTRACT_VERSION,
+        "contract_fingerprint": contract_fingerprint(),
+        "issuer": COMPANION_ATTESTATION_ISSUER,
+        "issuer_epoch": _hash("issuer-epoch"),
+        "p3_contract_name": P3_CONTRACT_NAME,
+        "p3_contract_version": P3_CONTRACT_VERSION,
+        "p3_contract_fingerprint": P3_CONTRACT_FINGERPRINT,
+        "source_kind": "forwarded_text",
+        "source_trust": "T3",
+        "firewall_status": "sanitized",
+        "disposition": "shadow_quarantine",
+        "reason_codes": ("p5b_attested",),
+        "source_event_ref_hash": _hash("source-event"),
+        "authority_attestation_ref_hash": _hash("authority-attestation"),
+        "request_hash": _hash("request"),
+        "session_hash": _hash("session"),
+        "derived_from_ref_hash": "",
+        "provenance_state": "observed",
+        "sink": "memory_recall",
+    }
+    value.update(overrides)
+    return value
+
+
+class C5ProvenanceTests(unittest.TestCase):
+    def test_descriptor_fingerprint_is_closed_and_stable(self) -> None:
+        descriptor = contract_descriptor()
+        canonical = json.dumps(descriptor, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+        self.assertEqual(_hash(canonical), contract_fingerprint())
+        self.assertEqual(13, len(descriptor["record_fields"]))
+        json.dumps(descriptor, ensure_ascii=True)
+
+    def test_legacy_unresolved_is_conservative_and_valid(self) -> None:
+        record = legacy_unresolved("memory-42", record_revision=4)
+        self.assertEqual("legacy_unresolved", record["provenance_state"])
+        self.assertEqual(("unknown", "T4", "unknown"), (record["source_kind"], record["source_trust"], record["firewall_status"]))
+        self.assertTrue(validate_provenance_record(record)["ok"])
+
+    def test_valid_snapshot_becomes_observed_and_invalid_snapshot_is_safe(self) -> None:
+        record = observed_from_companion_snapshot("memory-42", _snapshot(), record_revision=7)
+        self.assertEqual("observed", record["provenance_state"])
+        self.assertTrue(validate_provenance_record(record)["ok"])
+        self.assertEqual(_hash("source-event"), record["source_event_ref_hash"])
+
+        invalid = observed_from_companion_snapshot("memory-42", _snapshot(source_trust="T9"))
+        self.assertEqual("invalid", invalid["provenance_state"])
+        invalid = observed_from_companion_snapshot("memory-42", _snapshot(content="raw prose"))
+        self.assertEqual("invalid", invalid["provenance_state"])
+
+    def test_record_and_preview_reject_raw_fields_without_echoing_them(self) -> None:
+        record = legacy_unresolved("memory-42")
+        record["content"] = "do not retain this"
+        result = validate_provenance_record(record)
+        rendered = json.dumps(result, ensure_ascii=False, sort_keys=True)
+        self.assertFalse(result["ok"])
+        self.assertIn("forbidden_raw_field", result["error_codes"])
+        self.assertNotIn("do not retain this", rendered)
+
+        hostile = [{"memory_id": "memory-secret", "record_revision": 0, "prompt": "secret prompt"}]
+        preview = plan_legacy_migration(hostile, operation_ref_hash=_hash("migration"))
+        self.assertEqual([], preview["operations"])
+        self.assertNotIn("secret prompt", json.dumps(preview, ensure_ascii=False))
+
+    def test_preview_is_immutable_and_apply_returns_a_new_record(self) -> None:
+        source = [{"memory_id": "memory-42", "record_revision": 4}]
+        before = copy.deepcopy(source)
+        preview = plan_legacy_migration(source, operation_ref_hash=_hash("migration-42"))
+        self.assertEqual(before, source)
+        self.assertEqual(("preview", True, 0), (preview["mode"], preview["readonly"], preview["write_count"]))
+        operation = preview["operations"][0]
+        applied = apply_planned_operation({"memory_id": "memory-42", "record_revision": 4}, operation)
+        self.assertEqual((True, "applied", True), (applied["ok"], applied["status"], applied["changed"]))
+        self.assertIsNot(applied["record"], operation["after_record"])
+
+    def test_apply_is_idempotent_and_rollback_uses_cas(self) -> None:
+        operation = plan_legacy_migration(
+            [{"memory_id": "memory-42", "record_revision": 4}], operation_ref_hash=_hash("migration-42")
+        )["operations"][0]
+        applied = apply_planned_operation({"memory_id": "memory-42", "record_revision": 4}, operation)
+        retry = apply_planned_operation(applied["record"], operation)
+        self.assertEqual((True, "idempotent", False), (retry["ok"], retry["status"], retry["changed"]))
+
+        concurrent = copy.deepcopy(applied["record"])
+        concurrent["record_revision"] += 1
+        conflict = rollback_planned_operation(concurrent, operation)
+        self.assertEqual((False, "revision_conflict"), (conflict["ok"], conflict["status"]))
+
+        rolled_back = rollback_planned_operation(applied["record"], operation)
+        self.assertEqual((True, "rolled_back", True), (rolled_back["ok"], rolled_back["status"], rolled_back["removed"]))
+        self.assertIsNone(rolled_back["record"])
+
+    def test_owner_recovery_is_preview_only_and_requires_attested_snapshot(self) -> None:
+        legacy = legacy_unresolved("memory-42", record_revision=2)
+        from core.provenance import plan_owner_recovery
+
+        planned = plan_owner_recovery(legacy, _snapshot(), recovery_operation_ref_hash=_hash("recovery"))
+        self.assertTrue(planned["ok"])
+        self.assertEqual("owner_recovered", planned["operation"]["after_record"]["provenance_state"])
+        rejected = plan_owner_recovery(
+            legacy, _snapshot(p3_contract_fingerprint=_hash("wrong-p3")), recovery_operation_ref_hash=_hash("recovery-2")
+        )
+        self.assertEqual(["companion_snapshot_invalid"], rejected["error_codes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_c6_dual_plugin_boundary.py
+++ b/tests/test_c6_dual_plugin_boundary.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from core import bot_personal_contract
+from core.bridge import MemoryCompanionBridge
+from core.capability_probe import CapabilityCache, build_capability_snapshot
+from core.models import MemoryRecord
+from core.service import MemoryCompanionService
+from core.store import MemoryStore
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def archive(index: str = "1", **overrides):
+    value = {
+        "memory_type": "bot_observed_activity",
+        "memory_domain": bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN,
+        "subject": "bot_self",
+        "date": "2026-07-30",
+        "window": "afternoon",
+        "occurred_at": "2026-07-30T15:00:00+08:00",
+        "source_kind": "observed",
+        "source_refs": [f"companion:event:{index}"],
+        "certainty": 0.9,
+        "evidence_level": "L2",
+        "status": "active",
+        "version": 1,
+        "idempotency_key": f"c6:test:{index}",
+        "payload_schema_version": bot_personal_contract.BOT_PERSONAL_PAYLOAD_SCHEMA_VERSION,
+        "payload": {"summary": "safe archive summary", "activity": "rest"},
+    }
+    value.update(overrides)
+    return value
+
+
+class _Recorder:
+    def __init__(self, result=None):
+        self.calls = []
+        self.result = result or {"ok": True, "record_id": "c6-record", "version": 1}
+
+    async def record_external_event(self, **kwargs):
+        self.calls.append(kwargs)
+        return "external-record"
+
+    async def record_bot_personal_archive(self, dto):
+        self.calls.append(dto)
+        return self.result
+
+
+class _ProfileProvider:
+    async def read_bot_personal_profile(self, **_kwargs):
+        return {
+            "ok": True,
+            "state": "ready",
+            "items": [
+                {
+                    "record_id": "bot-1",
+                    "memory_domain": bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN,
+                    "memory_type": "bot_observed_activity",
+                    "summary": "safe summary",
+                    "payload": {"secret": "must not cross"},
+                    "content": "raw content must not cross",
+                }
+            ],
+        }
+
+
+class C6DualPluginBoundaryTests(unittest.TestCase):
+    def test_capability_probe_exposes_contract_domain_version_types_and_pending(self):
+        bridge = MemoryCompanionBridge(object())
+        pending = bridge.capability_status()
+        self.assertEqual("unprobed", pending["capability_state"])
+        self.assertTrue(pending["pending"])
+        self.assertFalse(pending["available"])
+
+        snapshot = bridge.probe_capability_snapshot()
+        self.assertEqual("available", snapshot["capability_state"])
+        self.assertTrue(snapshot["available"])
+        self.assertFalse(snapshot["degraded"])
+        self.assertEqual(bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN, snapshot["domain"])
+        self.assertEqual(str(bot_personal_contract.CONTRACT_REVISION), snapshot["contract_version"])
+        self.assertEqual(
+            list(bot_personal_contract.BOT_PERSONAL_MEMORY_TYPES), snapshot["memory_types"]
+        )
+        self.assertEqual(list(bot_personal_contract.WINDOW_SLUGS), snapshot["windows"])
+        self.assertIn("record_bot_personal_archive", snapshot["methods"])
+
+    def test_missing_contract_metadata_is_bounded_and_degraded(self):
+        snapshot = build_capability_snapshot(
+            contract_module=object(), state="degraded", warnings=["contract_missing"], error_code="bridge_missing"
+        )
+        self.assertEqual("degraded", snapshot["state"])
+        self.assertTrue(snapshot["degraded"])
+        self.assertFalse(snapshot["pending"])
+        self.assertEqual("bridge_missing", snapshot["error_code"])
+        self.assertEqual([], snapshot["domains"])
+        self.assertEqual([], snapshot["memory_types"])
+        self.assertEqual(["contract_missing"], snapshot["warnings"])
+        self.assertTrue(all(isinstance(value, (str, bool, list, dict)) for value in snapshot.values()))
+
+    def test_compatibility_writes_keep_bot_user_and_group_contexts_separate(self):
+        recorder = _Recorder()
+        bridge = MemoryCompanionBridge(recorder)
+
+        run(bridge.record_creative_work(content="C6 creative", session_id="bot:creative"))
+        run(
+            bridge.record_event(
+                content="user fact",
+                memory_type="user_fact",
+                scope="private",
+                session_id="private:user-1",
+                visibility="private_pair",
+                reality_level="real_user_fact",
+                subject={"kind": "user", "id": "user-1", "role": "current_sender"},
+            )
+        )
+        run(
+            bridge.record_event(
+                content="group fact",
+                memory_type="group_memory",
+                scope="group",
+                session_id="group:42",
+                group_id="42",
+                visibility="group_public",
+                reality_level="observed_utterance",
+                subject={"kind": "user", "id": "user-2", "role": "group_member"},
+            )
+        )
+
+        creative, user, group = recorder.calls
+        self.assertEqual(("creative_work", "bot_self", "fictional_content"),
+                         (creative["memory_type"], creative["visibility"], creative["reality_level"]))
+        self.assertEqual(("private", "private:user-1", ""),
+                         (user["scope"], user["session_id"], user["group_id"]))
+        self.assertEqual(("group", "group:42", "42"),
+                         (group["scope"], group["session_id"], group["group_id"]))
+        self.assertNotEqual(creative["visibility"], user["visibility"])
+        self.assertNotEqual(user["scope"], group["scope"])
+        self.assertNotEqual(user["session_id"], group["session_id"])
+
+    def test_entertainment_compatibility_writes_remain_bot_personal_records(self):
+        recorder = _Recorder()
+        bridge = MemoryCompanionBridge(recorder)
+
+        run(bridge.record_search_action(content="news summary", session_id="bot:news"))
+        run(bridge.record_image_action(content="image summary", session_id="bot:image"))
+        run(bridge.record_qzone_action(content="qzone summary", session_id="bot:qzone"))
+        run(bridge.record_reading(content="reading summary", session_id="bot:reading"))
+        run(bridge.record_schedule_fragment(content="outfit summary", session_id="bot:outfit"))
+
+        self.assertEqual(
+            ["search_action", "image_action", "qzone_action", "reading_memory", "schedule_fragment"],
+            [item["memory_type"] for item in recorder.calls],
+        )
+        self.assertTrue(all(item["visibility"] == "bot_self" for item in recorder.calls))
+        self.assertEqual(
+            ["bot_action", "bot_action", "bot_action", "bot_action", "persona_life"],
+            [item["reality_level"] for item in recorder.calls],
+        )
+        self.assertTrue(all(item["source_plugin"] == "external" for item in recorder.calls))
+
+    def test_bot_personal_archive_is_read_only_and_isolated_from_user_and_group_records(self):
+        with tempfile.TemporaryDirectory() as directory:
+            service = object.__new__(MemoryCompanionService)
+            service.store = MemoryStore(Path(directory) / "memory.db")
+            service.store.initialize()
+            service._schedule_memory_embedding = lambda *args, **kwargs: None
+            try:
+                bot = run(service.record_bot_personal_archive(archive("bot")))
+                run(service.store.insert_memory(MemoryRecord(
+                    id="user-1", memory_type="user_fact", scope="private", session_id="private:user",
+                    visibility="private_pair", content="user fact", metadata={"memory_domain": "user_memory"},
+                )))
+                run(service.store.insert_memory(MemoryRecord(
+                    id="group-1", memory_type="group_memory", scope="group", session_id="group:42",
+                    group_id="42", visibility="group_public", content="group fact",
+                    metadata={"memory_domain": "group_memory"},
+                )))
+                profile = run(service.read_bot_personal_profile(limit=10))
+                self.assertTrue(profile["read_only"])
+                self.assertEqual([bot["record_id"]], [item["record_id"] for item in profile["items"]])
+                self.assertTrue(all(item["memory_domain"] == bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN
+                                    for item in profile["items"]))
+                self.assertNotIn("payload", profile["items"][0])
+                self.assertNotIn("content", profile["items"][0])
+            finally:
+                service.store.close()
+
+    def test_bridge_failure_states_are_identifiable_without_leaking_exception_text(self):
+        missing = run(MemoryCompanionBridge(object()).record_bot_personal_archive(archive()))
+        self.assertEqual(("degraded", "bridge_method_unavailable"),
+                         (missing["state"], missing["error_code"]))
+
+        class Broken:
+            async def record_bot_personal_archive(self, _dto):
+                raise asyncio.TimeoutError()
+
+        timed_out = run(MemoryCompanionBridge(Broken()).record_bot_personal_archive(archive("timeout")))
+        self.assertEqual(("degraded", "bridge_exception"),
+                         (timed_out["state"], timed_out["error_code"]))
+        self.assertNotIn("TimeoutError", str(timed_out))
+
+        failed = _Recorder({"ok": False, "state": "failed", "error_code": "archive_failed"})
+        failed_result = run(MemoryCompanionBridge(failed).record_bot_personal_archive(archive("failed")))
+        self.assertEqual(("failed", "archive_failed"),
+                         (failed_result["state"], failed_result["error_code"]))
+
+    def test_profile_bridge_preserves_pending_degraded_and_filters_archive_payload(self):
+        ready = run(MemoryCompanionBridge(_ProfileProvider()).read_bot_personal_profile())
+        self.assertTrue(ready["read_only"])
+        self.assertEqual("ready", ready["state"])
+        self.assertEqual(["bot-1"], [item["record_id"] for item in ready["items"]])
+        self.assertNotIn("payload", ready["items"][0])
+        self.assertNotIn("content", ready["items"][0])
+
+        unavailable = run(MemoryCompanionBridge(object()).read_bot_personal_profile())
+        self.assertEqual("degraded", unavailable["state"])
+        self.assertTrue(unavailable["pending"])
+        self.assertEqual("bridge_method_unavailable", unavailable["error_code"])
+
+    def test_capability_probe_failure_keeps_degraded_contract_fields(self):
+        with patch.object(bot_personal_contract, "capability_descriptor", side_effect=RuntimeError("boom")):
+            result = MemoryCompanionBridge(object()).probe_capability_snapshot()
+        self.assertEqual("degraded", result["capability_state"])
+        self.assertTrue(result["degraded"])
+        self.assertFalse(result["available"])
+        self.assertEqual("contract_descriptor_exception", result["error_code"])
+        self.assertEqual(bot_personal_contract.BOT_PERSONAL_MEMORY_DOMAIN, result["domain"])
+        self.assertIn("contract_descriptor_exception", result["warnings"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_c6_dual_plugin_boundary.py
+++ b/tests/test_c6_dual_plugin_boundary.py
@@ -228,7 +228,7 @@ class C6DualPluginBoundaryTests(unittest.TestCase):
     def test_capability_probe_failure_keeps_degraded_contract_fields(self):
         with patch.object(bot_personal_contract, "capability_descriptor", side_effect=RuntimeError("boom")):
             result = MemoryCompanionBridge(object()).probe_capability_snapshot()
-        self.assertEqual("degraded", result["capability_state"])
+        self.assertEqual("negative", result["capability_state"])
         self.assertTrue(result["degraded"])
         self.assertFalse(result["available"])
         self.assertEqual("contract_descriptor_exception", result["error_code"])

--- a/tests/test_c7_bridge_timezone_page.py
+++ b/tests/test_c7_bridge_timezone_page.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+import time
+import unittest
+from unittest.mock import patch
+
+from core import bot_personal_contract
+from core.bridge import MemoryCompanionBridge
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class BridgeNegativeProbeTests(unittest.TestCase):
+    def test_contract_failure_is_negative_cached_and_not_reprobed(self):
+        bridge = MemoryCompanionBridge(object())
+        with patch.object(
+            bot_personal_contract,
+            "contract_self_check",
+            side_effect=[RuntimeError("private prompt must not escape"), []],
+        ) as checker:
+            first = bridge.probe_capability_snapshot()
+            second = bridge.probe_capability_snapshot()
+
+        self.assertEqual("negative", first["capability_state"])
+        self.assertEqual("negative", first["state"])
+        self.assertFalse(first["available"])
+        self.assertEqual("contract_self_check_exception", first["error_code"])
+        self.assertEqual(1, checker.call_count)
+        self.assertEqual("negative", second["capability_state"])
+
+    def test_negative_probe_expires_and_allows_recovery(self):
+        bridge = MemoryCompanionBridge(object())
+        with patch.object(bot_personal_contract, "contract_self_check", side_effect=RuntimeError("broken")):
+            first = bridge.probe_capability_snapshot()
+        self.assertEqual("negative", first["state"])
+
+        bridge._capability_cache._negative_at = time.monotonic() - 61.0
+        with patch.object(bot_personal_contract, "contract_self_check", return_value=[]):
+            recovered = bridge.probe_capability_snapshot()
+        self.assertEqual("available", recovered["state"])
+        self.assertTrue(recovered["available"])
+
+
+class C7StaticBoundaryTests(unittest.TestCase):
+    def test_service_uses_configured_local_timezone_for_wall_clock_checks(self):
+        source = (ROOT / "core" / "service.py").read_text(encoding="utf-8")
+        self.assertIn('LOCAL_TZ = ZoneInfo("Asia/Shanghai")', source)
+        self.assertIn("datetime.now(LOCAL_TZ)", source)
+        self.assertNotIn("datetime.now()", source)
+
+    def test_page_endpoints_return_real_errors_without_exception_text(self):
+        source = (ROOT / "page_api.py").read_text(encoding="utf-8")
+        for endpoint in ("timeline", "relations", "graph", "threads", "logs"):
+            self.assertIn(f'self._err("{endpoint}_unavailable", 500)', source)
+        self.assertNotIn('return self._ok({"items": []})', source)
+
+    def test_frontend_http_and_partial_context_errors_are_visible(self):
+        source = (ROOT / "pages" / "记忆面板" / "app.js").read_text(encoding="utf-8")
+        self.assertIn("if (!response.ok || data?.success === false)", source)
+        self.assertIn("renderContextPanelErrors", source)
+        self.assertIn("errors: {", source)
+        self.assertIn("已显示可用数据", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_c7_import_retrieval.py
+++ b/tests/test_c7_import_retrieval.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if "astrbot_plugin_remember_you" not in sys.modules:
+    package = types.ModuleType("astrbot_plugin_remember_you")
+    package.__path__ = [str(ROOT)]
+    sys.modules["astrbot_plugin_remember_you"] = package
+if str(ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(ROOT.parent))
+
+from astrbot_plugin_remember_you.core.chat_import import HistoricalChatImporter
+from astrbot_plugin_remember_you.core.models import MemoryRecord
+from astrbot_plugin_remember_you.core.operations import PORTABLE_EXPORT_PAGE_SIZE, PortableMemoryArchive
+from astrbot_plugin_remember_you.core.retrieval import RetrievalEngine
+from astrbot_plugin_remember_you.core.store import MemoryStore
+
+
+class _Config:
+    def int(self, _key: str, default: int) -> int:
+        return default
+
+
+class _ResumeStore:
+    def __init__(self) -> None:
+        self.batch = {"id": "batch-1", "state": "running", "checkpoint_segment": 7}
+        self.segments = [{"id": "seg-1", "segment_index": 1, "status": "processing", "attempts": 2}]
+        self.updates: list[tuple[str, dict]] = []
+
+    async def get_chat_import_batch(self, _batch_id: str):
+        return dict(self.batch)
+
+    async def chat_import_segments(self, _batch_id: str, *, statuses=None):
+        if statuses is None:
+            return list(self.segments)
+        return [item for item in self.segments if item["status"] in statuses]
+
+    async def update_chat_import_segment(self, segment_id: str, **changes):
+        self.updates.append((segment_id, changes))
+        for item in self.segments:
+            if item["id"] == segment_id:
+                item.update(changes)
+        return dict(self.segments[0])
+
+    async def update_chat_import_batch(self, _batch_id: str, **changes):
+        self.batch.update(changes)
+        return dict(self.batch)
+
+
+class C7ImportRecoveryTests(unittest.IsolatedAsyncioTestCase):
+    def test_corrupt_manifest_has_stable_redacted_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            importer = HistoricalChatImporter(SimpleNamespace(data_dir=Path(temp), store=object()))
+            upload_id = "chatup_" + "a" * 24
+            upload_dir = importer._upload_dir(upload_id)
+            upload_dir.mkdir(parents=True)
+            (upload_dir / "manifest.json").write_text("{broken", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "历史导入暂存数据损坏") as raised:
+                importer.preview_upload(upload_id)
+            self.assertNotIn(str(upload_dir), str(raised.exception))
+
+    def test_corrupt_parsed_jsonl_does_not_become_empty_import(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            importer = HistoricalChatImporter(SimpleNamespace(data_dir=Path(temp), store=object()))
+            upload_id = "chatup_" + "b" * 24
+            upload_dir = importer._upload_dir(upload_id)
+            upload_dir.mkdir(parents=True)
+            (upload_dir / "manifest.json").write_text(
+                json.dumps({"upload_id": upload_id}), encoding="utf-8"
+            )
+            (upload_dir / "parsed.jsonl").write_text('{"message_id":"ok"}\n{broken\n', encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "历史导入暂存数据损坏"):
+                importer._load_upload_messages(upload_id)
+
+    async def test_processing_segment_is_retried_only_without_active_worker(self) -> None:
+        store = _ResumeStore()
+        service = SimpleNamespace(data_dir=Path(tempfile.gettempdir()), store=store, config=_Config())
+        importer = HistoricalChatImporter(service)
+        importer._start_worker = lambda _batch_id: None
+        result = await importer.resume_batch("batch-1")
+        self.assertEqual("retry", store.segments[0]["status"])
+        self.assertEqual("running", result["batch"]["state"])
+        self.assertEqual(0, store.segments[0]["attempts"])
+
+
+class C7RetrievalBoundaryTests(unittest.TestCase):
+    def test_materialize_limit_is_explicit_and_bounded(self) -> None:
+        self.assertGreater(RetrievalEngine.DEFAULT_MATERIALIZE_LIMIT, 0)
+        self.assertLessEqual(RetrievalEngine.DEFAULT_MATERIALIZE_LIMIT, 2000)
+
+    def test_panel_polling_has_attempt_and_time_bounds(self) -> None:
+        panel = (ROOT / "pages" / "记忆面板" / "app.js").read_text(encoding="utf-8")
+        self.assertIn("historicalChatPollAttempts > 120", panel)
+        self.assertIn("elapsed > 10 * 60 * 1000", panel)
+        self.assertIn("历史导入轮询已达到上限", panel)
+
+
+class C7PerformanceBoundaryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_embedding_candidate_cache_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            store = MemoryStore(Path(temp) / "memory.db")
+            store.initialize()
+            try:
+                for index in range(store.EMBEDDING_CANDIDATE_CACHE_MAX + 1):
+                    await store.list_embedding_candidate_rows(
+                        provider_id=f"provider-{index}",
+                        limit=1,
+                    )
+                self.assertLessEqual(
+                    len(store._embedding_candidate_cache),
+                    store.EMBEDDING_CANDIDATE_CACHE_MAX,
+                )
+            finally:
+                store.close()
+
+    async def test_portable_export_pages_large_memory_sets_without_materializing_all_rows(self) -> None:
+        records = [
+            MemoryRecord(
+                id=f"memory-{index}",
+                memory_type="user_fact",
+                scope="private",
+                visibility="private_pair",
+                content=f"content-{index}",
+            )
+            for index in range(PORTABLE_EXPORT_PAGE_SIZE + 1)
+        ]
+
+        class PagedStore:
+            def __init__(self) -> None:
+                self.memory_calls: list[tuple[int, int]] = []
+
+            async def stats(self):
+                return {
+                    "total_memories": len(records),
+                    "identities": 0,
+                    "relationships": 0,
+                    "timeline_events": 0,
+                }
+
+            async def list_memories(self, *, limit, offset=0):
+                self.memory_calls.append((limit, offset))
+                return records[offset : offset + limit]
+
+            async def list_identities(self, *, limit, offset=0):
+                return []
+
+            async def list_relationships(self, *, limit, offset=0):
+                return []
+
+            async def recent_timeline(self, *, limit, offset=0):
+                return []
+
+            async def list_acl_rules(self):
+                return []
+
+            async def list_acl_policies(self):
+                return []
+
+        with tempfile.TemporaryDirectory() as temp:
+            store = PagedStore()
+            result = await PortableMemoryArchive(store, Path(temp)).export()
+            self.assertEqual(
+                [
+                    (PORTABLE_EXPORT_PAGE_SIZE, 0),
+                    (PORTABLE_EXPORT_PAGE_SIZE, PORTABLE_EXPORT_PAGE_SIZE),
+                ],
+                store.memory_calls,
+            )
+            self.assertEqual(len(records), result["counts"]["memory"])
+            self.assertEqual(
+                len(records) + 1,
+                len(Path(result["path"]).read_text(encoding="utf-8").splitlines()),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_c7_like_security.py
+++ b/tests/test_c7_like_security.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import tempfile
+import unittest
+
+from core.models import MemoryRecord
+from core.store import MemoryStore
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class LikeSecurityTests(unittest.TestCase):
+    def test_like_pattern_escapes_wildcards_and_backslashes(self):
+        self.assertEqual(r"%100\%\_ready\\now%", MemoryStore._like_pattern("100%_ready\\now"))
+
+    def test_memory_query_treats_percent_and_underscore_as_literal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = MemoryStore(Path(directory) / "memory.db")
+            store.initialize()
+            try:
+                run(store.insert_memory(MemoryRecord(
+                    id="literal",
+                    scope="private",
+                    session_id="private:user-1",
+                    content="needle%_literal",
+                )))
+                run(store.insert_memory(MemoryRecord(
+                    id="wildcard",
+                    scope="private",
+                    session_id="private:user-1",
+                    content="needleXliteral",
+                )))
+                rows = run(store.list_memories(query="needle%_literal", limit=10))
+                self.assertEqual(["literal"], [row.id for row in rows])
+            finally:
+                store.close()
+
+    def test_knowledge_term_search_treats_percent_and_underscore_as_literal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = MemoryStore(Path(directory) / "memory.db")
+            store.initialize()
+            try:
+                run(store.upsert_knowledge_node(node_type="topic", label="alpha%_literal"))
+                run(store.upsert_knowledge_node(node_type="topic", label="alphaXliteral"))
+                labels = run(store.related_knowledge_terms(["alpha%_literal"], limit=10))
+                self.assertEqual(["alpha%_literal"], labels)
+            finally:
+                store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e2_event_store.py
+++ b/tests/test_emotion_e2_event_store.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core.bridge import MemoryCompanionBridge  # noqa: E402
+from core.emotion_event_contract import (  # noqa: E402
+    EMOTION_EVENT_CONTRACT_FINGERPRINT,
+    normalize_emotion_event,
+)
+from core.store import MemoryStore  # noqa: E402
+
+
+class EmotionE2EventStoreTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = MemoryStore(Path(temp_dir.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def test_event_revisions_are_independent_from_memory_retrieval(self) -> None:
+        store = self.make_store()
+        first = normalize_emotion_event(
+            {
+                "event_type": "hurt",
+                "session_id": "qq:FriendMessage:u1",
+                "dedupe_key": "m1",
+                "trace_id": "trace-1",
+                "revision": 1,
+            },
+            producer_plugin="private_companion",
+        )
+        second = {**first, "revision": 2, "status": "revised", "event_type": "neutral", "correction_of": first["event_id"]}
+        await store.upsert_emotion_event(first)
+        await store.upsert_emotion_event(first)
+        await store.upsert_emotion_event(second)
+        trace = await store.get_emotion_trace("trace-1")
+        self.assertEqual([1, 2], [item["revision"] for item in trace])
+        self.assertEqual(0, store._conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0])
+        self.assertEqual(2, store._conn.execute("SELECT COUNT(*) FROM emotion_events").fetchone()[0])
+
+    async def test_bridge_records_and_reads_redacted_trace(self) -> None:
+        store = self.make_store()
+        plugin = type("Plugin", (), {"store": store})()
+        bridge = MemoryCompanionBridge(plugin)
+        event = await bridge.record_emotion_event({
+            "event_type": "comfort",
+            "session_id": "qq:FriendMessage:u1",
+            "dedupe_key": "m2",
+            "trace_id": "trace-2",
+            "raw_text": "PRIVATE",
+        })
+        trace = await bridge.get_emotion_trace("trace-2")
+        self.assertEqual(event["event_id"], trace[0]["event_id"])
+        self.assertNotIn("PRIVATE", repr(trace))
+        self.assertTrue(EMOTION_EVENT_CONTRACT_FINGERPRINT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e2_event_store.py
+++ b/tests/test_emotion_e2_event_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 import unittest
 
 
@@ -47,20 +48,75 @@ class EmotionE2EventStoreTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(0, store._conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0])
         self.assertEqual(2, store._conn.execute("SELECT COUNT(*) FROM emotion_events").fetchone()[0])
 
-    async def test_bridge_records_and_reads_redacted_trace(self) -> None:
+    def make_attested_bridge(self, store: MemoryStore) -> tuple[MemoryCompanionBridge, object]:
+        companion = object()
+        context = SimpleNamespace(
+            get_all_stars=lambda: [
+                SimpleNamespace(
+                    star_cls=companion,
+                    root_dir_name="astrbot_plugin_private_companion",
+                    name="PrivateCompanion",
+                    activated=True,
+                )
+            ]
+        )
+        service = SimpleNamespace(store=store, context=context)
+        bridge = MemoryCompanionBridge(service)
+        capability = bridge.register_emotion_producer(companion)
+        self.assertIsNotNone(capability)
+        producer_context = bridge.create_emotion_producer_context(
+            capability,
+            bot_id="bot-1",
+            scope="private",
+            platform="qq",
+            user_id="user-1",
+            session_id="qq:FriendMessage:user-1",
+        )
+        self.assertIsNotNone(producer_context)
+        return bridge, producer_context
+
+    async def test_bridge_requires_attested_producer_and_redacts_trace(self) -> None:
         store = self.make_store()
-        plugin = type("Plugin", (), {"store": store})()
-        bridge = MemoryCompanionBridge(plugin)
+        bridge, producer_context = self.make_attested_bridge(store)
+        denied = await bridge.record_emotion_event({"event_type": "comfort"})
+        self.assertEqual("forbidden", denied["state"])
+
         event = await bridge.record_emotion_event({
+            "producer_plugin": "untrusted_plugin",
+            "origin_kind": "memory_recall",
+            "bot_id": "other-bot",
+            "scope": "group",
+            "platform": "other-platform",
+            "actor_ref": {"kind": "user", "id": "other-user", "role": "speaker"},
+            "target_ref": {"kind": "bot", "id": "other-bot", "role": "bot_self"},
             "event_type": "comfort",
-            "session_id": "qq:FriendMessage:u1",
+            "session_id": "qq:FriendMessage:other-user",
             "dedupe_key": "m2",
             "trace_id": "trace-2",
             "raw_text": "PRIVATE",
-        })
-        trace = await bridge.get_emotion_trace("trace-2")
-        self.assertEqual(event["event_id"], trace[0]["event_id"])
-        self.assertNotIn("PRIVATE", repr(trace))
+        }, producer_context=producer_context)
+        self.assertEqual("private_companion", event["producer_plugin"])
+        self.assertEqual("interaction", event["origin_kind"])
+        self.assertEqual("bot-1", event["bot_id"])
+        self.assertEqual("user-1", event["actor_ref"]["id"])
+
+        raw_trace = await bridge.get_emotion_trace("trace-2")
+        self.assertEqual("forbidden", raw_trace["state"])
+
+        page = SimpleNamespace(plugin=bridge._plugin)
+        page_capability = bridge.bind_emotion_page_api(page)
+        admin_context = bridge.create_emotion_admin_context(
+            page_capability,
+            bot_id="bot-1",
+            scope="private",
+            session_id="qq:FriendMessage:user-1",
+        )
+        trace = await bridge.get_emotion_trace("trace-2", requester_context=admin_context)
+        self.assertEqual("ready", trace["state"])
+        self.assertEqual(event["event_id"], trace["items"][0]["event_id"])
+        rendered = repr(trace)
+        for secret in ("PRIVATE", "user-1", "qq:FriendMessage:user-1"):
+            self.assertNotIn(secret, rendered)
         self.assertTrue(EMOTION_EVENT_CONTRACT_FINGERPRINT)
 
 

--- a/tests/test_emotion_e3_replay.py
+++ b/tests/test_emotion_e3_replay.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core.emotion_event_contract import normalize_emotion_event  # noqa: E402
+from tests.emotion_eval_cases import build_emotion_eval_cases, emotion_eval_fingerprint  # noqa: E402
+
+
+class EmotionE3ReplayTests(unittest.TestCase):
+    def test_sixty_case_matrix_normalizes_identically(self) -> None:
+        cases = build_emotion_eval_cases()
+        self.assertEqual(60, len(cases))
+        self.assertEqual(emotion_eval_fingerprint(), emotion_eval_fingerprint())
+        ids: set[str] = set()
+        for case in cases:
+            source = case["event"]
+            event = normalize_emotion_event({
+                "event_type": source["event_type"],
+                "intensity": source["intensity"],
+                "confidence": source["confidence"],
+                "session_id": "qq:FriendMessage:u1",
+                "dedupe_key": case["case_id"],
+                "occurred_at": case["clock"],
+            }, producer_plugin="emotion_eval")
+            self.assertNotIn(event["event_id"], ids)
+            ids.add(event["event_id"])
+            self.assertEqual(source["event_type"], event["event_type"])
+            self.assertEqual(source["intensity"], event["intensity"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e3_replay.py
+++ b/tests/test_emotion_e3_replay.py
@@ -13,9 +13,9 @@ from tests.emotion_eval_cases import build_emotion_eval_cases, emotion_eval_fing
 
 
 class EmotionE3ReplayTests(unittest.TestCase):
-    def test_sixty_case_matrix_normalizes_identically(self) -> None:
+    def test_120_case_matrix_normalizes_identically(self) -> None:
         cases = build_emotion_eval_cases()
-        self.assertEqual(60, len(cases))
+        self.assertEqual(120, len(cases))
         self.assertEqual(emotion_eval_fingerprint(), emotion_eval_fingerprint())
         ids: set[str] = set()
         for case in cases:

--- a/tests/test_emotion_e4_afterglow_delivery.py
+++ b/tests/test_emotion_e4_afterglow_delivery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 import sys
 import tempfile
 import unittest
@@ -23,16 +24,41 @@ class EmotionE4AfterglowDeliveryTests(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(store.close)
         return store
 
-    async def add_event(self, store: MemoryStore, *, session_id: str, suffix: str) -> dict:
+    @staticmethod
+    def delivery_domain(*, session_id: str, allow_cross_window: bool = False) -> dict:
+        return {
+            "consumer_id": "private_companion.daily_state",
+            "bot_id": "bot-1",
+            "scope": "private",
+            "platform": "qq",
+            "user_id": "user-1",
+            "session_id": session_id,
+            "allow_cross_window": allow_cross_window,
+        }
+
+    async def add_event(
+        self,
+        store: MemoryStore,
+        *,
+        session_id: str,
+        suffix: str,
+        expires_at: str = "",
+    ) -> dict:
         event = normalize_emotion_event({
             "event_id": f"emo-{suffix}",
             "trace_id": f"trace-{suffix}",
             "origin_kind": "memory_recall",
+            "bot_id": "bot-1",
+            "scope": "private",
+            "platform": "qq",
             "session_id": session_id,
+            "actor_ref": {"kind": "user", "id": "user-1", "role": "speaker"},
+            "target_ref": {"kind": "bot", "id": "bot-1", "role": "bot_self"},
             "event_type": "warm_memory",
             "applied_energy_delta": 3.5,
             "valence_hint": 0.4,
             "dedupe_key": suffix,
+            "expires_at": expires_at,
         }, producer_plugin="memory_companion")
         return await store.upsert_emotion_event(event)
 
@@ -40,33 +66,82 @@ class EmotionE4AfterglowDeliveryTests(unittest.IsolatedAsyncioTestCase):
         store = self.make_store()
         event = await self.add_event(store, session_id="session-a", suffix="a")
         first = await store.list_emotion_event_deliveries(
-            consumer_id="companion", session_id="session-a", limit=5
+            **self.delivery_domain(session_id="session-a"), limit=5
         )
         retry = await store.list_emotion_event_deliveries(
-            consumer_id="companion", session_id="session-a", limit=5
+            **self.delivery_domain(session_id="session-a"), limit=5
         )
         self.assertEqual([event["event_id"]], [item["event_id"] for item in first["events"]])
         self.assertEqual(first["events"], retry["events"])
         self.assertNotIn("memory_id", repr(first))
         self.assertNotIn("actor_ref", repr(first))
+        self.assertNotIn("session-a", repr(first))
         ack = await store.ack_emotion_event_deliveries(
-            consumer_id="companion",
             event_refs=[{"event_id": event["event_id"], "revision": 1}],
+            **self.delivery_domain(session_id="session-a"),
         )
         self.assertEqual(1, ack["acked"])
         empty = await store.list_emotion_event_deliveries(
-            consumer_id="companion", session_id="session-a", limit=5
+            **self.delivery_domain(session_id="session-a"), limit=5
         )
         self.assertEqual([], empty["events"])
 
-    async def test_session_and_exclusion_filters_prevent_double_delivery(self) -> None:
+    async def test_cross_window_delivery_stays_in_same_identity_domain(self) -> None:
         store = self.make_store()
-        await self.add_event(store, session_id="session-a", suffix="a")
+        event_a = await self.add_event(store, session_id="session-a", suffix="a")
         event_b = await self.add_event(store, session_id="session-b", suffix="b")
         page = await store.list_emotion_event_deliveries(
-            consumer_id="companion", exclude_session_id="session-a", limit=5
+            **self.delivery_domain(session_id="session-a", allow_cross_window=True), limit=5
         )
-        self.assertEqual([event_b["event_id"]], [item["event_id"] for item in page["events"]])
+        self.assertEqual(
+            {event_a["event_id"], event_b["event_id"]},
+            {item["event_id"] for item in page["events"]},
+        )
+
+    async def test_expired_or_malformed_event_is_never_delivered_or_acknowledged(self) -> None:
+        store = self.make_store()
+        now = datetime.now(timezone.utc)
+        expired = await self.add_event(
+            store,
+            session_id="session-a",
+            suffix="expired",
+            expires_at=(now - timedelta(seconds=1)).isoformat(),
+        )
+        malformed = await self.add_event(
+            store,
+            session_id="session-a",
+            suffix="malformed",
+            expires_at="not-an-iso-time",
+        )
+        delivered_at = now.isoformat()
+        store._conn.execute(
+            """
+            INSERT INTO emotion_event_deliveries(
+                event_id, revision, consumer_id, attempts,
+                first_delivered_at, last_delivered_at, acked_at
+            ) VALUES(?,?,?,1,?,?,'')
+            """,
+            (
+                expired["event_id"],
+                expired["revision"],
+                "private_companion.daily_state",
+                delivered_at,
+                delivered_at,
+            ),
+        )
+        store._conn.commit()
+        page = await store.list_emotion_event_deliveries(
+            **self.delivery_domain(session_id="session-a"), limit=5
+        )
+        self.assertEqual([], page["events"])
+        ack = await store.ack_emotion_event_deliveries(
+            event_refs=[
+                {"event_id": expired["event_id"], "revision": expired["revision"]},
+                {"event_id": malformed["event_id"], "revision": malformed["revision"]},
+            ],
+            **self.delivery_domain(session_id="session-a"),
+        )
+        self.assertEqual(0, ack["acked"])
 
 
 if __name__ == "__main__":

--- a/tests/test_emotion_e4_afterglow_delivery.py
+++ b/tests/test_emotion_e4_afterglow_delivery.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.emotion_event_contract import normalize_emotion_event  # noqa: E402
+from core.store import MemoryStore  # noqa: E402
+
+
+class EmotionE4AfterglowDeliveryTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = MemoryStore(Path(temp_dir.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def add_event(self, store: MemoryStore, *, session_id: str, suffix: str) -> dict:
+        event = normalize_emotion_event({
+            "event_id": f"emo-{suffix}",
+            "trace_id": f"trace-{suffix}",
+            "origin_kind": "memory_recall",
+            "session_id": session_id,
+            "event_type": "warm_memory",
+            "applied_energy_delta": 3.5,
+            "valence_hint": 0.4,
+            "dedupe_key": suffix,
+        }, producer_plugin="memory_companion")
+        return await store.upsert_emotion_event(event)
+
+    async def test_list_retries_until_ack_and_returns_redacted_projection(self) -> None:
+        store = self.make_store()
+        event = await self.add_event(store, session_id="session-a", suffix="a")
+        first = await store.list_emotion_event_deliveries(
+            consumer_id="companion", session_id="session-a", limit=5
+        )
+        retry = await store.list_emotion_event_deliveries(
+            consumer_id="companion", session_id="session-a", limit=5
+        )
+        self.assertEqual([event["event_id"]], [item["event_id"] for item in first["events"]])
+        self.assertEqual(first["events"], retry["events"])
+        self.assertNotIn("memory_id", repr(first))
+        self.assertNotIn("actor_ref", repr(first))
+        ack = await store.ack_emotion_event_deliveries(
+            consumer_id="companion",
+            event_refs=[{"event_id": event["event_id"], "revision": 1}],
+        )
+        self.assertEqual(1, ack["acked"])
+        empty = await store.list_emotion_event_deliveries(
+            consumer_id="companion", session_id="session-a", limit=5
+        )
+        self.assertEqual([], empty["events"])
+
+    async def test_session_and_exclusion_filters_prevent_double_delivery(self) -> None:
+        store = self.make_store()
+        await self.add_event(store, session_id="session-a", suffix="a")
+        event_b = await self.add_event(store, session_id="session-b", suffix="b")
+        page = await store.list_emotion_event_deliveries(
+            consumer_id="companion", exclude_session_id="session-a", limit=5
+        )
+        self.assertEqual([event_b["event_id"]], [item["event_id"] for item in page["events"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e4_delivery_authorization.py
+++ b/tests/test_emotion_e4_delivery_authorization.py
@@ -163,6 +163,72 @@ class EmotionE4DeliveryAuthorizationTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(1, own_ack["acked"])
 
+    async def test_keyset_pagination_skips_foreign_flood_and_reaches_every_local_event(self) -> None:
+        store = self.make_store()
+        bridge, capability = self.make_bridge(store)
+        local_ids: set[str] = set()
+        for index in range(1002):
+            local = normalize_emotion_event(
+                {
+                    "event_id": f"local-{index:04d}",
+                    "trace_id": f"local-trace-{index:04d}",
+                    "origin_kind": "memory_recall",
+                    "bot_id": "bot-1",
+                    "scope": "private",
+                    "platform": "qq",
+                    "session_id": "session-a",
+                    "actor_ref": {"kind": "user", "id": "user-1", "role": "speaker"},
+                    "target_ref": {"kind": "bot", "id": "bot-1", "role": "bot_self"},
+                    "event_type": "warm_memory",
+                    "occurred_at": "2026-08-05T00:00:00+00:00",
+                    "dedupe_key": f"local-{index:04d}",
+                },
+                producer_plugin="memory_companion",
+            )
+            store._upsert_emotion_event_sync(local)
+            local_ids.add(local["event_id"])
+        for index in range(1002):
+            foreign = normalize_emotion_event(
+                {
+                    "event_id": f"foreign-{index:04d}",
+                    "trace_id": f"foreign-trace-{index:04d}",
+                    "origin_kind": "memory_recall",
+                    "bot_id": "bot-1",
+                    "scope": "private",
+                    "platform": "qq",
+                    "session_id": "foreign-session",
+                    "actor_ref": {"kind": "user", "id": "user-2", "role": "speaker"},
+                    "target_ref": {"kind": "bot", "id": "bot-1", "role": "bot_self"},
+                    "event_type": "warm_memory",
+                    "occurred_at": "2030-08-05T00:00:00+00:00",
+                    "dedupe_key": f"foreign-{index:04d}",
+                },
+                producer_plugin="memory_companion",
+            )
+            store._upsert_emotion_event_sync(foreign)
+
+        delivery_context = self.delivery_context(bridge, capability)
+        self.assertIsNotNone(delivery_context)
+        cursor = ""
+        received: set[str] = set()
+        for _ in range(60):
+            page = await bridge.list_emotion_events(
+                delivery_context=delivery_context,
+                cursor=cursor,
+                limit=20,
+            )
+            ids = {item["event_id"] for item in page["events"]}
+            self.assertFalse(ids - local_ids)
+            self.assertFalse(received & ids)
+            received.update(ids)
+            if not page["has_more"]:
+                break
+            self.assertTrue(page["next_cursor"])
+            cursor = page["next_cursor"]
+        else:
+            self.fail("keyset pagination did not finish")
+        self.assertEqual(local_ids, received)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_emotion_e4_delivery_authorization.py
+++ b/tests/test_emotion_e4_delivery_authorization.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.bridge import MemoryCompanionBridge  # noqa: E402
+from core.emotion_event_contract import normalize_emotion_event  # noqa: E402
+from core.store import MemoryStore  # noqa: E402
+
+
+class EmotionE4DeliveryAuthorizationTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = MemoryStore(Path(temp_dir.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    def make_bridge(self, store: MemoryStore) -> tuple[MemoryCompanionBridge, object]:
+        companion = object()
+        plugin = SimpleNamespace(
+            store=store,
+            context=SimpleNamespace(
+                get_all_stars=lambda: [
+                    SimpleNamespace(
+                        star_cls=companion,
+                        root_dir_name="astrbot_plugin_private_companion",
+                        name="PrivateCompanion",
+                        activated=True,
+                    )
+                ]
+            ),
+        )
+        bridge = MemoryCompanionBridge(plugin)
+        capability = bridge.register_emotion_producer(companion)
+        self.assertIsNotNone(capability)
+        return bridge, capability
+
+    @staticmethod
+    def delivery_context(
+        bridge: MemoryCompanionBridge,
+        capability: object,
+        *,
+        bot_id: str = "bot-1",
+        platform: str = "qq",
+        scope: str = "private",
+        user_id: str = "user-1",
+        session_id: str = "session-a",
+        allow_cross_window: bool = False,
+    ) -> object | None:
+        return bridge.create_emotion_delivery_context(
+            capability,
+            bot_id=bot_id,
+            scope=scope,
+            platform=platform,
+            user_id=user_id,
+            session_id=session_id,
+            allow_cross_window=allow_cross_window,
+        )
+
+    async def add_event(
+        self,
+        store: MemoryStore,
+        *,
+        suffix: str,
+        bot_id: str = "bot-1",
+        platform: str = "qq",
+        scope: str = "private",
+        user_id: str = "user-1",
+        session_id: str = "session-a",
+    ) -> dict:
+        event = normalize_emotion_event(
+            {
+                "event_id": f"event-{suffix}",
+                "trace_id": f"trace-{suffix}",
+                "origin_kind": "memory_recall",
+                "bot_id": bot_id,
+                "scope": scope,
+                "platform": platform,
+                "session_id": session_id,
+                "actor_ref": {"kind": "user", "id": user_id, "role": "speaker"},
+                "target_ref": {"kind": "bot", "id": bot_id, "role": "bot_self"},
+                "event_type": "warm_memory",
+                "dedupe_key": suffix,
+            },
+            producer_plugin="memory_companion",
+        )
+        return await store.upsert_emotion_event(event)
+
+    async def test_delivery_and_ack_are_bound_to_one_private_identity_domain(self) -> None:
+        store = self.make_store()
+        bridge, capability = self.make_bridge(store)
+        same = await self.add_event(store, suffix="same")
+        cross_window = await self.add_event(store, suffix="same-user-window", session_id="session-b")
+        other_user = await self.add_event(store, suffix="other-user", user_id="user-2", session_id="session-c")
+        other_bot = await self.add_event(store, suffix="other-bot", bot_id="bot-2", session_id="session-d")
+        other_platform = await self.add_event(store, suffix="other-platform", platform="wechat", session_id="session-e")
+        group_scope = await self.add_event(store, suffix="group", scope="group", session_id="session-f")
+
+        denied = await bridge.list_emotion_events(consumer_id="private_companion.daily_state")
+        self.assertEqual("forbidden", denied["state"])
+        denied_ack = await bridge.ack_emotion_events([{"event_id": same["event_id"], "revision": 1}])
+        self.assertEqual(0, denied_ack["acked"])
+
+        same_context = self.delivery_context(bridge, capability)
+        self.assertIsNotNone(same_context)
+        same_page = await bridge.list_emotion_events(delivery_context=same_context)
+        self.assertEqual([same["event_id"]], [item["event_id"] for item in same_page["events"]])
+
+        cross_context = self.delivery_context(
+            bridge,
+            capability,
+            allow_cross_window=True,
+        )
+        self.assertIsNotNone(cross_context)
+        cross_page = await bridge.list_emotion_events(delivery_context=cross_context)
+        self.assertEqual(
+            {same["event_id"], cross_window["event_id"]},
+            {item["event_id"] for item in cross_page["events"]},
+        )
+        rendered = repr(cross_page)
+        for raw_identifier in ("session-a", "session-b", "user-1", "bot-1", "actor_ref", "target_ref"):
+            self.assertNotIn(raw_identifier, rendered)
+
+        for context, forbidden_event in (
+            (
+                self.delivery_context(bridge, capability, user_id="user-2", session_id="session-c"),
+                same,
+            ),
+            (
+                self.delivery_context(bridge, capability, bot_id="bot-2", session_id="session-d"),
+                same,
+            ),
+            (
+                self.delivery_context(bridge, capability, platform="wechat", session_id="session-e"),
+                same,
+            ),
+        ):
+            self.assertIsNotNone(context)
+            page = await bridge.list_emotion_events(delivery_context=context)
+            self.assertNotIn(forbidden_event["event_id"], [item["event_id"] for item in page["events"]])
+
+        self.assertIsNone(self.delivery_context(bridge, capability, scope="group"))
+        self.assertNotIn(group_scope["event_id"], [item["event_id"] for item in cross_page["events"]])
+        foreign_context = self.delivery_context(bridge, capability, user_id="user-2", session_id="session-c")
+        foreign_ack = await bridge.ack_emotion_events(
+            [{"event_id": same["event_id"], "revision": same["revision"]}],
+            delivery_context=foreign_context,
+        )
+        self.assertEqual(0, foreign_ack["acked"])
+        own_ack = await bridge.ack_emotion_events(
+            [{"event_id": same["event_id"], "revision": same["revision"]}],
+            delivery_context=same_context,
+        )
+        self.assertEqual(1, own_ack["acked"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e5_authority_projection.py
+++ b/tests/test_emotion_e5_authority_projection.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.bridge import sanitize_companion_relationship_projection  # noqa: E402
+from core.models import SessionContext  # noqa: E402
+from core.service import MemoryCompanionService  # noqa: E402
+
+
+def projection() -> dict:
+    return {
+        "schema_version": "chat.relationship_projection.v1",
+        "authority": "private_companion.relationship_score",
+        "read_only": True,
+        "score": 205,
+        "phase_key": "acquaintance",
+        "phase_label": "初识",
+        "tone": "友好",
+        "address_level": "中性",
+        "proactive_care_limit": 0,
+        "soft_behaviors": {
+            "allow_playful_jokes": False,
+            "allow_followup": True,
+            "allow_memory_mention": False,
+            "allow_daily_care": False,
+        },
+        "current_interaction": {
+            "expression_band": "hurt",
+            "label": "受伤",
+            "source": "automatic",
+            "reason": "hurt_event",
+            "manual_override": False,
+            "dynamics_version": "interaction_dynamics.v1",
+            "recovery_band": "recovering",
+            "expires_at": 2000.0,
+            "projection_revision": 2,
+        },
+    }
+
+
+class EmotionE5AuthorityProjectionTests(unittest.TestCase):
+    def test_memory_consumes_bounded_dynamics_without_becoming_authority(self) -> None:
+        accepted = sanitize_companion_relationship_projection(projection())
+        self.assertEqual("accepted", accepted["status"])
+        ctx = SessionContext(scope="private")
+        event = SimpleNamespace(private_companion_context={"relationship_projection": projection()})
+        MemoryCompanionService._apply_companion_relationship_projection(ctx, event=event)
+        self.assertEqual("private_companion.relationship_score", ctx.relationship_authority_source)
+        self.assertEqual("interaction_dynamics.v1", ctx.companion_interaction_dynamics_version)
+        self.assertEqual("recovering", ctx.companion_interaction_recovery_band)
+
+    def test_invalid_dynamics_fail_closed(self) -> None:
+        hostile = projection()
+        hostile["current_interaction"]["expires_at"] = "NaN"
+        self.assertEqual("invalid", sanitize_companion_relationship_projection(hostile)["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e6_affect_event_projection.py
+++ b/tests/test_emotion_e6_affect_event_projection.py
@@ -29,8 +29,13 @@ class EmotionE6AffectEventProjectionTests(unittest.IsolatedAsyncioTestCase):
         event = normalize_emotion_event({
             "event_id": "emo-affect",
             "origin_kind": "memory_recall",
+            "bot_id": "bot-1",
+            "scope": "private",
+            "platform": "qq",
             "event_type": "warm_memory",
             "session_id": "session-a",
+            "actor_ref": {"kind": "user", "id": "user-1", "role": "speaker"},
+            "target_ref": {"kind": "bot", "id": "bot-1", "role": "bot_self"},
             "valence_hint": 2.0,
             "arousal_hint": 0.6,
             "vulnerability_hint": 0.4,
@@ -38,7 +43,15 @@ class EmotionE6AffectEventProjectionTests(unittest.IsolatedAsyncioTestCase):
             "dedupe_key": "affect",
         }, producer_plugin="memory_companion")
         await store.upsert_emotion_event(event)
-        page = await store.list_emotion_event_deliveries(consumer_id="companion", limit=5)
+        page = await store.list_emotion_event_deliveries(
+            consumer_id="private_companion.daily_state",
+            bot_id="bot-1",
+            scope="private",
+            platform="qq",
+            user_id="user-1",
+            session_id="session-a",
+            limit=5,
+        )
         delivered = page["events"][0]
         self.assertEqual(1.0, delivered["affect_modulation"]["valence"])
         self.assertEqual(["emo-affect"], delivered["affect_modulation"]["source_event_ids"])

--- a/tests/test_emotion_e6_affect_event_projection.py
+++ b/tests/test_emotion_e6_affect_event_projection.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.affect_modulation import normalize_affect_modulation  # noqa: E402
+from core.emotion_event_contract import normalize_emotion_event  # noqa: E402
+from core.store import MemoryStore  # noqa: E402
+
+
+class EmotionE6AffectEventProjectionTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = MemoryStore(Path(temp_dir.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def test_delivery_contains_bounded_event_delta_without_mood_command(self) -> None:
+        store = self.make_store()
+        event = normalize_emotion_event({
+            "event_id": "emo-affect",
+            "origin_kind": "memory_recall",
+            "event_type": "warm_memory",
+            "session_id": "session-a",
+            "valence_hint": 2.0,
+            "arousal_hint": 0.6,
+            "vulnerability_hint": 0.4,
+            "confidence": 0.8,
+            "dedupe_key": "affect",
+        }, producer_plugin="memory_companion")
+        await store.upsert_emotion_event(event)
+        page = await store.list_emotion_event_deliveries(consumer_id="companion", limit=5)
+        delivered = page["events"][0]
+        self.assertEqual(1.0, delivered["affect_modulation"]["valence"])
+        self.assertEqual(["emo-affect"], delivered["affect_modulation"]["source_event_ids"])
+        self.assertNotIn("mood_hint", delivered)
+        self.assertNotIn("memory_id", delivered)
+
+    def test_old_or_nonfinite_values_degrade_to_neutral(self) -> None:
+        result = normalize_affect_modulation({"valence": "1", "arousal": float("nan")})
+        self.assertEqual(0.0, result["valence"])
+        self.assertEqual(0.0, result["arousal"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e7_actor_target_memory.py
+++ b/tests/test_emotion_e7_actor_target_memory.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from core.classifier import MemoryClassifier  # noqa: E402
 from core.emotion_targeting import memory_emotion_refs  # noqa: E402
 from core.models import EntityRef, MemoryRecord, SessionContext  # noqa: E402
 
@@ -18,23 +19,61 @@ class EmotionE7ActorTargetMemoryTests(unittest.TestCase):
     def test_matching_subject_and_session_are_preserved(self) -> None:
         memory = MemoryRecord(
             id="m1",
-            session_id="session-a",
+            session_id="qq:FriendMessage:u1",
+            scope="private",
+            platform="qq",
             subject=EntityRef(kind="user", id="u1", role="speaker"),
+            object=EntityRef(kind="bot", id="b1", role="bot_self"),
+            metadata={"owner_bot_id": "b1"},
         )
-        ctx = SessionContext(session_id="session-a", scope="private", user_id="u1", bot_id="b1")
+        ctx = SessionContext(
+            session_id="qq:FriendMessage:u1",
+            scope="private",
+            platform="qq",
+            user_id="u1",
+            bot_id="b1",
+        )
         refs = memory_emotion_refs(memory, ctx)
         self.assertEqual("u1", refs["actor_ref"]["id"])
         self.assertEqual("b1", refs["target_ref"]["id"])
 
     def test_cross_session_or_different_user_is_rejected(self) -> None:
-        ctx = SessionContext(session_id="session-a", scope="private", user_id="u1", bot_id="b1")
+        ctx = SessionContext(
+            session_id="qq:FriendMessage:u1",
+            scope="private",
+            platform="qq",
+            user_id="u1",
+            bot_id="b1",
+        )
         for memory in (
-            MemoryRecord(id="m1", session_id="session-b", subject=EntityRef(kind="user", id="u1")),
-            MemoryRecord(id="m2", session_id="session-a", subject=EntityRef(kind="user", id="u2")),
-            MemoryRecord(id="m3", session_id="session-a", subject=EntityRef(kind="other", id="nickname")),
+            MemoryRecord(id="m1", session_id="qq:FriendMessage:u2", scope="private", platform="qq", subject=EntityRef(kind="user", id="u1"), metadata={"owner_bot_id": "b1"}),
+            MemoryRecord(id="m2", session_id="qq:FriendMessage:u1", scope="private", platform="qq", subject=EntityRef(kind="user", id="u2"), metadata={"owner_bot_id": "b1"}),
+            MemoryRecord(id="m3", session_id="qq:FriendMessage:u1", scope="private", platform="qq", subject=EntityRef(kind="other", id="nickname"), metadata={"owner_bot_id": "b1"}),
         ):
             with self.subTest(memory=memory.id):
                 self.assertIsNone(memory_emotion_refs(memory, ctx))
+
+    def test_current_user_target_from_classifier_keeps_verified_bot_owner(self) -> None:
+        ctx = SessionContext(
+            session_id="qq:FriendMessage:u1",
+            scope="private",
+            platform="qq",
+            user_id="u1",
+            user_name="小明",
+            bot_id="b1",
+            message_text="今天心情很好",
+        )
+        record = MemoryClassifier().from_user_message(ctx)
+        self.assertIsNotNone(record)
+        assert record is not None
+        self.assertEqual("user", record.object.kind)
+        self.assertEqual("u1", record.object.id)
+        self.assertEqual("b1", record.metadata["owner_bot_id"])
+        refs = memory_emotion_refs(record, ctx)
+        self.assertIsNotNone(refs)
+        assert refs is not None
+        self.assertEqual("u1", refs["actor_ref"]["id"])
+        self.assertEqual("b1", refs["target_ref"]["id"])
 
     def test_nickname_text_is_not_used_as_identity(self) -> None:
         memory = SimpleNamespace(
@@ -42,8 +81,33 @@ class EmotionE7ActorTargetMemoryTests(unittest.TestCase):
             content="小明说你是垃圾",
             subject=SimpleNamespace(kind="user", id="", role="speaker", name="小明"),
         )
-        ctx = SessionContext(session_id="session-a", scope="private", user_id="u1", bot_id="b1")
+        ctx = SessionContext(session_id="session-a", scope="private", platform="qq", user_id="u1", bot_id="b1")
         self.assertIsNone(memory_emotion_refs(memory, ctx))
+
+    def test_recalled_memory_owner_domain_mismatches_are_rejected(self) -> None:
+        ctx = SessionContext(
+            session_id="qq:FriendMessage:u1",
+            scope="private",
+            platform="qq",
+            user_id="u1",
+            bot_id="b1",
+        )
+        base = {
+            "session_id": "qq:FriendMessage:u1",
+            "scope": "private",
+            "platform": "qq",
+            "subject": EntityRef(kind="user", id="u1", role="speaker"),
+        }
+        for suffix, overrides in (
+            ("owner", {"metadata": {"owner_bot_id": "b2"}}),
+            ("target", {"object": EntityRef(kind="bot", id="b2", role="bot_self")}),
+            ("unowned_user_target", {"object": EntityRef(kind="user", id="u1", role="current_private_user")}),
+            ("platform", {"platform": "wechat", "metadata": {"owner_bot_id": "b1"}}),
+            ("scope", {"scope": "group", "metadata": {"owner_bot_id": "b1"}}),
+        ):
+            with self.subTest(domain=suffix):
+                memory = MemoryRecord(id=f"m-{suffix}", **(base | overrides))
+                self.assertIsNone(memory_emotion_refs(memory, ctx))
 
 
 if __name__ == "__main__":

--- a/tests/test_emotion_e7_actor_target_memory.py
+++ b/tests/test_emotion_e7_actor_target_memory.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.emotion_targeting import memory_emotion_refs  # noqa: E402
+from core.models import EntityRef, MemoryRecord, SessionContext  # noqa: E402
+
+
+class EmotionE7ActorTargetMemoryTests(unittest.TestCase):
+    def test_matching_subject_and_session_are_preserved(self) -> None:
+        memory = MemoryRecord(
+            id="m1",
+            session_id="session-a",
+            subject=EntityRef(kind="user", id="u1", role="speaker"),
+        )
+        ctx = SessionContext(session_id="session-a", scope="private", user_id="u1", bot_id="b1")
+        refs = memory_emotion_refs(memory, ctx)
+        self.assertEqual("u1", refs["actor_ref"]["id"])
+        self.assertEqual("b1", refs["target_ref"]["id"])
+
+    def test_cross_session_or_different_user_is_rejected(self) -> None:
+        ctx = SessionContext(session_id="session-a", scope="private", user_id="u1", bot_id="b1")
+        for memory in (
+            MemoryRecord(id="m1", session_id="session-b", subject=EntityRef(kind="user", id="u1")),
+            MemoryRecord(id="m2", session_id="session-a", subject=EntityRef(kind="user", id="u2")),
+            MemoryRecord(id="m3", session_id="session-a", subject=EntityRef(kind="other", id="nickname")),
+        ):
+            with self.subTest(memory=memory.id):
+                self.assertIsNone(memory_emotion_refs(memory, ctx))
+
+    def test_nickname_text_is_not_used_as_identity(self) -> None:
+        memory = SimpleNamespace(
+            session_id="session-a",
+            content="小明说你是垃圾",
+            subject=SimpleNamespace(kind="user", id="", role="speaker", name="小明"),
+        )
+        ctx = SessionContext(session_id="session-a", scope="private", user_id="u1", bot_id="b1")
+        self.assertIsNone(memory_emotion_refs(memory, ctx))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e8_expression_authority.py
+++ b/tests/test_emotion_e8_expression_authority.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.bridge import sanitize_companion_expression_decision  # noqa: E402
+from core.models import SessionContext  # noqa: E402
+from core.service import MemoryCompanionService  # noqa: E402
+
+
+def v2_decision(**updates):
+    value = {
+        "contract": "companion_interaction_expression.v2",
+        "expression_band": "warm",
+        "followup": True,
+        "allowed_behaviors": ["reply", "support", "followup"],
+        "safety_mode": "normal",
+        "blocker": None,
+        "reason_codes": ["interaction_band_applied"],
+        "pacing": "steady",
+        "directness": "natural",
+        "validation_style": "support_first",
+        "self_disclosure": "light",
+        "humor_mode": "light",
+        "topic_initiative": "followup",
+    }
+    value.update(updates)
+    return value
+
+
+class EmotionE8ExpressionAuthorityTests(unittest.TestCase):
+    def test_v2_dimensions_are_validated_and_consumed_read_only(self) -> None:
+        accepted = sanitize_companion_expression_decision(v2_decision())
+        self.assertEqual("accepted", accepted["status"])
+        self.assertEqual("support_first", accepted["decision"]["validation_style"])
+        ctx = SessionContext(scope="private")
+        req = SimpleNamespace(_private_companion_expression_decision=v2_decision())
+        MemoryCompanionService._apply_companion_expression_decision(ctx, req=req)
+        self.assertEqual("companion_interaction_expression.v2", ctx.companion_expression_contract)
+        self.assertEqual("light", ctx.companion_expression_humor_mode)
+        self.assertEqual("followup", ctx.companion_expression_topic_initiative)
+
+    def test_invalid_dimension_fails_closed_and_v1_remains_compatible(self) -> None:
+        self.assertEqual("invalid", sanitize_companion_expression_decision(v2_decision(humor_mode="override_safety"))["status"])
+        legacy = v2_decision(contract="companion_interaction_expression.v1")
+        for key in ("pacing", "directness", "validation_style", "self_disclosure", "humor_mode", "topic_initiative"):
+            legacy.pop(key)
+        accepted = sanitize_companion_expression_decision(legacy)
+        self.assertEqual("accepted", accepted["status"])
+        self.assertNotIn("humor_mode", accepted["decision"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e9_page_admin_gate.py
+++ b/tests/test_emotion_e9_page_admin_gate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import sys
 import types
 import unittest
@@ -19,8 +21,20 @@ if "quart" not in sys.modules:
     quart_stub.send_file = AsyncMock()
     sys.modules["quart"] = quart_stub
 
-import astrbot_plugin_remember_you.page_api as page_api_module  # noqa: E402
-from astrbot_plugin_remember_you.page_api import PluginPageApi  # noqa: E402
+PACKAGE_NAME = "astrbot_plugin_remember_you"
+if PACKAGE_NAME not in sys.modules:
+    package_spec = importlib.util.spec_from_file_location(
+        PACKAGE_NAME,
+        ROOT / "__init__.py",
+        submodule_search_locations=[str(ROOT)],
+    )
+    assert package_spec and package_spec.loader
+    package = importlib.util.module_from_spec(package_spec)
+    sys.modules[PACKAGE_NAME] = package
+    package_spec.loader.exec_module(package)
+
+page_api_module = importlib.import_module(f"{PACKAGE_NAME}.page_api")
+PluginPageApi = page_api_module.PluginPageApi
 
 
 class _JsonResponse(dict):

--- a/tests/test_emotion_e9_page_admin_gate.py
+++ b/tests/test_emotion_e9_page_admin_gate.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(ROOT.parent))
+
+if "quart" not in sys.modules:
+    quart_stub = types.ModuleType("quart")
+    quart_stub.jsonify = lambda payload=None, **kwargs: payload or kwargs
+    quart_stub.request = SimpleNamespace(args={}, method="GET")
+    quart_stub.send_file = AsyncMock()
+    sys.modules["quart"] = quart_stub
+
+import astrbot_plugin_remember_you.page_api as page_api_module  # noqa: E402
+from astrbot_plugin_remember_you.page_api import PluginPageApi  # noqa: E402
+
+
+class _JsonResponse(dict):
+    status_code = 200
+
+
+class _Bridge:
+    def __init__(self) -> None:
+        self.capability = object()
+        self.context = object()
+        self.get_emotion_trace_diagnostic = AsyncMock(
+            return_value={"state": "ready", "read_only": True, "items": []}
+        )
+
+    def bind_emotion_page_api(self, _page_api):
+        return self.capability
+
+    def create_emotion_admin_context(self, capability, *, bot_id, scope, session_id):
+        if capability is not self.capability:
+            return None
+        if (bot_id, scope, session_id) != ("bot-1", "private", "session-1"):
+            return None
+        return self.context
+
+
+class EmotionE9PageAdminGateTests(unittest.IsolatedAsyncioTestCase):
+    async def invoke(self, *, bound_username: str, query: dict[str, str]):
+        bridge = _Bridge()
+        plugin = SimpleNamespace(
+            service=SimpleNamespace(),
+            context=SimpleNamespace(get_config=lambda: {"dashboard": {"username": "admin"}}),
+            memory_companion=bridge,
+        )
+        api = PluginPageApi(plugin)
+        fake_request = SimpleNamespace(
+            args=query,
+            headers={"X-Emotion-Admin": "true"},
+            cookies={"emotion_admin": "true"},
+        )
+        with (
+            patch.object(page_api_module, "request", fake_request),
+            patch.object(page_api_module, "astrbot_web_request", SimpleNamespace(username=bound_username)),
+            patch.object(page_api_module, "jsonify", side_effect=lambda body: _JsonResponse(body)),
+        ):
+            response = await api.emotion_trace()
+        return response, bridge
+
+    async def test_query_header_and_cookie_cannot_claim_admin(self) -> None:
+        response, bridge = await self.invoke(
+            bound_username="attacker",
+            query={
+                "trace_id": "trace-1",
+                "bot_id": "bot-1",
+                "scope": "private",
+                "session_id": "session-1",
+                "is_admin": "true",
+            },
+        )
+        self.assertEqual(403, response.status_code)
+        self.assertEqual("admin_required", response["error"])
+        bridge.get_emotion_trace_diagnostic.assert_not_awaited()
+
+    async def test_framework_bound_dashboard_admin_reaches_bridge(self) -> None:
+        response, bridge = await self.invoke(
+            bound_username="admin",
+            query={
+                "trace_id": "trace-1",
+                "bot_id": "bot-1",
+                "scope": "private",
+                "session_id": "session-1",
+            },
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(response["success"])
+        bridge.get_emotion_trace_diagnostic.assert_awaited_once_with(
+            "trace-1", bridge.context, limit=100
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emotion_e9_trace_query.py
+++ b/tests/test_emotion_e9_trace_query.py
@@ -32,6 +32,7 @@ class EmotionE9TraceQueryTests(unittest.IsolatedAsyncioTestCase):
             "origin_kind": "memory_recall",
             "bot_id": bot_id,
             "scope": "private",
+            "platform": "qq",
             "session_id": session_id,
             "event_type": "warm_memory",
             "actor_ref": {"kind": "user", "id": "raw-user-id", "role": "speaker"},
@@ -58,7 +59,15 @@ class EmotionE9TraceQueryTests(unittest.IsolatedAsyncioTestCase):
         store = self.make_store()
         await self.add_event(store, event_id="e1", trace_id="trace-shared", bot_id="b1", session_id="s1")
         await self.add_event(store, event_id="e2", trace_id="trace-shared", bot_id="b2", session_id="s2")
-        await store.list_emotion_event_deliveries(consumer_id="companion", session_id="s1", limit=5)
+        await store.list_emotion_event_deliveries(
+            consumer_id="private_companion.daily_state",
+            bot_id="b1",
+            scope="private",
+            platform="qq",
+            user_id="raw-user-id",
+            session_id="s1",
+            limit=5,
+        )
         bridge = MemoryCompanionBridge(type("Plugin", (), {"store": store})())
 
         denied = await bridge.get_emotion_trace_diagnostic("trace-shared", {"is_admin": True})

--- a/tests/test_emotion_e9_trace_query.py
+++ b/tests/test_emotion_e9_trace_query.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -39,6 +40,20 @@ class EmotionE9TraceQueryTests(unittest.IsolatedAsyncioTestCase):
             "raw_text": "PRIVATE CHAT /tmp/secret token=abc",
         }, producer_plugin="memory_companion"))
 
+    @staticmethod
+    def admin_context(bridge: MemoryCompanionBridge, *, bot_id: str, scope: str, session_id: str):
+        page = SimpleNamespace(plugin=bridge._plugin)
+        capability = bridge.bind_emotion_page_api(page)
+        assert capability is not None
+        context = bridge.create_emotion_admin_context(
+            capability,
+            bot_id=bot_id,
+            scope=scope,
+            session_id=session_id,
+        )
+        assert context is not None
+        return context
+
     async def test_admin_scope_filter_redaction_and_delivery_status(self) -> None:
         store = self.make_store()
         await self.add_event(store, event_id="e1", trace_id="trace-shared", bot_id="b1", session_id="s1")
@@ -46,11 +61,11 @@ class EmotionE9TraceQueryTests(unittest.IsolatedAsyncioTestCase):
         await store.list_emotion_event_deliveries(consumer_id="companion", session_id="s1", limit=5)
         bridge = MemoryCompanionBridge(type("Plugin", (), {"store": store})())
 
-        denied = await bridge.get_emotion_trace_diagnostic("trace-shared", {"is_admin": False})
+        denied = await bridge.get_emotion_trace_diagnostic("trace-shared", {"is_admin": True})
         self.assertEqual("forbidden", denied["state"])
         result = await bridge.get_emotion_trace_diagnostic(
             "trace-shared",
-            {"is_admin": True, "bot_id": "b1", "scope": "private", "session_id": "s1"},
+            self.admin_context(bridge, bot_id="b1", scope="private", session_id="s1"),
         )
         self.assertEqual(1, len(result["items"]))
         item = result["items"][0]
@@ -67,13 +82,13 @@ class EmotionE9TraceQueryTests(unittest.IsolatedAsyncioTestCase):
             await self.add_event(store, event_id=f"e{index}", trace_id=f"t{index}", bot_id="b1", session_id="s1")
         bridge = MemoryCompanionBridge(type("Plugin", (), {"store": store})())
         first = await bridge.get_emotion_trace_summary(
-            {"is_admin": True, "bot_id": "b1", "scope": "private", "session_id": "s1"},
+            self.admin_context(bridge, bot_id="b1", scope="private", session_id="s1"),
             limit=1000,
         )
         self.assertEqual(100, len(first["items"]))
         self.assertTrue(first["has_more"])
         second = await bridge.get_emotion_trace_summary(
-            {"is_admin": True, "bot_id": "b1", "scope": "private", "session_id": "s1"},
+            self.admin_context(bridge, bot_id="b1", scope="private", session_id="s1"),
             cursor=first["next_cursor"],
             limit=100,
         )

--- a/tests/test_emotion_e9_trace_query.py
+++ b/tests/test_emotion_e9_trace_query.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.bridge import MemoryCompanionBridge  # noqa: E402
+from core.emotion_event_contract import normalize_emotion_event  # noqa: E402
+from core.store import MemoryStore  # noqa: E402
+
+
+class EmotionE9TraceQueryTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = MemoryStore(Path(temp_dir.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def add_event(self, store: MemoryStore, *, event_id: str, trace_id: str, bot_id: str, session_id: str) -> None:
+        await store.upsert_emotion_event(normalize_emotion_event({
+            "event_id": event_id,
+            "trace_id": trace_id,
+            "origin_kind": "memory_recall",
+            "bot_id": bot_id,
+            "scope": "private",
+            "session_id": session_id,
+            "event_type": "warm_memory",
+            "actor_ref": {"kind": "user", "id": "raw-user-id", "role": "speaker"},
+            "target_ref": {"kind": "bot", "id": bot_id, "role": "bot_self"},
+            "dedupe_key": event_id,
+            "raw_text": "PRIVATE CHAT /tmp/secret token=abc",
+        }, producer_plugin="memory_companion"))
+
+    async def test_admin_scope_filter_redaction_and_delivery_status(self) -> None:
+        store = self.make_store()
+        await self.add_event(store, event_id="e1", trace_id="trace-shared", bot_id="b1", session_id="s1")
+        await self.add_event(store, event_id="e2", trace_id="trace-shared", bot_id="b2", session_id="s2")
+        await store.list_emotion_event_deliveries(consumer_id="companion", session_id="s1", limit=5)
+        bridge = MemoryCompanionBridge(type("Plugin", (), {"store": store})())
+
+        denied = await bridge.get_emotion_trace_diagnostic("trace-shared", {"is_admin": False})
+        self.assertEqual("forbidden", denied["state"])
+        result = await bridge.get_emotion_trace_diagnostic(
+            "trace-shared",
+            {"is_admin": True, "bot_id": "b1", "scope": "private", "session_id": "s1"},
+        )
+        self.assertEqual(1, len(result["items"]))
+        item = result["items"][0]
+        self.assertEqual("e1", item["event_id"])
+        self.assertEqual(12, len(item["actor"]["id_hash"]))
+        self.assertEqual(1, item["deliveries"][0]["attempts"])
+        rendered = repr(result)
+        for secret in ("PRIVATE CHAT", "/tmp/secret", "token=abc", "raw-user-id"):
+            self.assertNotIn(secret, rendered)
+
+    async def test_summary_is_hard_limited_and_paginated_over_1000_events(self) -> None:
+        store = self.make_store()
+        for index in range(1005):
+            await self.add_event(store, event_id=f"e{index}", trace_id=f"t{index}", bot_id="b1", session_id="s1")
+        bridge = MemoryCompanionBridge(type("Plugin", (), {"store": store})())
+        first = await bridge.get_emotion_trace_summary(
+            {"is_admin": True, "bot_id": "b1", "scope": "private", "session_id": "s1"},
+            limit=1000,
+        )
+        self.assertEqual(100, len(first["items"]))
+        self.assertTrue(first["has_more"])
+        second = await bridge.get_emotion_trace_summary(
+            {"is_admin": True, "bot_id": "b1", "scope": "private", "session_id": "s1"},
+            cursor=first["next_cursor"],
+            limit=100,
+        )
+        self.assertEqual(100, len(second["items"]))
+        self.assertNotEqual(first["items"][0]["event_id"], second["items"][0]["event_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_epistemic_calibration.py
+++ b/tests/test_epistemic_calibration.py
@@ -136,7 +136,7 @@ class EpistemicCalibrationTests(unittest.TestCase):
         self.assertFalse(decision.suppress_long_memory)
         self.assertFalse(decision.allow_contextual_expansion)
 
-    def test_group_actor_guard_is_private_by_default_but_allows_named_recall(self) -> None:
+    def test_group_actor_guard_blocks_profile_and_private_recall_even_when_named(self) -> None:
         service = self.make_service()
         ctx = SessionContext(
             session_id="qq:GroupMessage:g1",
@@ -199,9 +199,13 @@ class EpistemicCalibrationTests(unittest.TestCase):
 
         filtered, blocked = service._filter_group_actor_memory_slots(ctx, slots)
         selected_ids = {item.memory.id for items in filtered.values() for item in items}
-        self.assertEqual({"current-profile"}, selected_ids)
+        self.assertEqual(set(), selected_ids)
         self.assertEqual(
-            {"group_profile_actor_not_current_sender", "group_private_memory_requires_recall_or_personalization"},
+            {
+                "req036_group_profile_requires_portrait_summary",
+                "req036_group_third_party_profile_forbidden",
+                "req036_group_private_memory_forbidden",
+            },
             {item["reason"] for item in blocked},
         )
 
@@ -211,9 +215,13 @@ class EpistemicCalibrationTests(unittest.TestCase):
             query_text="给我讲个符合我性格的故事",
         )
         personalized_ids = {item.memory.id for items in personalized.values() for item in items}
-        self.assertEqual({"current-profile", "current-private"}, personalized_ids)
+        self.assertEqual(set(), personalized_ids)
         self.assertEqual(
-            {"group_profile_actor_not_current_sender", "group_private_memory_actor_not_current_sender"},
+            {
+                "req036_group_profile_requires_portrait_summary",
+                "req036_group_third_party_profile_forbidden",
+                "req036_group_private_memory_forbidden",
+            },
             {item["reason"] for item in personalized_blocked},
         )
 
@@ -223,8 +231,15 @@ class EpistemicCalibrationTests(unittest.TestCase):
             query_text="还记得小李之前说过的蛋糕吗？",
         )
         recalled_ids = {item.memory.id for items in recalled.values() for item in items}
-        self.assertEqual({"current-profile", "current-private", "other-profile", "other-private"}, recalled_ids)
-        self.assertEqual([], recalled_blocked)
+        self.assertEqual(set(), recalled_ids)
+        self.assertEqual(
+            {
+                "req036_group_profile_requires_portrait_summary",
+                "req036_group_third_party_profile_forbidden",
+                "req036_group_private_memory_forbidden",
+            },
+            {item["reason"] for item in recalled_blocked},
+        )
 
     def test_future_arrangement_route_keeps_association_soft(self) -> None:
         service = self.make_service()

--- a/tests/test_ops_parity_p6_relationship.py
+++ b/tests/test_ops_parity_p6_relationship.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if "astrbot_plugin_remember_you" not in sys.modules:
+    package = types.ModuleType("astrbot_plugin_remember_you")
+    package.__path__ = [str(ROOT)]
+    sys.modules["astrbot_plugin_remember_you"] = package
+if str(ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(ROOT.parent))
+
+from astrbot_plugin_remember_you.core.bridge import MemoryCompanionBridge
+from astrbot_plugin_remember_you.core.coordination_status import build_coordination_status, project_p6_status, project_runtime_health
+from astrbot_plugin_remember_you.core.p6_four_package_manifest import (
+    FOUR_PACKAGE_IDS,
+    FOUR_PACKAGE_MANIFEST_SCHEMA,
+    verify_four_package_manifests,
+)
+from astrbot_plugin_remember_you.core.p6_readonly_projection import (
+    P6_READONLY_STATUS_FINGERPRINT,
+    P6_READONLY_STATUS_SCHEMA,
+    build_p6_readonly_status,
+)
+
+
+def _manifest_set() -> dict[str, dict[str, str]]:
+    return {
+        package_id: {
+            "schema": FOUR_PACKAGE_MANIFEST_SCHEMA,
+            "package_id": package_id,
+            "manifest_version": "1.0",
+            "package_fingerprint": "a" * 64,
+            "compatibility_fingerprint": "b" * 64,
+        }
+        for package_id in FOUR_PACKAGE_IDS
+    }
+
+
+def _p6_raw(**changes):
+    result = {
+        "schema_version": P6_READONLY_STATUS_SCHEMA,
+        "source_plugin": "private_companion",
+        "contract_fingerprint": P6_READONLY_STATUS_FINGERPRINT,
+        "health": "ready",
+        "reason_code": "",
+        "counts": {"profiles": 1, "identity_links": 2, "audit_events": 3, "operations": 4},
+    }
+    result.update(changes)
+    return result
+
+
+class OpsParityP6RelationshipTests(unittest.TestCase):
+    class _HashCollisionKey:
+        def __init__(self, field: str) -> None:
+            self._field = field
+            self.hash_calls = 0
+            self.eq_calls = 0
+            self.str_calls = 0
+
+        def __hash__(self) -> int:
+            self.hash_calls += 1
+            return hash(self._field)
+
+        def __eq__(self, other: object) -> bool:
+            self.eq_calls += 1
+            raise AssertionError("hostile key was compared")
+
+        def __str__(self) -> str:
+            self.str_calls += 1
+            raise AssertionError("hostile key was stringified")
+
+    class _HostileValue:
+        def __init__(self) -> None:
+            self.hash_calls = 0
+            self.eq_calls = 0
+            self.str_calls = 0
+
+        def __hash__(self) -> int:
+            self.hash_calls += 1
+            raise AssertionError("hostile value was hashed")
+
+        def __eq__(self, other: object) -> bool:
+            self.eq_calls += 1
+            raise AssertionError("hostile value was compared")
+
+        def __str__(self) -> str:
+            self.str_calls += 1
+            raise AssertionError("hostile value was stringified")
+
+    def test_p6_manifest_and_readonly_projection_reject_extensions_and_conflicts(self):
+        self.assertEqual("verified", verify_four_package_manifests(_manifest_set())["status"])
+        extended = _manifest_set()
+        extended["memory"]["identity"] = "must-not-project"
+        self.assertEqual("unverifiable", verify_four_package_manifests(extended)["status"])
+
+        conflict = _manifest_set()
+        conflict["peiban"]["compatibility_fingerprint"] = "c" * 64
+        self.assertEqual("compatibility_fingerprint_mismatch", verify_four_package_manifests(conflict)["reason_code"])
+
+        self.assertEqual("ready", project_p6_status(_p6_raw())["health"])
+        self.assertEqual("unverifiable", project_p6_status(_p6_raw(extra="must-not-project"))["health"])
+        self.assertEqual("unverifiable", project_p6_status(_p6_raw(contract_fingerprint="x" * 64))["health"])
+
+    def test_p6_enum_checks_reject_hostile_values_before_hooks(self):
+        for field in ("schema_version", "source_plugin", "contract_fingerprint", "health", "reason_code"):
+            raw = _p6_raw(**{field: self._HostileValue()})
+            self.assertEqual("unverifiable", project_p6_status(raw)["health"])
+        hostile = self._HostileValue()
+        self.assertEqual("unverifiable", build_p6_readonly_status({}, health=hostile)["health"])
+        self.assertEqual("invalid_reason_code", build_p6_readonly_status({}, reason_code=hostile)["reason_code"])
+
+    def test_p6_and_bridge_reject_hash_collision_hostile_keys_before_hooks(self):
+        raw_key = self._HashCollisionKey("schema_version")
+        counts_key = self._HashCollisionKey("profiles")
+        bridge_key = self._HashCollisionKey("health")
+        self.assertEqual("unverifiable", project_p6_status({raw_key: "not-reached"})["health"])
+        self.assertEqual("unverifiable", project_p6_status({**_p6_raw(), "counts": {counts_key: 1}})["health"])
+        status = build_coordination_status(
+            config=None,
+            runtime={"compatibility_level": "full"},
+            bridge={bridge_key: "not-reached"},
+            p6_raw=_p6_raw(),
+        )
+        self.assertEqual({"health": "unverifiable", "reason_code": "bridge_status_unavailable"}, status["bridge"])
+
+    def test_p6_projection_rejects_hash_collision_hostile_keys_before_hooks(self):
+        hostile = self._HashCollisionKey("profiles")
+        status = {hostile: 1}
+        hash_calls_before_projection = hostile.hash_calls
+
+        projection = build_p6_readonly_status(status)
+
+        self.assertEqual("unverifiable", projection["health"])
+        self.assertEqual("registry_status_unavailable", projection["reason_code"])
+        self.assertEqual(
+            {"profiles": 0, "identity_links": 0, "audit_events": 0, "operations": 0},
+            projection["counts"],
+        )
+        self.assertEqual(hash_calls_before_projection, hostile.hash_calls)
+        self.assertEqual(0, hostile.eq_calls)
+        self.assertEqual(0, hostile.str_calls)
+
+    def test_relationship_peek_fails_closed_and_filters_untrusted_fields(self):
+        class Broken:
+            def _peek_relationship_phase(self, _ctx):
+                raise RuntimeError("broken")
+
+        class Extended:
+            def _peek_relationship_phase(self, _ctx):
+                return {
+                    "observed": True,
+                    "phase": "close",
+                    "momentum_band": "rising",
+                    "touch_count": 7,
+                    "momentum": 0.9,
+                    "person_id": "must-not-project",
+                }
+
+        fallback = {"observed": False, "phase": "unknown", "momentum_band": "unknown"}
+        self.assertEqual(fallback, MemoryCompanionBridge(Broken()).peek_relationship_phase(session_id="s"))
+        projection = MemoryCompanionBridge(Extended()).peek_relationship_phase(session_id="s")
+        self.assertEqual({"observed": True, "phase": "close", "momentum_band": "rising", "touch_count": 7}, projection)
+        self.assertNotIn("momentum", projection)
+        self.assertNotIn("person_id", projection)
+
+        hostile_key = self._HashCollisionKey("observed")
+        hostile_value = self._HostileValue()
+        hostile_result = {hostile_key: hostile_value}
+        hash_calls_before_peek = hostile_key.hash_calls
+        projection = MemoryCompanionBridge(
+            types.SimpleNamespace(_peek_relationship_phase=lambda _ctx: hostile_result)
+        ).peek_relationship_phase(session_id="s")
+        self.assertEqual(fallback, projection)
+        self.assertEqual(hash_calls_before_peek, hostile_key.hash_calls)
+        self.assertEqual(0, hostile_key.eq_calls)
+        self.assertEqual(0, hostile_key.str_calls)
+        self.assertEqual(0, hostile_value.hash_calls)
+        self.assertEqual(0, hostile_value.eq_calls)
+        self.assertEqual(0, hostile_value.str_calls)
+        self.assertNotIn("hostile", repr(projection))
+
+    def test_runtime_health_rejects_hostile_dict_keys_and_values_before_hooks(self):
+        self.assertEqual(
+            {"health": "unverifiable", "reason_code": "runtime_unsupported"},
+            project_runtime_health({"compatibility_level": "full", "extra": "must-not-project"}),
+        )
+
+        hostile_key = self._HashCollisionKey("compatibility_level")
+        hostile_runtime = {hostile_key: "full"}
+        hash_calls_before_projection = hostile_key.hash_calls
+        self.assertEqual(
+            {"health": "unverifiable", "reason_code": "runtime_unsupported"},
+            project_runtime_health(hostile_runtime),
+        )
+        self.assertEqual(hash_calls_before_projection, hostile_key.hash_calls)
+        self.assertEqual(0, hostile_key.eq_calls)
+        self.assertEqual(0, hostile_key.str_calls)
+
+        hostile_value = self._HostileValue()
+        self.assertEqual(
+            {"health": "unverifiable", "reason_code": "runtime_unsupported"},
+            project_runtime_health({"compatibility_level": hostile_value}),
+        )
+        self.assertEqual(0, hostile_value.hash_calls)
+        self.assertEqual(0, hostile_value.eq_calls)
+        self.assertEqual(0, hostile_value.str_calls)
+
+    def test_coordination_status_degrades_for_invalid_bridge_and_p6_without_leaking_fields(self):
+        status = build_coordination_status(
+            config=None,
+            runtime={"compatibility_level": "full"},
+            bridge={"health": "ready", "reason_code": "companion_bridge_available", "session_id": "must-not-project"},
+            p6_raw=_p6_raw(extra="must-not-project"),
+        )
+        self.assertEqual("unverifiable", status["health"])
+        self.assertEqual({"health": "unverifiable", "reason_code": "bridge_status_unavailable"}, status["bridge"])
+        self.assertEqual("unverifiable", status["p6"]["health"])
+        self.assertNotIn("must-not-project", repr(status))

--- a/tests/test_panel_regressions.py
+++ b/tests/test_panel_regressions.py
@@ -140,7 +140,7 @@ class PanelRegressionTests(unittest.TestCase):
         self.assertIn("height:calc(100% - 16px)", image_block.group(1))
         self.assertIn("object-fit:contain", image_block.group(1))
         self.assertIn("height:clamp(480px, 62vh, 820px)", drawer_block.group(1))
-        self.assertIn("app.css?v=1.7.1", page)
+        self.assertIn("app.css?v=1.7.1-user-workspace", page)
 
     def test_microscope_has_explicit_context_and_non_overlapping_results(self) -> None:
         page = (ROOT / "pages" / "记忆面板" / "index.html").read_text(encoding="utf-8")
@@ -264,10 +264,26 @@ class PanelRegressionTests(unittest.TestCase):
         self.assertIn(':root[data-overview-layout="standard"] .projection-stage', styles)
         self.assertIn(".film-app.is-workspace .overview-layout-switch", styles)
         self.assertIn("@media(max-width:760px)", styles)
-        self.assertIn("app.js?v=1.7.1", page)
+        self.assertIn("app.js?v=1.7.1-user-workspace", page)
 
         ids = re.findall(r'\bid="([^"]+)"', page)
         self.assertEqual(len(ids), len(set(ids)), "记忆面板不能包含重复 HTML id")
+
+    def test_user_profile_and_private_memory_share_one_user_workspace(self) -> None:
+        page = (ROOT / "pages" / "记忆面板" / "index.html").read_text(encoding="utf-8")
+        script = (ROOT / "pages" / "记忆面板" / "app.js").read_text(encoding="utf-8")
+
+        self.assertIn("用户档案与记忆", page)
+        self.assertIn('data-overview-view="relations" data-user-memory-filter="private"', page)
+        self.assertIn('id="userMemoryTitle"', page)
+        self.assertIn('data-user-memory-filter="profile"', page)
+        self.assertIn('data-user-memory-filter="private"', page)
+        self.assertIn('if (view === "maintain")', script)
+        self.assertIn('view = "relations"', script)
+        self.assertIn('if (state.activeView === "relations") return "private"', script)
+        self.assertIn('scopedMemoryParams("private", { limit: 180 })', script)
+        self.assertIn('params.delete("session_id")', script)
+        self.assertNotIn('id="clearCurrentPrivateMemoryBtn" class="danger subtle" type="button" disabled>清空当前用户</button>\n            </div>\n            <div id="privateMemoryList"', page)
 
 
 if __name__ == "__main__":

--- a/tests/test_private_group_acl_recall.py
+++ b/tests/test_private_group_acl_recall.py
@@ -91,7 +91,7 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             effect="allow",
         )
 
-    async def test_acl_shared_explicit_memory_answers_natural_group_question(self) -> None:
+    async def test_acl_shared_explicit_memory_does_not_enter_group_prompt(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(self.private_memory())
         await self.allow_private_to_group(service)
@@ -103,13 +103,9 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             write_log=False,
         )
 
-        self.assertIn("番茄鸡蛋面", injection)
-        self.assertIn("acl_allowed", injection)
-        self.assertIn("权限只表示该记忆可作为候选", injection)
-        self.assertIn("普通陈述或意图不清时忽略", injection)
-        self.assertIn("当前发言者的核心意图", injection)
+        self.assertNotIn("番茄鸡蛋面", injection)
 
-    async def test_acl_shared_tool_memory_is_kept_by_recent_state_guard(self) -> None:
+    async def test_acl_shared_tool_memory_does_not_enter_group_prompt(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(self.private_memory(memory_type="tool_memory"))
         await self.allow_private_to_group(service)
@@ -120,10 +116,9 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             write_log=False,
         )
 
-        self.assertIn("番茄鸡蛋面", injection)
-        self.assertIn("普通陈述或意图不清时忽略", injection)
+        self.assertNotIn("番茄鸡蛋面", injection)
 
-    async def test_production_remember_tool_record_is_recalled_across_acl(self) -> None:
+    async def test_production_remember_tool_record_is_not_recalled_across_acl(self) -> None:
         service = self.make_service()
         private_ctx = SessionContext(
             session_id="qq:FriendMessage:u1",
@@ -149,11 +144,9 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             write_log=False,
         )
 
-        self.assertIn("云杉面馆", injection)
-        self.assertNotIn("只影响语气，禁止复述", injection)
-        self.assertIn("普通陈述或意图不清时忽略", injection)
+        self.assertNotIn("云杉面馆", injection)
 
-    async def test_acl_shared_preference_can_be_used_without_recall_keywords(self) -> None:
+    async def test_acl_shared_preference_does_not_enter_group_prompt(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(
             self.private_memory(
@@ -170,8 +163,7 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             write_log=False,
         )
 
-        self.assertIn("云杉面馆", injection)
-        self.assertIn("普通陈述或意图不清时忽略", injection)
+        self.assertNotIn("云杉面馆", injection)
 
     async def test_no_forward_acl_reverse_acl_and_unrelated_query_stay_private(self) -> None:
         service = self.make_service()
@@ -199,7 +191,7 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn("番茄鸡蛋面", unrelated)
 
-    async def test_related_group_statement_is_prompt_guarded_instead_of_keyword_blocked(self) -> None:
+    async def test_related_group_statement_does_not_reopen_private_memory(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(
             self.private_memory(
@@ -215,10 +207,9 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             write_log=False,
         )
 
-        self.assertIn("小王喜欢的面馆", injection)
-        self.assertIn("否则不要主动公开或复述", injection)
+        self.assertNotIn("小王喜欢的面馆", injection)
 
-    async def test_natural_request_without_fixed_question_words_can_use_acl_candidate(self) -> None:
+    async def test_natural_request_without_fixed_question_words_does_not_reopen_private_memory(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(
             self.private_memory(
@@ -234,10 +225,9 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             write_log=False,
         )
 
-        self.assertIn("云杉面馆", injection)
-        self.assertIn("不要依赖固定疑问词判断用户意图", injection)
+        self.assertNotIn("云杉面馆", injection)
 
-    async def test_omitted_subject_recall_is_not_rejected_by_pronoun_rules(self) -> None:
+    async def test_omitted_subject_recall_does_not_reopen_private_memory(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(self.private_memory())
         await self.allow_private_to_group(service)
@@ -248,8 +238,7 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             write_log=False,
         )
 
-        self.assertIn("番茄鸡蛋面", injection)
-        self.assertIn("普通陈述或意图不清时忽略", injection)
+        self.assertNotIn("番茄鸡蛋面", injection)
 
     async def test_private_acl_does_not_cross_bot_or_platform(self) -> None:
         service = self.make_service()
@@ -283,7 +272,7 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertNotIn("番茄鸡蛋面", injection)
 
-    async def test_acl_revoke_removes_cached_private_group_result(self) -> None:
+    async def test_acl_cannot_create_cached_private_group_result(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(self.private_memory())
         rule = await self.allow_private_to_group(service)
@@ -291,22 +280,21 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
 
         first = await service._compose_memory_injection(ctx, max_chars=3200, write_log=False)
         second = await service._compose_memory_injection(ctx, max_chars=3200, write_log=False)
-        self.assertIn("番茄鸡蛋面", first)
-        self.assertIn("番茄鸡蛋面", second)
+        self.assertNotIn("番茄鸡蛋面", first)
+        self.assertNotIn("番茄鸡蛋面", second)
 
         await service.store.delete_acl_rule(rule["id"])
         revoked = await service._compose_memory_injection(ctx, max_chars=3200, write_log=False)
         self.assertNotIn("番茄鸡蛋面", revoked)
 
-    async def test_recall_tool_uses_same_group_actor_guard(self) -> None:
+    async def test_recall_tool_blocks_private_memory_for_group_owner_and_others(self) -> None:
         service = self.make_service()
         await service.store.insert_memory(self.private_memory())
         await self.allow_private_to_group(service)
 
         service.identity.resolve_event_context = AsyncMock(return_value=self.group_context())
         owner_result = await service.tool_recall(object(), "我中午吃了什么？")
-        self.assertEqual(["小王明确说过：中午吃了番茄鸡蛋面。"], [item["content"] for item in owner_result["memories"]])
-        self.assertIn("条件候选", owner_result["usage"])
+        self.assertEqual([], owner_result["memories"])
 
         service.identity.resolve_event_context = AsyncMock(
             return_value=self.group_context(user_id="u2", message_text="小王中午吃了什么？")
@@ -730,7 +718,7 @@ class PrivateToGroupAclRecallTests(unittest.IsolatedAsyncioTestCase):
             max_chars=3200,
             write_log=False,
         )
-        self.assertIn("番茄鸡蛋面", recalled)
+        self.assertNotIn("番茄鸡蛋面", recalled)
 
 
 if __name__ == "__main__":

--- a/tests/test_req027_relationship_authority.py
+++ b/tests/test_req027_relationship_authority.py
@@ -26,6 +26,14 @@ def valid_projection() -> dict:
         "tone": "温暖、自然",
         "address_level": "使用已确认昵称",
         "proactive_care_limit": 2,
+        "relationship_mode": "owner_exclusive",
+        "current_interaction": {
+            "expression_band": "affectionate",
+            "label": "爱意",
+            "source": "manual",
+            "reason": "administrator_manual_override",
+            "manual_override": True,
+        },
         "soft_behaviors": {
             "allow_playful_jokes": True,
             "allow_followup": True,
@@ -45,6 +53,9 @@ class Req027RelationshipAuthorityTests(unittest.TestCase):
         self.assertEqual("private_companion.relationship_score", accepted["authority"])
         self.assertTrue(accepted["read_only"])
         self.assertEqual("close", accepted["phase_key"])
+        self.assertEqual("owner_exclusive", accepted["relationship_mode"])
+        self.assertEqual("affectionate", accepted["current_interaction"]["expression_band"])
+        self.assertTrue(accepted["current_interaction"]["manual_override"])
         for forbidden in ("owner", "cross_user_query", "p4_bypass"):
             self.assertNotIn(forbidden, accepted)
 
@@ -80,7 +91,7 @@ class Req027RelationshipAuthorityTests(unittest.TestCase):
         self.assertEqual("", group.relationship_authority_source)
         self.assertEqual("", group.companion_relationship_phase_key)
 
-    def test_companion_authority_stops_memory_phase_transition_but_keeps_momentum(self) -> None:
+    def test_companion_authority_stops_memory_phase_state_writes(self) -> None:
         service = MemoryCompanionService.__new__(MemoryCompanionService)
         state = {
             "phase": "acquaintance",
@@ -108,11 +119,10 @@ class Req027RelationshipAuthorityTests(unittest.TestCase):
             companion_relationship_phase_key="close",
             companion_relationship_phase_label="亲近",
         )
-        self.assertTrue(service._update_relationship_phase_momentum(authoritative, touch_type="warm"))
-        self.assertGreater(state["momentum"], 0)
+        self.assertFalse(service._update_relationship_phase_momentum(authoritative, touch_type="warm"))
+        self.assertEqual(0.0, state["momentum"])
         self.assertEqual(0, calls["transition"])
-        self.assertEqual("private_companion.relationship_score", state["phase_authority"])
-        self.assertEqual("close", state["companion_phase_key"])
+        self.assertEqual(0, calls["save"])
 
         fallback = SessionContext(
             session_id="telegram:FriendMessage:u2",
@@ -122,7 +132,7 @@ class Req027RelationshipAuthorityTests(unittest.TestCase):
         )
         self.assertTrue(service._update_relationship_phase_momentum(fallback, touch_type="warm"))
         self.assertEqual(1, calls["transition"])
-        self.assertEqual(2, calls["save"])
+        self.assertEqual(1, calls["save"])
 
     def test_address_hint_uses_companion_phase_and_memory_declares_trend_only(self) -> None:
         service = MemoryCompanionService.__new__(MemoryCompanionService)

--- a/tests/test_req027_relationship_authority.py
+++ b/tests/test_req027_relationship_authority.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.bridge import sanitize_companion_relationship_projection
+from core.models import SessionContext
+from core.service import MemoryCompanionService
+
+
+def valid_projection() -> dict:
+    return {
+        "schema_version": "chat.relationship_projection.v1",
+        "authority": "private_companion.relationship_score",
+        "read_only": True,
+        "score": 620,
+        "phase_key": "close",
+        "phase_label": "亲近",
+        "tone": "温暖、自然",
+        "address_level": "使用已确认昵称",
+        "proactive_care_limit": 2,
+        "soft_behaviors": {
+            "allow_playful_jokes": True,
+            "allow_followup": True,
+            "allow_memory_mention": True,
+            "allow_daily_care": True,
+        },
+    }
+
+
+class Req027RelationshipAuthorityTests(unittest.TestCase):
+    def test_bridge_accepts_only_the_read_only_fixed_contract(self) -> None:
+        projection = valid_projection()
+        projection.update({"owner": True, "cross_user_query": True, "p4_bypass": True})
+        result = sanitize_companion_relationship_projection(projection)
+        self.assertEqual("accepted", result["status"])
+        accepted = result["projection"]
+        self.assertEqual("private_companion.relationship_score", accepted["authority"])
+        self.assertTrue(accepted["read_only"])
+        self.assertEqual("close", accepted["phase_key"])
+        for forbidden in ("owner", "cross_user_query", "p4_bypass"):
+            self.assertNotIn(forbidden, accepted)
+
+        for mutation in (
+            {"schema_version": "chat.relationship_projection.v2"},
+            {"authority": "memory.relationship_phase"},
+            {"read_only": False},
+            {"score": 1201},
+            {"phase_key": "forged"},
+            {"soft_behaviors": {"allow_followup": "true"}},
+        ):
+            with self.subTest(mutation=mutation):
+                hostile = valid_projection()
+                hostile.update(mutation)
+                self.assertEqual("invalid", sanitize_companion_relationship_projection(hostile)["status"])
+
+        malformed_limit = valid_projection()
+        malformed_limit["proactive_care_limit"] = {"owner": True}
+        sanitized = sanitize_companion_relationship_projection(malformed_limit)
+        self.assertEqual("accepted", sanitized["status"])
+        self.assertEqual(0, sanitized["projection"]["proactive_care_limit"])
+
+    def test_private_context_consumes_projection_but_group_context_does_not(self) -> None:
+        event = SimpleNamespace(private_companion_context={"relationship_projection": valid_projection()})
+        private = SessionContext(session_id="telegram:FriendMessage:u1", scope="private", user_id="u1")
+        MemoryCompanionService._apply_companion_relationship_projection(private, event=event)
+        self.assertEqual("private_companion.relationship_score", private.relationship_authority_source)
+        self.assertEqual(620, private.companion_relationship_score)
+        self.assertEqual("close", private.companion_relationship_phase_key)
+
+        group = SessionContext(session_id="telegram:GroupMessage:g1", scope="group", group_id="g1", user_id="u1")
+        MemoryCompanionService._apply_companion_relationship_projection(group, event=event)
+        self.assertEqual("", group.relationship_authority_source)
+        self.assertEqual("", group.companion_relationship_phase_key)
+
+    def test_companion_authority_stops_memory_phase_transition_but_keeps_momentum(self) -> None:
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        state = {
+            "phase": "acquaintance",
+            "momentum": 0.0,
+            "touch_count": 0,
+            "recent_touch_message_ids": [],
+        }
+        calls = {"transition": 0, "save": 0}
+        service._get_relationship_phase = MethodType(lambda _self, _ctx: state, service)
+        service._maybe_transition_phase = MethodType(
+            lambda _self, _ctx, _state: calls.__setitem__("transition", calls["transition"] + 1),
+            service,
+        )
+        service._save_relationship_phase_state = MethodType(
+            lambda _self: calls.__setitem__("save", calls["save"] + 1),
+            service,
+        )
+
+        authoritative = SessionContext(
+            session_id="telegram:FriendMessage:u1",
+            scope="private",
+            user_id="u1",
+            message_id="m1",
+            relationship_authority_source="private_companion.relationship_score",
+            companion_relationship_phase_key="close",
+            companion_relationship_phase_label="亲近",
+        )
+        self.assertTrue(service._update_relationship_phase_momentum(authoritative, touch_type="warm"))
+        self.assertGreater(state["momentum"], 0)
+        self.assertEqual(0, calls["transition"])
+        self.assertEqual("private_companion.relationship_score", state["phase_authority"])
+        self.assertEqual("close", state["companion_phase_key"])
+
+        fallback = SessionContext(
+            session_id="telegram:FriendMessage:u2",
+            scope="private",
+            user_id="u2",
+            message_id="m2",
+        )
+        self.assertTrue(service._update_relationship_phase_momentum(fallback, touch_type="warm"))
+        self.assertEqual(1, calls["transition"])
+        self.assertEqual(2, calls["save"])
+
+    def test_address_hint_uses_companion_phase_and_memory_declares_trend_only(self) -> None:
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        ctx = SessionContext(
+            session_id="telegram:FriendMessage:u1",
+            scope="private",
+            user_id="u1",
+            relationship_authority_source="private_companion.relationship_score",
+            companion_relationship_phase_key="close",
+            companion_relationship_phase_label="亲近",
+            companion_relationship_tone="温暖、自然",
+            companion_relationship_address_level="使用已确认昵称",
+        )
+        hint = service._address_hint_for_injection(ctx)
+        self.assertIn("陪伴插件是长期亲密度权威", hint)
+        self.assertIn("亲近", hint)
+        self.assertIn("温暖、自然", hint)
+        self.assertIn("Memory 仅提供记忆触动趋势", hint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req028_expression_sync.py
+++ b/tests/test_req028_expression_sync.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.bridge import sanitize_companion_expression_decision
+from core.models import MemoryRecord, SearchResult, SessionContext
+from core.service import MemoryCompanionService, MemoryRouteDecision
+from core.time_intent import TimeIntent
+
+
+def valid_expression_decision(**updates) -> dict:
+    decision = {
+        "contract": "companion_interaction_expression.v1",
+        "expression_band": "warm",
+        "tone": "gentle",
+        "warmth": 76,
+        "distance": 28,
+        "address_style": "warm",
+        "response_length": "balanced",
+        "followup": True,
+        "initiative": "passive_only",
+        "proactive_budget": 0,
+        "tts_style": "warm",
+        "allowed_behaviors": ["reply", "support", "followup"],
+        "safety_mode": "normal",
+        "blocker": None,
+        "reason_codes": ["interaction_band_applied"],
+    }
+    decision.update(updates)
+    return decision
+
+
+def memory_item() -> tuple[MemoryRecord, SearchResult]:
+    memory = MemoryRecord(
+        id="mem-1",
+        memory_type="user_profile",
+        scope="private",
+        session_id="qq:FriendMessage:u1",
+        visibility="private",
+        sayability="direct",
+        reality_level="real_user_fact",
+        content="用户的生日是八月一日",
+        confidence=0.95,
+        importance=0.8,
+        metadata={},
+    )
+    return memory, SearchResult(memory=memory, score=1.2, reason="")
+
+
+class Req028ExpressionSyncTests(unittest.TestCase):
+    def test_expression_contract_is_strict_and_redacted(self) -> None:
+        accepted = sanitize_companion_expression_decision(valid_expression_decision(owner_id="secret"))
+        self.assertEqual("accepted", accepted["status"])
+        self.assertEqual("warm", accepted["decision"]["expression_band"])
+        self.assertNotIn("owner_id", accepted["decision"])
+
+        hostile_values = (
+            valid_expression_decision(contract="companion_interaction_expression.v2"),
+            valid_expression_decision(expression_band="forged"),
+            valid_expression_decision(followup="true"),
+            valid_expression_decision(allowed_behaviors=["reply", "memory_override"]),
+            valid_expression_decision(safety_mode="bypass"),
+            valid_expression_decision(blocker="owner_override"),
+            valid_expression_decision(reason_codes=["unknown_reason"]),
+        )
+        for value in hostile_values:
+            with self.subTest(value=value):
+                self.assertEqual("invalid", sanitize_companion_expression_decision(value)["status"])
+
+    def test_private_context_consumes_request_scoped_decision_and_group_ignores_it(self) -> None:
+        req = SimpleNamespace(_private_companion_expression_decision=valid_expression_decision())
+        private = SessionContext(scope="private", session_id="qq:FriendMessage:u1", user_id="u1")
+        MemoryCompanionService._apply_companion_expression_decision(private, req=req)
+        self.assertEqual("companion_interaction_expression.v1", private.companion_expression_contract)
+        self.assertEqual("warm", private.companion_expression_band)
+        self.assertEqual(("reply", "support", "followup"), private.companion_expression_allowed_behaviors)
+
+        group = SessionContext(scope="group", session_id="qq:GroupMessage:g1", group_id="g1", user_id="u1")
+        MemoryCompanionService._apply_companion_expression_decision(group, req=req)
+        self.assertEqual("", group.companion_expression_contract)
+        self.assertEqual("", group.companion_expression_band)
+
+    def test_companion_caps_unsolicited_mentions_but_explicit_recall_still_reads_fact(self) -> None:
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        memory, item = memory_item()
+        route = MemoryRouteDecision()
+        restricted = SessionContext(
+            scope="private",
+            message_text="今天过得怎么样",
+            companion_expression_contract="companion_interaction_expression.v1",
+            companion_expression_band="hurt",
+            companion_expression_allowed_behaviors=("acknowledge", "brief_reply", "give_space"),
+            companion_expression_safety_mode="normal",
+        )
+        expression, reason = service._memory_expression_decision(
+            restricted, memory, item, "user_profile", route, TimeIntent(), query_text=restricted.message_text
+        )
+        self.assertEqual("tone", expression)
+        self.assertEqual("companion_expression:band_hurt", reason)
+
+        restricted.message_text = "你还记得我的生日吗"
+        expression, reason = service._memory_expression_decision(
+            restricted, memory, item, "user_profile", route, TimeIntent(), query_text=restricted.message_text
+        )
+        self.assertEqual("mention", expression)
+        self.assertEqual("stable_user_fact", reason)
+
+    def test_allowed_behaviors_are_a_maximum_not_a_memory_override(self) -> None:
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        memory, item = memory_item()
+        route = MemoryRouteDecision()
+        relaxed = SessionContext(
+            scope="private",
+            message_text="随便聊聊",
+            companion_expression_contract="companion_interaction_expression.v1",
+            companion_expression_band="relaxed",
+            companion_expression_allowed_behaviors=("reply", "clarify"),
+            companion_expression_safety_mode="normal",
+        )
+        self.assertEqual(
+            ("tone", "companion_expression:behavior_cap"),
+            service._memory_expression_decision(relaxed, memory, item, "user_profile", route, TimeIntent()),
+        )
+        relaxed.companion_expression_band = "warm"
+        relaxed.companion_expression_allowed_behaviors = ("reply", "support")
+        self.assertEqual(
+            ("mention", "stable_user_fact"),
+            service._memory_expression_decision(relaxed, memory, item, "user_profile", route, TimeIntent()),
+        )
+
+    def test_paired_mode_does_not_inject_second_tone_or_write_legacy_state(self) -> None:
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        ctx = SessionContext(
+            scope="private",
+            session_id="qq:FriendMessage:u1",
+            user_id="u1",
+            message_id="m1",
+            relationship_authority_source="private_companion.relationship_score",
+            companion_expression_contract="companion_interaction_expression.v1",
+            companion_expression_band="warm",
+            companion_expression_allowed_behaviors=("reply", "support"),
+            companion_expression_safety_mode="normal",
+        )
+        calls = {"get": 0, "save": 0}
+        service._get_relationship_phase = MethodType(
+            lambda _self, _ctx: calls.__setitem__("get", calls["get"] + 1) or {}, service
+        )
+        service._save_relationship_phase_state = MethodType(
+            lambda _self: calls.__setitem__("save", calls["save"] + 1), service
+        )
+        self.assertEqual("", service._address_hint_for_injection(ctx))
+        service._update_address_evolution(ctx, "宝贝")
+        self.assertFalse(service._update_relationship_phase_momentum(ctx, touch_type="warm"))
+        self.assertEqual({"get": 0, "save": 0}, calls)
+
+    def test_standalone_fallback_remains_available(self) -> None:
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        service._BOT_ADDRESS_SUGGESTIONS = {"acquaintance": {"hint": "standalone address hint"}}
+        service._get_relationship_phase = MethodType(
+            lambda _self, _ctx: {"phase": "acquaintance", "current_address_phase": ""}, service
+        )
+        ctx = SessionContext(scope="private", session_id="qq:FriendMessage:u1", user_id="u1")
+        self.assertEqual("standalone address hint", service._address_hint_for_injection(ctx))
+
+    def test_page_source_exposes_coordination_without_second_relationship_authority(self) -> None:
+        source = (ROOT / "pages" / "记忆面板" / "app.js").read_text(encoding="utf-8")
+        for retired in ("关系阶段演进", "情绪事件队列", "称呼演变记录", "Bot 称呼建议"):
+            self.assertNotIn(retired, source)
+        for required in ("陪伴表达协同状态", "记忆触动趋势", "记忆触动事件", "当时关系情境"):
+            self.assertIn(required, source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req029_user_memory_summary_bridge.py
+++ b/tests/test_req029_user_memory_summary_bridge.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.bridge import MemoryCompanionBridge
+from core.models import EntityRef, MemoryRecord
+from core.service import MemoryCompanionService, USER_MEMORY_SUMMARY_VERSION
+from core.store import MemoryStore
+
+
+class _Config:
+    def __init__(self, enabled: bool = True) -> None:
+        self.enabled = enabled
+
+    def bridge_enabled(self) -> bool:
+        return self.enabled
+
+
+class Req029UserMemorySummaryBridgeTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = MemoryStore(Path(temp_dir.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def add_private_memory(
+        self,
+        store: MemoryStore,
+        *,
+        record_id: str,
+        user_id: str,
+        memory_type: str,
+        content: str,
+        session_id: str | None = None,
+    ) -> None:
+        await store.insert_memory(
+            MemoryRecord(
+                id=record_id,
+                memory_type=memory_type,
+                subject=EntityRef(kind="user", id=user_id),
+                object=EntityRef.bot_self(),
+                scope="private",
+                session_id=session_id or f"qq:FriendMessage:{user_id}",
+                visibility="private_pair",
+                lifecycle="stable_memory",
+                content=content,
+                occurred_at="2026-08-02T10:00:00+00:00",
+            )
+        )
+
+    async def test_exact_identity_query_counts_categories_and_excludes_other_users(self) -> None:
+        store = self.make_store()
+        for record_id, memory_type in (
+            ("profile", "user_profile"),
+            ("preference", "user_preference"),
+            ("relation", "relationship_claim"),
+            ("conversation", "conversation_summary"),
+        ):
+            await self.add_private_memory(
+                store,
+                record_id=record_id,
+                user_id="u1",
+                memory_type=memory_type,
+                content=f"u1-private-{record_id}",
+            )
+        await self.add_private_memory(
+            store,
+            record_id="other-user",
+            user_id="u2",
+            memory_type="user_profile",
+            content="u2-private-only",
+        )
+        await store.insert_memory(
+            MemoryRecord(
+                id="group-u1",
+                memory_type="user_profile",
+                subject=EntityRef(kind="user", id="u1"),
+                object=EntityRef(kind="group", id="g1"),
+                scope="group",
+                session_id="qq:GroupMessage:g1",
+                group_id="g1",
+                visibility="group_public",
+                content="group-only",
+            )
+        )
+
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        service.config = _Config(True)
+        service.store = store
+        result = await service.read_user_memory_summary("u1", session_id="qq:FriendMessage:u1", limit=8)
+
+        self.assertEqual(USER_MEMORY_SUMMARY_VERSION, result["contract"])
+        self.assertTrue(result["ok"])
+        self.assertEqual("ready", result["state"])
+        self.assertEqual(
+            {"profile": 1, "preference": 1, "relationship": 1, "private_conversation": 1, "other": 0, "total": 4},
+            result["counts"],
+        )
+        rendered = repr(result["summaries"])
+        for forbidden in ("u1-private", "u2-private-only", "group-only"):
+            self.assertNotIn(forbidden, rendered)
+        self.assertTrue(all(item["content_redacted"] and item["truncated"] for item in result["summaries"]))
+
+    async def test_session_mismatch_fails_closed_without_cross_user_fallback(self) -> None:
+        store = self.make_store()
+        await self.add_private_memory(
+            store,
+            record_id="u1-profile",
+            user_id="u1",
+            memory_type="user_profile",
+            content="private-u1",
+        )
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        service.config = _Config(True)
+        service.store = store
+
+        result = await service.read_user_memory_summary("u1", session_id="qq:FriendMessage:u2")
+        self.assertFalse(result["ok"])
+        self.assertEqual("degraded", result["state"])
+        self.assertEqual("session_identity_mismatch", result["error_code"])
+        self.assertEqual(0, result["counts"]["total"])
+
+    async def test_bridge_contract_redacts_records_and_degrades_for_disabled_or_failed_queries(self) -> None:
+        store = self.make_store()
+        await self.add_private_memory(
+            store,
+            record_id="secret-profile",
+            user_id="u1",
+            memory_type="user_profile",
+            content="TOKEN=PRIVATE_CONTEXT_MUST_NOT_LEAK " + "x" * 500,
+        )
+        service = MemoryCompanionService.__new__(MemoryCompanionService)
+        service.config = _Config(True)
+        service.store = store
+        bridge = MemoryCompanionBridge(service)
+
+        ready = await bridge.read_user_memory_summary("u1", limit=99)
+        self.assertTrue(ready["ok"])
+        self.assertEqual(USER_MEMORY_SUMMARY_VERSION, ready["contract"])
+        self.assertLessEqual(len(ready["summaries"]), 8)
+        self.assertNotIn("PRIVATE_CONTEXT_MUST_NOT_LEAK", repr(ready))
+        self.assertNotIn("content", ready["summaries"][0])
+
+        service.config = _Config(False)
+        disabled = await bridge.read_user_memory_summary("u1")
+        self.assertFalse(disabled["ok"])
+        self.assertEqual("bridge_disabled", disabled["error_code"])
+        self.assertEqual(0, disabled["counts"]["total"])
+
+        class _BrokenService:
+            async def read_user_memory_summary(self, *_args, **_kwargs):
+                raise RuntimeError("sensitive failure details")
+
+        broken = await MemoryCompanionBridge(_BrokenService()).read_user_memory_summary("u1")
+        self.assertFalse(broken["ok"])
+        self.assertEqual("bridge_exception", broken["error_code"])
+        self.assertNotIn("sensitive failure details", repr(broken))
+
+    def test_bridge_and_page_api_expose_only_the_read_only_workspace_contract(self) -> None:
+        bridge_source = (ROOT / "core" / "bridge.py").read_text(encoding="utf-8")
+        page_source = (ROOT / "page_api.py").read_text(encoding="utf-8")
+        self.assertIn("async def read_user_memory_summary", bridge_source)
+        self.assertIn('"/user-memory-summary"', page_source)
+        self.assertIn("content_redacted", bridge_source)
+        self.assertNotIn("write_user_memory_summary", bridge_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req036_portrait.py
+++ b/tests/test_req036_portrait.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "req036_memory"
+if PACKAGE not in sys.modules:
+    module = types.ModuleType(PACKAGE)
+    module.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE] = module
+
+from req036_memory.core.models import EntityRef, MemoryRecord, SearchResult, SessionContext
+from req036_memory.core.bridge import MemoryCompanionBridge
+from req036_memory.core.portrait import build_evidence, normalized_claim_hash
+from req036_memory.core.portrait_service import PortraitService
+from req036_memory.core.service import MemoryCompanionService
+from req036_memory.core.store import MemoryStore
+from req036_memory.unified_profile_contract import build_capability_summary, build_profile_dto, build_portrait_request
+
+
+PERSON_REF = {
+    "person_id": "person_" + "1" * 24,
+    "resolved_identity_key": "chat-origin-v1:" + "2" * 64,
+    "projection_revision": 1,
+    "identity_assurance": "observed",
+    "profile_status": "active",
+}
+
+
+class _Config:
+    @staticmethod
+    def int(key: str, default: int) -> int:
+        return {
+            "portrait.min_independent_evidence": 3,
+            "portrait.daily_success_limit_per_person": 1,
+            "portrait.daily_attempt_limit_per_person": 2,
+            "portrait.inferred_freshness_days": 90,
+        }.get(key, default)
+
+    @staticmethod
+    def float(key: str, default: float) -> float:
+        return {"portrait.usage_min_confidence": 0.75}.get(key, default)
+
+
+class Req036PortraitTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        store = MemoryStore(Path(temp.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    @staticmethod
+    def dto(mode: str = "learn_and_use") -> dict[str, object]:
+        return build_profile_dto(
+            person_ref=PERSON_REF,
+            capability_summary={
+                "private_companion_enabled": True,
+                "proactive_private_enabled": False,
+                "portrait_mode": mode,
+                "grant_source": "administrator",
+            },
+        )
+
+    @staticmethod
+    def request(scope: str = "private", requester: str | None = None) -> dict[str, object]:
+        return build_portrait_request(
+            person_ref=PERSON_REF,
+            requester_person_id=requester if requester is not None else PERSON_REF["person_id"],
+            target_person_id=PERSON_REF["person_id"],
+            scope=scope,
+            purpose="summarize_to_subject",
+        )
+
+    async def test_explicit_evidence_daily_limit_and_scope_filtered_summary(self) -> None:
+        store = self.make_store()
+        service = PortraitService(store, _Config())
+        for index, text in enumerate(("我喜欢烤肉", "我真的喜欢烤肉", "我最喜欢烤肉")):
+            event = types.SimpleNamespace(private_companion_unified_profile_context=self.dto())
+            ctx = SessionContext(
+                session_id="onebot:FriendMessage:10001",
+                scope="private",
+                platform="onebot",
+                user_id="10001",
+                message_id=f"m-{index}",
+                message_text=text,
+            )
+            result = await service.capture_user_message(ctx, event=event)
+            self.assertTrue(result["ok"])
+
+        batch = await service.run_daily_batch(PERSON_REF["person_id"], run_day="2026-08-05")
+        self.assertTrue(batch["ok"])
+        self.assertEqual(1, batch["successes"])
+        self.assertEqual("portrait_daily_limit", (await service.run_daily_batch(PERSON_REF["person_id"], run_day="2026-08-05"))["code"])
+        summary = await service.read_summary(self.request())
+        self.assertTrue(summary["ok"])
+        self.assertTrue(any("烤肉" in item["summary"] for item in summary["items"]))
+
+    async def test_mechanical_repeats_do_not_satisfy_independent_evidence_threshold(self) -> None:
+        store = self.make_store()
+        service = PortraitService(store, _Config())
+        for index in range(3):
+            event = types.SimpleNamespace(private_companion_unified_profile_context=self.dto())
+            ctx = SessionContext(
+                session_id="onebot:FriendMessage:10001",
+                scope="private",
+                platform="onebot",
+                user_id="10001",
+                message_id=f"repeat-{index}",
+                message_text="我喜欢烤肉",
+            )
+            self.assertTrue((await service.capture_user_message(ctx, event=event))["ok"])
+        result = await service.run_daily_batch(PERSON_REF["person_id"], run_day="2026-08-05")
+        self.assertFalse(result["ok"])
+        self.assertEqual("portrait_insufficient_evidence", result["code"])
+
+    async def test_third_party_rejection_happens_before_store_query(self) -> None:
+        store = self.make_store()
+        portraits = PortraitService(store, _Config())
+        service = object.__new__(MemoryCompanionService)
+        service.portraits = portraits
+        calls = 0
+
+        async def should_not_query(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            return {"ok": True, "items": []}
+
+        store.portrait_summary = should_not_query  # type: ignore[method-assign]
+        result = await service.read_unified_profile_portrait(
+            self.request(requester="person_" + "9" * 24)
+        )
+        self.assertFalse(result["ok"])
+        self.assertEqual("portrait_third_party_forbidden", result["code"])
+        self.assertEqual(0, calls)
+
+    async def test_unverified_or_stale_projection_is_rejected_before_fact_query(self) -> None:
+        store = self.make_store()
+        portraits = PortraitService(store, _Config())
+        service = object.__new__(MemoryCompanionService)
+        service.portraits = portraits
+        current_ref = {**PERSON_REF, "projection_revision": 2}
+        await store.upsert_portrait_person_projection(
+            current_ref,
+            build_capability_summary({
+                "private_companion_enabled": True,
+                "proactive_private_enabled": False,
+                "portrait_mode": "use_existing",
+            }),
+        )
+        calls = 0
+
+        async def should_not_query(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            return {"ok": True, "items": []}
+
+        store.portrait_summary = should_not_query  # type: ignore[method-assign]
+        self.assertEqual(
+            "bridge_stale_revision",
+            (await service.read_unified_profile_portrait(self.request()))["code"],
+        )
+        unverified_ref = {**PERSON_REF, "identity_assurance": "unverified"}
+        unverified_request = build_portrait_request(
+            person_ref=unverified_ref,
+            requester_person_id=unverified_ref["person_id"],
+            target_person_id=unverified_ref["person_id"],
+            scope="private",
+            purpose="summarize_to_subject",
+        )
+        self.assertEqual(
+            "bridge_person_mismatch",
+            (await service.read_unified_profile_portrait(unverified_request))["code"],
+        )
+        self.assertEqual(0, calls)
+
+    async def test_group_source_only_fact_cannot_cross_into_private_scope(self) -> None:
+        store = self.make_store()
+        await store.upsert_portrait_person_projection(
+            PERSON_REF,
+            build_capability_summary({
+                "private_companion_enabled": True,
+                "proactive_private_enabled": False,
+                "portrait_mode": "use_existing",
+            }),
+        )
+        claim_hash = normalized_claim_hash("preference", "like:桌游")
+        evidence = build_evidence(
+            person_ref=PERSON_REF,
+            scope="group:onebot:group-a",
+            session_id="onebot:GroupMessage:group-a",
+            message_id="g-1",
+            source_identity_key=PERSON_REF["resolved_identity_key"],
+            text="我喜欢桌游",
+        )
+        await store.add_portrait_evidence(evidence)
+        await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_REF["person_id"],
+                "dimension": "preference",
+                "normalized_claim_hash": claim_hash,
+                "claim_summary": "喜欢 桌游",
+                "portrait_tier": "base",
+                "producer_kind": "rule_explicit",
+                "producer_version": "test",
+                "derivation_kind": "explicit_statement",
+                "epistemic_status": "explicit",
+                "source_scope": "group:onebot:group-a",
+                "usable_scope": "source_only",
+                "confidence": 0.9,
+                "sensitivity": "low",
+                "evidence_hashes": [evidence["evidence_hash"]],
+                "operation_id": "group-fact",
+            }
+        )
+        private = await store.portrait_summary(PERSON_REF["person_id"], scope="private")
+        group_a = await store.portrait_summary(PERSON_REF["person_id"], scope="group:onebot:group-a")
+        group_b = await store.portrait_summary(PERSON_REF["person_id"], scope="group:onebot:group-b")
+        self.assertEqual([], private["items"])
+        self.assertEqual(1, len(group_a["items"]))
+        self.assertEqual([], group_b["items"])
+
+    async def test_cross_scene_allowlist_keeps_schedule_like_habits_in_source_scope(self) -> None:
+        store = self.make_store()
+        service = PortraitService(store, _Config())
+        event = types.SimpleNamespace(private_companion_unified_profile_context=self.dto("use_existing"))
+        for message_id, text in (("food", "我喜欢烤肉"), ("schedule", "我通常凌晨工作")):
+            result = await service.capture_user_message(
+                SessionContext(
+                    session_id="onebot:FriendMessage:10001",
+                    scope="private",
+                    platform="onebot",
+                    user_id="10001",
+                    message_id=message_id,
+                    message_text=text,
+                ),
+                event=event,
+            )
+            self.assertTrue(result["ok"])
+
+        group_summary = await service.read_summary(self.request(scope="group:onebot:group-a"))
+        summaries = [item["summary"] for item in group_summary["items"]]
+        self.assertTrue(any("烤肉" in item for item in summaries))
+        self.assertFalse(any("凌晨" in item for item in summaries))
+
+    async def test_suppression_blocks_write_and_read_and_is_idempotent(self) -> None:
+        store = self.make_store()
+        await store.upsert_portrait_person_projection(
+            PERSON_REF,
+            build_capability_summary({
+                "private_companion_enabled": True,
+                "proactive_private_enabled": False,
+                "portrait_mode": "use_existing",
+            }),
+        )
+        claim_hash = normalized_claim_hash("preference", "like:烤肉")
+        evidence = build_evidence(
+            person_ref=PERSON_REF,
+            scope="private",
+            session_id="onebot:FriendMessage:10001",
+            message_id="m-1",
+            source_identity_key=PERSON_REF["resolved_identity_key"],
+            text="我喜欢烤肉",
+        )
+        await store.add_portrait_evidence(evidence)
+        inserted = await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_REF["person_id"], "dimension": "preference", "normalized_claim_hash": claim_hash,
+                "claim_summary": "喜欢 烤肉", "portrait_tier": "base", "producer_kind": "rule_explicit",
+                "producer_version": "test", "derivation_kind": "explicit_statement", "epistemic_status": "explicit",
+                "source_scope": "private", "usable_scope": "self_low_global", "confidence": 0.9, "sensitivity": "low",
+                "evidence_hashes": [evidence["evidence_hash"]], "operation_id": "fact-1",
+            }
+        )
+        governed = await store.govern_portrait_fact(
+            person_id=PERSON_REF["person_id"], fact_id=inserted["fact_id"], action="suppress",
+            actor="administrator", operation_id="suppress-1",
+        )
+        self.assertTrue(governed["ok"])
+        replay = await store.govern_portrait_fact(
+            person_id=PERSON_REF["person_id"], fact_id=inserted["fact_id"], action="suppress",
+            actor="administrator", operation_id="suppress-1",
+        )
+        self.assertEqual("suppression_idempotent_replay", replay["code"])
+        self.assertEqual([], (await store.portrait_summary(PERSON_REF["person_id"], scope="private"))["items"])
+        blocked = await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_REF["person_id"], "dimension": "preference", "normalized_claim_hash": claim_hash,
+                "claim_summary": "喜欢 烤肉", "portrait_tier": "intelligent", "producer_kind": "daily_evidence_batch",
+                "producer_version": "test", "derivation_kind": "aggregate", "epistemic_status": "inferred",
+                "source_scope": "private", "usable_scope": "self_low_global", "confidence": 0.9, "sensitivity": "low",
+                "evidence_hashes": [evidence["evidence_hash"]], "operation_id": "replay-evidence",
+            }
+        )
+        self.assertEqual("portrait_suppressed", blocked["code"])
+
+    async def test_migration_dry_run_apply_idempotence_and_rollback(self) -> None:
+        store = self.make_store()
+        dry = await store.portrait_migration(operation_id="migration-1", dry_run=True)
+        self.assertEqual("migration_dry_run", dry["code"])
+        applied = await store.portrait_migration(operation_id="migration-1", dry_run=False)
+        self.assertEqual("migration_applied", applied["code"])
+        self.assertEqual("migration_idempotent_replay", (await store.portrait_migration(operation_id="migration-1", dry_run=False))["code"])
+        self.assertEqual("migration_rolled_back", (await store.rollback_portrait_migration(operation_id="migration-1"))["code"])
+
+    async def test_denied_private_gate_bypasses_memory_service_before_identity_resolution(self) -> None:
+        service = object.__new__(MemoryCompanionService)
+        service.identity = types.SimpleNamespace(resolve_event_context=AsyncMock())
+        event = types.SimpleNamespace(private_companion_req036_denied=True)
+
+        await service.handle_llm_request(event, object())
+
+        service.identity.resolve_event_context.assert_not_awaited()
+
+    async def test_bridge_never_returns_high_sensitivity_portrait_items(self) -> None:
+        class PortraitPlugin:
+            async def read_unified_profile_portrait(self, _request, *, limit: int):
+                self.assert_limit = limit
+                return {
+                    "ok": True,
+                    "code": "profile_exact",
+                    "portrait_revision": 7,
+                    "items": [
+                        {
+                            "dimension": "preference",
+                            "summary": "喜欢 烤肉",
+                            "sensitivity": "low",
+                            "portrait_tier": "base",
+                            "epistemic_status": "explicit",
+                            "confidence": 0.9,
+                            "updated_at": "2026-08-05T00:00:00+00:00",
+                        },
+                        {
+                            "dimension": "health",
+                            "summary": "敏感健康信息",
+                            "sensitivity": "high",
+                            "portrait_tier": "base",
+                            "epistemic_status": "explicit",
+                            "confidence": 0.9,
+                            "updated_at": "2026-08-05T00:00:00+00:00",
+                        },
+                    ],
+                }
+
+        plugin = PortraitPlugin()
+        result = await MemoryCompanionBridge(plugin).read_unified_profile_portrait(
+            self.request(),
+            limit=99,
+        )
+
+        self.assertEqual(16, plugin.assert_limit)
+        self.assertEqual(["喜欢 烤肉"], [item["summary"] for item in result["items"]])
+        self.assertNotIn("敏感健康信息", str(result))
+
+    async def test_group_profile_and_private_blocks_ignore_legacy_guard_toggle(self) -> None:
+        service = object.__new__(MemoryCompanionService)
+        service._context_bool = lambda *_args, **_kwargs: False
+        ctx = SessionContext(
+            session_id="onebot:GroupMessage:group-a",
+            scope="group",
+            platform="onebot",
+            group_id="group-a",
+            user_id="10001",
+            user_name="测试用户",
+        )
+        profile = MemoryRecord(
+            id="profile",
+            memory_type="user_profile",
+            subject=EntityRef(kind="user", id="10001", name="测试用户"),
+            scope="group",
+            group_id="group-a",
+            visibility="group_public",
+            content="不应进入群聊模型的旧画像。",
+        )
+        private = MemoryRecord(
+            id="private",
+            memory_type="conversation_summary",
+            subject=EntityRef(kind="user", id="10001", name="测试用户"),
+            scope="private",
+            visibility="private_pair",
+            content="不应进入群聊模型的私聊记忆。",
+        )
+
+        filtered, blocked = service._filter_group_actor_memory_slots(
+            ctx,
+            {
+                "user_profile": [SearchResult(memory=profile, score=1.0)],
+                "conversation_summary": [SearchResult(memory=private, score=1.0)],
+            },
+        )
+
+        self.assertEqual(set(), {item.memory.id for items in filtered.values() for item in items})
+        self.assertEqual(
+            {
+                "req036_group_profile_requires_portrait_summary",
+                "req036_group_private_memory_forbidden",
+            },
+            {item["reason"] for item in blocked},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_security_cache.py
+++ b/tests/test_security_cache.py
@@ -480,7 +480,7 @@ class SecurityAndCacheTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual({}, service._retrieval_result_cache)
         self.assertEqual({}, json.loads(service._RELATIONSHIP_PHASE_FILE.read_text(encoding="utf-8")))
 
-    async def test_cross_window_emotional_reads_are_opt_in(self) -> None:
+    async def test_cross_window_emotional_reads_without_context_are_disabled(self) -> None:
         config: dict = {"private_companion_bridge": {}}
         service = self.make_service(config)
         service._emotional_event_queue["qq:FriendMessage:u1"] = [
@@ -495,8 +495,8 @@ class SecurityAndCacheTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, len(service._emotional_event_queue["qq:FriendMessage:u1"]))
 
         config["private_companion_bridge"]["cross_window_emotional_continuity_enabled"] = True
-        events = service.bridge_get_emotional_events(session_id="")
-        self.assertEqual(["emotion-1"], [item["id"] for item in events])
+        self.assertEqual([], service.bridge_get_emotional_events(session_id=""))
+        self.assertEqual(1, len(service._emotional_event_queue["qq:FriendMessage:u1"]))
 
     async def test_note_tools_keep_read_and_delete_scoped_to_current_bot(self) -> None:
         service = self.make_service({"retrieval": {"embedding_enabled": False}})

--- a/tests/test_summary_relationship.py
+++ b/tests/test_summary_relationship.py
@@ -938,6 +938,75 @@ class SummaryAndRelationshipTests(unittest.IsolatedAsyncioTestCase):
         bridged = bridge.get_relationship_phase(session_id=private.session_id, scope="private")
         self.assertIs(state, bridged)
 
+    async def test_peek_relationship_phase_is_read_only_and_fails_closed(self) -> None:
+        service = self.make_service()
+        ctx = SessionContext(
+            session_id="qq:FriendMessage:ambiguous-user",
+            scope="private",
+            platform="qq",
+            user_id="ambiguous-user",
+        )
+        fallback = {"observed": False, "phase": "unknown", "momentum_band": "unknown"}
+        self.assertEqual(fallback, service._peek_relationship_phase(ctx))
+        self.assertEqual({}, service._relationship_phase_state)
+        self.assertFalse(service._RELATIONSHIP_PHASE_FILE.exists())
+
+        identity = service._phase_identity(ctx)
+        service._relationship_phase_state = {
+            "candidate-a": {"_identity": dict(identity), "phase": "close", "momentum": 0.2, "touch_count": 1},
+            "candidate-b": {"_identity": dict(identity), "phase": "close", "momentum": 0.2, "touch_count": 1},
+        }
+        before = json.loads(json.dumps(service._relationship_phase_state))
+        self.assertEqual(fallback, service._peek_relationship_phase(ctx))
+        self.assertEqual(before, service._relationship_phase_state)
+
+        service._relationship_phase_state = {
+            service._phase_key(ctx): {"phase": "close", "momentum": "not-a-number", "touch_count": 1}
+        }
+        before = json.loads(json.dumps(service._relationship_phase_state))
+        self.assertEqual(fallback, service._peek_relationship_phase(ctx))
+        self.assertEqual(before, service._relationship_phase_state)
+        self.assertFalse(service._RELATIONSHIP_PHASE_FILE.exists())
+
+    async def test_peek_relationship_phase_rejects_nonfinite_momentum_without_writing(self) -> None:
+        service = self.make_service()
+        ctx = SessionContext(
+            session_id="qq:FriendMessage:nonfinite-user",
+            scope="private",
+            platform="qq",
+            user_id="nonfinite-user",
+        )
+        fallback = {"observed": False, "phase": "unknown", "momentum_band": "unknown"}
+
+        for momentum in (float("nan"), float("inf"), float("-inf")):
+            service._relationship_phase_state = {
+                service._phase_key(ctx): {"phase": "close", "momentum": momentum, "touch_count": 1}
+            }
+            before = json.dumps(service._relationship_phase_state, sort_keys=True)
+            self.assertEqual(fallback, service._peek_relationship_phase(ctx))
+            self.assertEqual(before, json.dumps(service._relationship_phase_state, sort_keys=True))
+            self.assertFalse(service._RELATIONSHIP_PHASE_FILE.exists())
+
+    async def test_peek_relationship_phase_preserves_finite_momentum_bands(self) -> None:
+        service = self.make_service()
+        ctx = SessionContext(
+            session_id="qq:FriendMessage:finite-user",
+            scope="private",
+            platform="qq",
+            user_id="finite-user",
+        )
+
+        for momentum, momentum_band in ((-0.08, "cooling"), (0, "steady"), (0.08, "rising")):
+            service._relationship_phase_state = {
+                service._phase_key(ctx): {"phase": "close", "momentum": momentum, "touch_count": 1}
+            }
+            before = json.dumps(service._relationship_phase_state, sort_keys=True)
+            self.assertEqual(
+                {"observed": True, "phase": "close", "momentum_band": momentum_band, "touch_count": 1},
+                service._peek_relationship_phase(ctx),
+            )
+            self.assertEqual(before, json.dumps(service._relationship_phase_state, sort_keys=True))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unified_profile_contract.py
+++ b/unified_profile_contract.py
@@ -1,0 +1,338 @@
+"""REQ-036 minimal cross-plugin unified-profile contract.
+
+The contract deliberately contains references and policy state only.  Raw chat
+text, evidence bodies, and authority-owned portrait records never cross this
+boundary.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+
+CONTRACT_NAME = "chat.unified_profile.v1"
+CONTRACT_VERSION = "1.0"
+SCHEMA_VERSION = "1.0"
+MAX_DTO_BYTES = 32768
+
+PORTRAIT_MODES = frozenset({"disabled", "use_existing", "learn_and_use"})
+PORTRAIT_PURPOSES = frozenset({"adapt_for_subject", "summarize_to_subject", "disclose_to_third_party"})
+IDENTITY_ASSURANCE = frozenset({"unverified", "observed", "verified", "explicit_linked"})
+PROFILE_STATUS = frozenset({"active", "suspended", "quarantined", "deleted"})
+LOW_SENSITIVITY = "low"
+
+PERSON_REF_FIELDS = (
+    "person_id",
+    "resolved_identity_key",
+    "projection_revision",
+    "identity_assurance",
+    "profile_status",
+)
+CAPABILITY_FIELDS = (
+    "private_companion_enabled",
+    "proactive_private_enabled",
+    "effective_proactive_private_enabled",
+    "portrait_mode",
+    "portrait_learning_enabled",
+    "portrait_usage_enabled",
+    "grant_source",
+    "blocked_reasons",
+)
+DTO_FIELDS = (
+    "contract_name",
+    "contract_version",
+    "contract_fingerprint",
+    "schema_version",
+    "person_ref",
+    "identity_summary",
+    "expression_summary",
+    "capability_summary",
+    "portrait_summary",
+    "context_overlays",
+    "bridge_status",
+)
+FORBIDDEN_KEYS = frozenset(
+    {
+        "content",
+        "chat_text",
+        "evidence",
+        "messages",
+        "transcript",
+        "prompt",
+        "raw_prompt",
+        "raw_text",
+        "private_object",
+        "database",
+    }
+)
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _shape() -> dict[str, Any]:
+    return {
+        "name": CONTRACT_NAME,
+        "version": CONTRACT_VERSION,
+        "schema": SCHEMA_VERSION,
+        "person_ref": list(PERSON_REF_FIELDS),
+        "capability_summary": list(CAPABILITY_FIELDS),
+        "dto": list(DTO_FIELDS),
+        "portrait_modes": sorted(PORTRAIT_MODES),
+        "portrait_purposes": sorted(PORTRAIT_PURPOSES),
+        "max_bytes": MAX_DTO_BYTES,
+    }
+
+
+CONTRACT_FINGERPRINT = hashlib.sha256(_canonical(_shape()).encode("utf-8")).hexdigest()[:16]
+
+
+def _text(value: Any, limit: int = 240) -> str:
+    if isinstance(value, bool) or value is None:
+        return ""
+    result = str(value).strip()
+    if not result or "\x00" in result:
+        return ""
+    return result[:limit]
+
+
+def _safe(value: Any, depth: int = 0) -> Any:
+    if depth > 2 or value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        return _text(value, 240)
+    if isinstance(value, (list, tuple)):
+        return [_safe(item, depth + 1) for item in list(value)[:16]]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in list(value.items())[:24]:
+            name = _text(key, 80).lower()
+            if not name or name in FORBIDDEN_KEYS:
+                continue
+            safe = _safe(item, depth + 1)
+            if safe not in (None, "", [], {}):
+                result[name] = safe
+        return result
+    return None
+
+
+def _contains_forbidden(value: Any, depth: int = 0) -> bool:
+    """Reject caller-supplied DTOs that smuggle conversation material in.
+
+    ``build_profile_dto`` already drops these fields, but validation is also a
+    trust boundary because the Memory bridge receives an event-carried DTO.
+    """
+    if depth > 4:
+        return True
+    if isinstance(value, dict):
+        for key, item in value.items():
+            name = _text(key, 80).lower()
+            if not name or name in FORBIDDEN_KEYS:
+                return True
+            if _contains_forbidden(item, depth + 1):
+                return True
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_forbidden(item, depth + 1) for item in value)
+    return False
+
+
+def _positive_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def normalize_portrait_mode(value: Any) -> str:
+    mode = _text(value, 40).lower()
+    aliases = {
+        "off": "disabled",
+        "disabled": "disabled",
+        "use": "use_existing",
+        "use_existing": "use_existing",
+        "learn": "learn_and_use",
+        "learn_and_use": "learn_and_use",
+    }
+    return aliases.get(mode, "disabled")
+
+
+def portrait_mode_flags(mode: Any) -> tuple[bool, bool]:
+    normalized = normalize_portrait_mode(mode)
+    return normalized == "learn_and_use", normalized in {"use_existing", "learn_and_use"}
+
+
+def build_person_ref(value: Any) -> dict[str, Any]:
+    source = value if isinstance(value, dict) else {}
+    result = {
+        "person_id": _text(source.get("person_id"), 80),
+        "resolved_identity_key": _text(source.get("resolved_identity_key"), 96),
+        "projection_revision": _positive_int(source.get("projection_revision")),
+        "identity_assurance": _text(source.get("identity_assurance"), 40),
+        "profile_status": _text(source.get("profile_status"), 40),
+    }
+    return result
+
+
+def validate_person_ref(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["person_ref_invalid"]
+    errors = [f"missing_{field}" for field in PERSON_REF_FIELDS if field not in value]
+    person_id = _text(value.get("person_id"), 80)
+    identity_key = _text(value.get("resolved_identity_key"), 96)
+    if re.fullmatch(r"person_[0-9a-f]{24}", person_id) is None:
+        errors.append("person_id_invalid")
+    if re.fullmatch(r"chat-origin-v1:[0-9a-f]{64}", identity_key) is None:
+        errors.append("identity_key_invalid")
+    if not isinstance(value.get("projection_revision"), int) or value["projection_revision"] < 1:
+        errors.append("projection_revision_invalid")
+    if value.get("identity_assurance") not in IDENTITY_ASSURANCE:
+        errors.append("identity_assurance_invalid")
+    if value.get("profile_status") not in PROFILE_STATUS:
+        errors.append("profile_status_invalid")
+    return errors
+
+
+def build_capability_summary(value: Any) -> dict[str, Any]:
+    source = value if isinstance(value, dict) else {}
+    mode = normalize_portrait_mode(source.get("portrait_mode"))
+    learning, usage = portrait_mode_flags(mode)
+    private_enabled = source.get("private_companion_enabled") is True
+    proactive_enabled = source.get("proactive_private_enabled") is True
+    reasons = [_text(item, 80) for item in source.get("blocked_reasons", []) if _text(item, 80)] if isinstance(source.get("blocked_reasons"), list) else []
+    if proactive_enabled and not private_enabled and "proactive_requires_private_companion" not in reasons:
+        reasons.append("proactive_requires_private_companion")
+    if not private_enabled and "private_companion_disabled" not in reasons:
+        reasons.append("private_companion_disabled")
+    return {
+        "private_companion_enabled": private_enabled,
+        "proactive_private_enabled": proactive_enabled,
+        "effective_proactive_private_enabled": proactive_enabled and private_enabled,
+        "portrait_mode": mode,
+        "portrait_learning_enabled": learning,
+        "portrait_usage_enabled": usage,
+        "grant_source": _text(source.get("grant_source"), 80) or "default_closed",
+        "blocked_reasons": reasons[:8],
+    }
+
+
+def build_profile_dto(
+    *,
+    person_ref: Any,
+    identity_summary: Any = None,
+    expression_summary: Any = None,
+    capability_summary: Any = None,
+    portrait_summary: Any = None,
+    context_overlays: Any = None,
+    bridge_status: Any = None,
+) -> dict[str, Any]:
+    return {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "contract_fingerprint": CONTRACT_FINGERPRINT,
+        "schema_version": SCHEMA_VERSION,
+        "person_ref": build_person_ref(person_ref),
+        "identity_summary": _safe(identity_summary or {}) or {},
+        "expression_summary": _safe(expression_summary or {}) or {},
+        "capability_summary": build_capability_summary(capability_summary),
+        "portrait_summary": _safe(portrait_summary or {}) or {},
+        "context_overlays": _safe(context_overlays or {}) or {},
+        "bridge_status": _safe(bridge_status or {}) or {},
+    }
+
+
+def dto_size_bytes(value: Any) -> int:
+    try:
+        return len(_canonical(value).encode("utf-8"))
+    except (TypeError, ValueError):
+        return MAX_DTO_BYTES + 1
+
+
+def validate_profile_dto(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["dto_invalid"]
+    errors = [f"missing_{field}" for field in DTO_FIELDS if field not in value]
+    if value.get("contract_name") != CONTRACT_NAME:
+        errors.append("contract_name_mismatch")
+    if value.get("contract_version") != CONTRACT_VERSION:
+        errors.append("contract_version_mismatch")
+    if value.get("contract_fingerprint") != CONTRACT_FINGERPRINT:
+        errors.append("contract_fingerprint_mismatch")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        errors.append("schema_version_mismatch")
+    for field in ("identity_summary", "expression_summary", "portrait_summary", "context_overlays", "bridge_status"):
+        if not isinstance(value.get(field), dict):
+            errors.append(f"{field}_invalid")
+        elif _contains_forbidden(value.get(field)):
+            errors.append(f"{field}_contains_forbidden_data")
+    errors.extend(validate_person_ref(value.get("person_ref")))
+    capabilities = value.get("capability_summary")
+    if not isinstance(capabilities, dict):
+        errors.append("capability_summary_invalid")
+    elif capabilities != build_capability_summary(capabilities):
+        errors.append("capability_summary_invalid")
+    if dto_size_bytes(value) > MAX_DTO_BYTES:
+        errors.append("dto_too_large")
+    return errors
+
+
+def build_portrait_request(
+    *,
+    person_ref: Any,
+    requester_person_id: Any,
+    target_person_id: Any,
+    scope: Any,
+    purpose: Any,
+) -> dict[str, Any]:
+    return {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "contract_fingerprint": CONTRACT_FINGERPRINT,
+        "person_ref": build_person_ref(person_ref),
+        "requester_person_id": _text(requester_person_id, 80),
+        "target_person_id": _text(target_person_id, 80),
+        "scope": _text(scope, 80),
+        "purpose": _text(purpose, 80),
+        "max_sensitivity": LOW_SENSITIVITY,
+    }
+
+
+def validate_portrait_request(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["portrait_request_invalid"]
+    errors: list[str] = []
+    if value.get("contract_name") != CONTRACT_NAME or value.get("contract_version") != CONTRACT_VERSION:
+        errors.append("contract_mismatch")
+    if value.get("contract_fingerprint") != CONTRACT_FINGERPRINT:
+        errors.append("contract_fingerprint_mismatch")
+    errors.extend(validate_person_ref(value.get("person_ref")))
+    if _text(value.get("target_person_id"), 80) != _text((value.get("person_ref") or {}).get("person_id"), 80):
+        errors.append("target_person_mismatch")
+    if value.get("purpose") not in PORTRAIT_PURPOSES:
+        errors.append("portrait_purpose_invalid")
+    if not _text(value.get("scope"), 80):
+        errors.append("scope_invalid")
+    if value.get("max_sensitivity") != LOW_SENSITIVITY:
+        errors.append("max_sensitivity_invalid")
+    if _contains_forbidden(value):
+        errors.append("portrait_request_contains_forbidden_data")
+    return errors
+
+
+def contract_self_check() -> list[str]:
+    expected = hashlib.sha256(_canonical(_shape()).encode("utf-8")).hexdigest()[:16]
+    return [] if expected == CONTRACT_FINGERPRINT else ["contract_fingerprint_stale"]
+
+
+__all__ = [name for name in globals() if name.isupper() or name in {
+    "build_capability_summary", "build_person_ref", "build_profile_dto", "build_portrait_request",
+    "contract_self_check", "dto_size_bytes", "normalize_portrait_mode", "portrait_mode_flags",
+    "validate_person_ref", "validate_profile_dto", "validate_portrait_request",
+}]


### PR DESCRIPTION
## 概要

- 在不替代 LivingMemory 的前提下，增加画像、证据、抑制、迁移和人物投影的加法式数据表。
- 在画像检索前校验人物身份 assurance、投影 revision、请求者/目标一致性、敏感等级、作用域与第三方拒绝策略。
- 支持明确事实、每日证据批处理、重复证据抑制、治理、迁移 dry-run/幂等/回滚以及 Memory 管理界面。
- 跨场景使用仅限冻结的低敏白名单，且只能用于与本人交流。

## 合同与安全性

- 与 Companion 保持字节一致的 `chat.unified_profile.v1/1.0` 合同。
- Memory 保持事实、证据与召回权威，绝不授予 Companion 权限或结算关系状态。
- 既有 LivingMemory 数据路径、插件 ID、数据目录与路由隔离保持不变。

## 验证

- Memory 全量：310 passed。
- REQ-036 画像/隐私/迁移专项：11 passed。
- 画像、ACL 与主动重建回归：54 passed。
- 双插件合同专项：3 passed；两侧合同 SHA-256 一致。
- AST、JSON、JavaScript、敏感模式扫描及 git diff 检查均通过。

## 非目标

- 不替代 LivingMemory；不执行生产迁移、部署或直接向第三方披露画像。