### PR TITLE
feat(req041): add strict namespaced memory and scoped migration storage

### DIFF
--- a/core/bridge.py
+++ b/core/bridge.py
@@ -456,11 +456,22 @@ class MemoryCompanionBridge:
         self._capability_cache = CapabilityCache()
         self._emotion_producer_token = object()
         self._emotion_page_admin_token = object()
+        self._active = True
+
+    def bridge_lifecycle_status(self) -> dict[str, Any]:
+        """Expose only whether this in-process bridge can still serve calls."""
+        return {"active": self._active}
+
+    def deactivate(self) -> None:
+        """Revoke all issued capabilities before plugin service shutdown."""
+        self._active = False
+        self._emotion_producer_token = object()
+        self._emotion_page_admin_token = object()
 
     def register_emotion_producer(self, producer: Any) -> Any | None:
         """Issue a private Companion capability only to a live registered plugin."""
 
-        if not self._is_registered_private_companion(producer):
+        if not self._active or not self._is_registered_private_companion(producer):
             return None
         return _EmotionProducerCapability(self, producer, self._emotion_producer_token)
 
@@ -541,6 +552,8 @@ class MemoryCompanionBridge:
     def bind_emotion_page_api(self, page_api: Any) -> Any | None:
         """Issue a private diagnostic capability to this Memory plugin's Page API."""
 
+        if not self._active:
+            return None
         page_plugin = getattr(page_api, "plugin", None)
         if page_plugin is not self._plugin and getattr(page_plugin, "service", None) is not self._plugin:
             return None
@@ -611,7 +624,8 @@ class MemoryCompanionBridge:
 
     def _is_valid_emotion_producer_capability(self, capability: Any) -> bool:
         return (
-            type(capability) is _EmotionProducerCapability
+            self._active
+            and type(capability) is _EmotionProducerCapability
             and capability._bridge is self
             and capability._token is self._emotion_producer_token
             and self._is_registered_private_companion(capability._producer)
@@ -642,7 +656,8 @@ class MemoryCompanionBridge:
 
     def _is_valid_emotion_page_admin_capability(self, capability: Any) -> bool:
         return (
-            type(capability) is _EmotionPageAdminCapability
+            self._active
+            and type(capability) is _EmotionPageAdminCapability
             and capability._bridge is self
             and capability._token is self._emotion_page_admin_token
             and (
@@ -1603,6 +1618,8 @@ class MemoryCompanionBridge:
         must remain safe to call from ordinary chat paths even when the contract
         is stale or the local module is otherwise malformed.
         """
+        if not self._active:
+            return self._negative_personal_capability_probe("bridge_inactive")
         if self._capability_cache.snapshot().get("state") == "negative":
             return self.capability_status()
         try:
@@ -1687,7 +1704,7 @@ class MemoryCompanionBridge:
     def probe_namespace_context_capabilities(self) -> dict[str, Any]:
         """Advertise ready only after the store and active epoch are bound."""
         status = self._scoped_store.epoch_status() if self._scoped_store is not None else {"bound": False}
-        ready = status.get("bound") is True
+        ready = self._active and status.get("bound") is True
         return namespace_capability_descriptor(
             available=ready,
             methods=(
@@ -1700,7 +1717,11 @@ class MemoryCompanionBridge:
                 "tombstone_scoped_record",
                 "upsert_scoped_record",
             ) if ready else (),
-            error_code="" if ready else "namespace_scoped_api_not_bound",
+            error_code=(
+                "" if ready
+                else "bridge_inactive" if not self._active
+                else "namespace_scoped_api_not_bound"
+            ),
         )
 
     def bind_namespace_migration_epoch(
@@ -1712,6 +1733,8 @@ class MemoryCompanionBridge:
         migration_epoch: str,
         policy_version: str,
     ) -> dict[str, Any]:
+        if not self._active:
+            return {"ok": False, "state": "degraded", "code": "bridge_inactive"}
         if not self._is_valid_private_companion_capability(capability):
             return {"ok": False, "state": "forbidden", "code": "producer_capability_required"}
         if self._scoped_store is None:
@@ -1735,10 +1758,14 @@ class MemoryCompanionBridge:
     def _authorized_scoped_context(
         self, capability: Any, namespace: Any
     ) -> tuple[Any | None, dict[str, Any] | None]:
+        if not self._active:
+            return None, {"ok": False, "state": "degraded", "code": "bridge_inactive"}
         if not self._is_valid_private_companion_capability(capability):
             return None, {"ok": False, "state": "forbidden", "code": "producer_capability_required"}
         if self._scoped_store is None:
             return None, {"ok": False, "state": "degraded", "code": "namespace_scoped_store_unavailable"}
+        if self._scoped_store.epoch_status().get("bound") is not True:
+            return None, {"ok": False, "state": "degraded", "code": "namespace_scoped_api_not_bound"}
         errors = validate_namespace_context(namespace)
         if errors:
             return None, {"ok": False, "state": "rejected", "code": errors[0]}

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -1693,6 +1693,7 @@ class MemoryCompanionBridge:
             methods=(
                 "list_scoped_records",
                 "read_scoped_record",
+                "tombstone_scoped_identity_scopes",
                 "tombstone_scoped_namespace",
                 "tombstone_scoped_record",
                 "upsert_scoped_record",
@@ -1825,6 +1826,25 @@ class MemoryCompanionBridge:
             return denied
         try:
             result = self._scoped_store.tombstone_namespace(
+                context, operation_id=operation_id, reason_code=reason_code,
+            )
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", **result}
+
+    def tombstone_scoped_identity_scopes(
+        self,
+        capability: Any,
+        namespace: Any,
+        *,
+        operation_id: str,
+        reason_code: str,
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            result = self._scoped_store.tombstone_identity_scopes(
                 context, operation_id=operation_id, reason_code=reason_code,
             )
         except ScopedStoreError as exc:

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -451,12 +451,26 @@ class MemoryCompanionBridge:
 
     def __init__(self, plugin: Any):
         self._plugin = plugin
-        candidate_scoped_store = getattr(plugin, "scoped_store", None)
-        self._scoped_store = candidate_scoped_store if isinstance(candidate_scoped_store, ScopedStore) else None
+        self.__scoped_store: ScopedStore | None = None
+        self.__scoped_store_resolved = False
         self._capability_cache = CapabilityCache()
         self._emotion_producer_token = object()
         self._emotion_page_admin_token = object()
         self._active = True
+
+    @property
+    def _scoped_store(self) -> ScopedStore | None:
+        """Resolve the namespace store only when a namespace API is used.
+
+        Bot-personal capability probes are pure contract probes and must not
+        touch plugin services or databases merely because a Bridge object was
+        constructed.
+        """
+        if not self.__scoped_store_resolved:
+            candidate = getattr(self._plugin, "scoped_store", None)
+            self.__scoped_store = candidate if isinstance(candidate, ScopedStore) else None
+            self.__scoped_store_resolved = True
+        return self.__scoped_store
 
     def bridge_lifecycle_status(self) -> dict[str, Any]:
         """Expose only whether this in-process bridge can still serve calls."""

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -1694,6 +1694,7 @@ class MemoryCompanionBridge:
                 "list_scoped_records",
                 "read_scoped_record",
                 "erase_scoped_group_scopes",
+                "erase_scoped_persona_scopes",
                 "tombstone_scoped_identity_scopes",
                 "tombstone_scoped_namespace",
                 "tombstone_scoped_record",
@@ -1865,6 +1866,25 @@ class MemoryCompanionBridge:
             return denied
         try:
             result = self._scoped_store.erase_group_scopes(
+                context, operation_id=operation_id, reason_code=reason_code,
+            )
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", **result}
+
+    def erase_scoped_persona_scopes(
+        self,
+        capability: Any,
+        namespace: Any,
+        *,
+        operation_id: str,
+        reason_code: str = "persona_reset",
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            result = self._scoped_store.erase_persona_scopes(
                 context, operation_id=operation_id, reason_code=reason_code,
             )
         except ScopedStoreError as exc:

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -1693,6 +1693,7 @@ class MemoryCompanionBridge:
             methods=(
                 "list_scoped_records",
                 "read_scoped_record",
+                "erase_scoped_group_scopes",
                 "tombstone_scoped_identity_scopes",
                 "tombstone_scoped_namespace",
                 "tombstone_scoped_record",
@@ -1845,6 +1846,25 @@ class MemoryCompanionBridge:
             return denied
         try:
             result = self._scoped_store.tombstone_identity_scopes(
+                context, operation_id=operation_id, reason_code=reason_code,
+            )
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", **result}
+
+    def erase_scoped_group_scopes(
+        self,
+        capability: Any,
+        namespace: Any,
+        *,
+        operation_id: str,
+        reason_code: str = "group_reset",
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            result = self._scoped_store.erase_group_scopes(
                 context, operation_id=operation_id, reason_code=reason_code,
             )
         except ScopedStoreError as exc:

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -15,7 +15,9 @@ from .capability_probe import CapabilityCache, PROFILE_NAMES as C4_PROFILE_NAMES
 from .context_consumer import consume_context_projection
 from .models import EntityRef, MemoryRecord, SessionContext, clean_text
 from .namespace_capability import namespace_capability_descriptor
+from .namespace import build_namespace_context, validate_namespace_context
 from .person_projection import consume_person_projection
+from .scoped_store import ScopedStore, ScopedStoreError
 
 
 LOCAL_TZ = ZoneInfo("Asia/Shanghai")
@@ -449,6 +451,8 @@ class MemoryCompanionBridge:
 
     def __init__(self, plugin: Any):
         self._plugin = plugin
+        candidate_scoped_store = getattr(plugin, "scoped_store", None)
+        self._scoped_store = candidate_scoped_store if isinstance(candidate_scoped_store, ScopedStore) else None
         self._capability_cache = CapabilityCache()
         self._emotion_producer_token = object()
         self._emotion_page_admin_token = object()
@@ -1681,12 +1685,131 @@ class MemoryCompanionBridge:
         return result
 
     def probe_namespace_context_capabilities(self) -> dict[str, Any]:
-        """Advertise the strict contract without overstating unwired APIs."""
+        """Advertise ready only after the store and active epoch are bound."""
+        status = self._scoped_store.epoch_status() if self._scoped_store is not None else {"bound": False}
+        ready = status.get("bound") is True
         return namespace_capability_descriptor(
-            available=False,
-            methods=(),
-            error_code="namespace_scoped_api_not_bound",
+            available=ready,
+            methods=(
+                "list_scoped_records",
+                "read_scoped_record",
+                "tombstone_scoped_record",
+                "upsert_scoped_record",
+            ) if ready else (),
+            error_code="" if ready else "namespace_scoped_api_not_bound",
         )
+
+    def bind_namespace_migration_epoch(
+        self,
+        capability: Any,
+        *,
+        operation_id: str,
+        expected_previous_epoch: str,
+        migration_epoch: str,
+        policy_version: str,
+    ) -> dict[str, Any]:
+        if not self._is_valid_private_companion_capability(capability):
+            return {"ok": False, "state": "forbidden", "code": "producer_capability_required"}
+        if self._scoped_store is None:
+            return {"ok": False, "state": "degraded", "code": "namespace_scoped_store_unavailable"}
+        try:
+            result = self._scoped_store.bind_epoch(
+                operation_id=operation_id,
+                expected_previous_epoch=expected_previous_epoch,
+                migration_epoch=migration_epoch,
+                policy_version=policy_version,
+            )
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {
+            "ok": True,
+            "state": "ready",
+            "code": result,
+            "epoch": self._scoped_store.epoch_status(),
+        }
+
+    def _authorized_scoped_context(
+        self, capability: Any, namespace: Any
+    ) -> tuple[Any | None, dict[str, Any] | None]:
+        if not self._is_valid_private_companion_capability(capability):
+            return None, {"ok": False, "state": "forbidden", "code": "producer_capability_required"}
+        if self._scoped_store is None:
+            return None, {"ok": False, "state": "degraded", "code": "namespace_scoped_store_unavailable"}
+        errors = validate_namespace_context(namespace)
+        if errors:
+            return None, {"ok": False, "state": "rejected", "code": errors[0]}
+        context = build_namespace_context(namespace)
+        if context is None:
+            return None, {"ok": False, "state": "rejected", "code": "namespace_context_invalid"}
+        return context, None
+
+    def upsert_scoped_record(
+        self,
+        capability: Any,
+        namespace: Any,
+        *,
+        record_kind: str,
+        record_id: str,
+        revision: int,
+        payload: dict[str, Any],
+        event_id: str,
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            result = self._scoped_store.upsert(
+                context, record_kind=record_kind, record_id=record_id, revision=revision,
+                payload=payload, event_id=event_id,
+            )
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", "code": result}
+
+    def read_scoped_record(
+        self, capability: Any, namespace: Any, *, record_kind: str, record_id: str
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            record = self._scoped_store.read(context, record_kind=record_kind, record_id=record_id)
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", "code": "found" if record is not None else "not_found", "record": record}
+
+    def list_scoped_records(
+        self, capability: Any, namespace: Any, *, record_kind: str, limit: int = 100
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            records = self._scoped_store.list_records(context, record_kind=record_kind, limit=limit)
+        except (ScopedStoreError, TypeError, ValueError, OverflowError) as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", "code": "listed", "records": records}
+
+    def tombstone_scoped_record(
+        self,
+        capability: Any,
+        namespace: Any,
+        *,
+        record_kind: str,
+        record_id: str,
+        revision: int,
+        event_id: str,
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            result = self._scoped_store.tombstone(
+                context, record_kind=record_kind, record_id=record_id, revision=revision, event_id=event_id,
+            )
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", "code": result}
 
     def capability_status(self) -> dict[str, Any]:
         """Return the bounded C4 cache state without probing storage."""

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -1693,6 +1693,7 @@ class MemoryCompanionBridge:
             methods=(
                 "list_scoped_records",
                 "read_scoped_record",
+                "tombstone_scoped_namespace",
                 "tombstone_scoped_record",
                 "upsert_scoped_record",
             ) if ready else (),
@@ -1810,6 +1811,25 @@ class MemoryCompanionBridge:
         except ScopedStoreError as exc:
             return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
         return {"ok": True, "state": "ready", "code": result}
+
+    def tombstone_scoped_namespace(
+        self,
+        capability: Any,
+        namespace: Any,
+        *,
+        operation_id: str,
+        reason_code: str,
+    ) -> dict[str, Any]:
+        context, denied = self._authorized_scoped_context(capability, namespace)
+        if denied is not None:
+            return denied
+        try:
+            result = self._scoped_store.tombstone_namespace(
+                context, operation_id=operation_id, reason_code=reason_code,
+            )
+        except ScopedStoreError as exc:
+            return {"ok": False, "state": "rejected", "code": str(exc)[:120]}
+        return {"ok": True, "state": "ready", **result}
 
     def capability_status(self) -> dict[str, Any]:
         """Return the bounded C4 cache state without probing storage."""

--- a/core/bridge.py
+++ b/core/bridge.py
@@ -14,6 +14,7 @@ from .bot_personal_dto import BotPersonalArchiveDTO, build_bot_personal_archive
 from .capability_probe import CapabilityCache, PROFILE_NAMES as C4_PROFILE_NAMES, build_capability_snapshot
 from .context_consumer import consume_context_projection
 from .models import EntityRef, MemoryRecord, SessionContext, clean_text
+from .namespace_capability import namespace_capability_descriptor
 from .person_projection import consume_person_projection
 
 
@@ -1678,6 +1679,14 @@ class MemoryCompanionBridge:
             result["state"] = "ready"
         result["legacy_state"] = result.get("state", "degraded")
         return result
+
+    def probe_namespace_context_capabilities(self) -> dict[str, Any]:
+        """Advertise the strict contract without overstating unwired APIs."""
+        return namespace_capability_descriptor(
+            available=False,
+            methods=(),
+            error_code="namespace_scoped_api_not_bound",
+        )
 
     def capability_status(self) -> dict[str, Any]:
         """Return the bounded C4 cache state without probing storage."""

--- a/core/migration_outbox.py
+++ b/core/migration_outbox.py
@@ -1,0 +1,390 @@
+"""REQ-041 durable outbox, revision, epoch and tombstone primitives."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import sqlite3
+import threading
+import time
+from typing import Any, Iterator
+
+from .namespace import NamespaceContext, validate_namespace_context
+
+
+MIGRATION_STATES = frozenset({"active", "degraded", "paused", "replaying", "verified"})
+OUTBOX_STATES = frozenset({"pending", "applied", "failed", "discarded"})
+MAX_PAYLOAD_BYTES = 32768
+FORBIDDEN_PAYLOAD_KEYS = frozenset({
+    "chat_text", "content", "conversation", "evidence_body", "message_text", "messages", "prompt", "raw_text",
+})
+
+
+class OutboxError(RuntimeError):
+    pass
+
+
+class OutboxConflict(OutboxError):
+    pass
+
+
+class RevisionGap(OutboxError):
+    pass
+
+
+class StaleMigrationEpoch(OutboxError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxItem:
+    event_id: str
+    migration_epoch: str
+    source_revision: int
+    namespace: dict[str, str]
+    policy_version: str
+    payload: dict[str, Any]
+    payload_hash: str
+    state: str
+    retry_count: int
+    error_code: str
+    target_revision: int
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _contains_forbidden(value: Any, depth: int = 0) -> bool:
+    if depth > 5:
+        return True
+    if isinstance(value, dict):
+        return any(
+            not isinstance(key, str)
+            or key.strip().lower() in FORBIDDEN_PAYLOAD_KEYS
+            or _contains_forbidden(item, depth + 1)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_forbidden(item, depth + 1) for item in value)
+    return not (value is None or isinstance(value, (str, int, float, bool)))
+
+
+def _payload(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict) or _contains_forbidden(value):
+        raise OutboxError("outbox_payload_invalid")
+    try:
+        encoded = _canonical(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise OutboxError("outbox_payload_invalid") from exc
+    if len(encoded.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+        raise OutboxError("outbox_payload_too_large")
+    return encoded, hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _token(value: Any, *, limit: int = 128) -> str:
+    if not isinstance(value, str):
+        return ""
+    result = value.strip()
+    if not result or len(result) > limit or any(ord(ch) < 32 for ch in result):
+        return ""
+    return result
+
+
+class MigrationOutbox:
+    """SQLite-backed single-process outbox with transactional idempotency."""
+
+    def __init__(self, path: str | Path, *, clock: Any = None) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._clock = clock if callable(clock) else time.time
+        self._lock = threading.RLock()
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.path), timeout=15.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=FULL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                yield conn
+                if conn.in_transaction:
+                    conn.execute("COMMIT")
+            except Exception:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise
+            finally:
+                conn.close()
+
+    def _initialize(self) -> None:
+        with self._connection() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS migration_epochs (
+                    migration_epoch TEXT PRIMARY KEY,
+                    state TEXT NOT NULL,
+                    checkpoint TEXT NOT NULL DEFAULT '',
+                    policy_version TEXT NOT NULL,
+                    updated_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS outbox (
+                    event_id TEXT NOT NULL,
+                    migration_epoch TEXT NOT NULL,
+                    source_revision INTEGER NOT NULL,
+                    namespace_json TEXT NOT NULL,
+                    namespace_scope TEXT NOT NULL,
+                    policy_version TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    state TEXT NOT NULL DEFAULT 'pending',
+                    retry_count INTEGER NOT NULL DEFAULT 0,
+                    error_code TEXT NOT NULL DEFAULT '',
+                    target_revision INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (event_id, migration_epoch),
+                    FOREIGN KEY (migration_epoch) REFERENCES migration_epochs(migration_epoch)
+                );
+                CREATE INDEX IF NOT EXISTS idx_outbox_pending ON outbox(migration_epoch, state, source_revision, created_at);
+                CREATE TABLE IF NOT EXISTS revisions (
+                    stream_key TEXT NOT NULL,
+                    migration_epoch TEXT NOT NULL,
+                    revision INTEGER NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (stream_key, migration_epoch),
+                    FOREIGN KEY (migration_epoch) REFERENCES migration_epochs(migration_epoch)
+                );
+                CREATE TABLE IF NOT EXISTS tombstones (
+                    object_key TEXT NOT NULL,
+                    migration_epoch TEXT NOT NULL,
+                    revision INTEGER NOT NULL,
+                    reason_code TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY (object_key, migration_epoch),
+                    FOREIGN KEY (migration_epoch) REFERENCES migration_epochs(migration_epoch)
+                );
+                """
+            )
+
+    def begin_epoch(self, migration_epoch: str, *, policy_version: str, state: str = "active") -> dict[str, Any]:
+        epoch = _token(migration_epoch)
+        policy = _token(policy_version, limit=64)
+        if not epoch or not policy or state not in MIGRATION_STATES:
+            raise OutboxError("migration_epoch_invalid")
+        now = float(self._clock())
+        with self._transaction() as conn:
+            row = conn.execute(
+                "SELECT state, checkpoint, policy_version FROM migration_epochs WHERE migration_epoch=?", (epoch,)
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    "INSERT INTO migration_epochs(migration_epoch,state,checkpoint,policy_version,updated_at) VALUES(?,?,?,?,?)",
+                    (epoch, state, "", policy, now),
+                )
+            elif row["policy_version"] != policy:
+                raise OutboxConflict("migration_epoch_policy_conflict")
+        return self.epoch_status(epoch)
+
+    def epoch_status(self, migration_epoch: str) -> dict[str, Any]:
+        epoch = _token(migration_epoch)
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT migration_epoch,state,checkpoint,policy_version,updated_at FROM migration_epochs WHERE migration_epoch=?",
+                (epoch,),
+            ).fetchone()
+        return dict(row) if row is not None else {}
+
+    def set_epoch_state(self, migration_epoch: str, state: str, *, checkpoint: str | None = None) -> dict[str, Any]:
+        epoch = _token(migration_epoch)
+        if state not in MIGRATION_STATES:
+            raise OutboxError("migration_state_invalid")
+        with self._transaction() as conn:
+            row = conn.execute("SELECT checkpoint FROM migration_epochs WHERE migration_epoch=?", (epoch,)).fetchone()
+            if row is None:
+                raise StaleMigrationEpoch("migration_epoch_missing")
+            value = row["checkpoint"] if checkpoint is None else _token(checkpoint, limit=256)
+            conn.execute(
+                "UPDATE migration_epochs SET state=?,checkpoint=?,updated_at=? WHERE migration_epoch=?",
+                (state, value, float(self._clock()), epoch),
+            )
+        return self.epoch_status(epoch)
+
+    def _require_epoch(self, conn: sqlite3.Connection, epoch: str, policy: str) -> None:
+        row = conn.execute(
+            "SELECT state,policy_version FROM migration_epochs WHERE migration_epoch=?", (epoch,)
+        ).fetchone()
+        if row is None:
+            raise StaleMigrationEpoch("migration_epoch_missing")
+        if row["policy_version"] != policy:
+            raise StaleMigrationEpoch("migration_policy_stale")
+        if row["state"] == "verified":
+            raise StaleMigrationEpoch("migration_epoch_closed")
+
+    def enqueue(
+        self,
+        *,
+        event_id: str,
+        source_revision: int,
+        namespace: NamespaceContext,
+        migration_epoch: str,
+        policy_version: str,
+        payload: dict[str, Any],
+    ) -> str:
+        event = _token(event_id)
+        epoch = _token(migration_epoch)
+        policy = _token(policy_version, limit=64)
+        if not event or source_revision < 1 or not epoch or not policy:
+            raise OutboxError("outbox_envelope_invalid")
+        namespace_payload = namespace.to_dict() if isinstance(namespace, NamespaceContext) else {}
+        if validate_namespace_context(namespace_payload):
+            raise OutboxError("outbox_namespace_invalid")
+        if namespace.migration_epoch != epoch or namespace.policy_version != policy:
+            raise StaleMigrationEpoch("outbox_namespace_epoch_mismatch")
+        encoded, digest = _payload(payload)
+        namespace_json = _canonical(namespace_payload)
+        now = float(self._clock())
+        with self._transaction() as conn:
+            self._require_epoch(conn, epoch, policy)
+            existing = conn.execute(
+                "SELECT source_revision,namespace_json,policy_version,payload_hash FROM outbox WHERE event_id=? AND migration_epoch=?",
+                (event, epoch),
+            ).fetchone()
+            if existing is not None:
+                same = (
+                    existing["source_revision"] == source_revision
+                    and existing["namespace_json"] == namespace_json
+                    and existing["policy_version"] == policy
+                    and existing["payload_hash"] == digest
+                )
+                if same:
+                    return "duplicate"
+                raise OutboxConflict("outbox_event_conflict")
+            conn.execute(
+                """INSERT INTO outbox(
+                    event_id,migration_epoch,source_revision,namespace_json,namespace_scope,policy_version,
+                    payload_json,payload_hash,state,retry_count,error_code,target_revision,created_at,updated_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    event, epoch, source_revision, namespace_json, namespace.cache_scope(), policy,
+                    encoded, digest, "pending", 0, "", 0, now, now,
+                ),
+            )
+        return "enqueued"
+
+    @staticmethod
+    def _item(row: sqlite3.Row) -> OutboxItem:
+        return OutboxItem(
+            event_id=row["event_id"], migration_epoch=row["migration_epoch"], source_revision=row["source_revision"],
+            namespace=json.loads(row["namespace_json"]), policy_version=row["policy_version"],
+            payload=json.loads(row["payload_json"]), payload_hash=row["payload_hash"], state=row["state"],
+            retry_count=row["retry_count"], error_code=row["error_code"], target_revision=row["target_revision"],
+        )
+
+    def pending(self, migration_epoch: str, *, limit: int = 100) -> list[OutboxItem]:
+        epoch = _token(migration_epoch)
+        safe_limit = max(1, min(1000, int(limit)))
+        with self._connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM outbox WHERE migration_epoch=? AND state IN ('pending','failed') ORDER BY source_revision,created_at LIMIT ?",
+                (epoch, safe_limit),
+            ).fetchall()
+        return [self._item(row) for row in rows]
+
+    def mark_applied(self, event_id: str, migration_epoch: str, *, target_revision: int) -> None:
+        if target_revision < 1:
+            raise OutboxError("target_revision_invalid")
+        with self._transaction() as conn:
+            changed = conn.execute(
+                "UPDATE outbox SET state='applied',target_revision=?,error_code='',updated_at=? WHERE event_id=? AND migration_epoch=?",
+                (target_revision, float(self._clock()), _token(event_id), _token(migration_epoch)),
+            ).rowcount
+            if changed != 1:
+                raise OutboxError("outbox_event_missing")
+
+    def mark_failed(self, event_id: str, migration_epoch: str, *, error_code: str) -> None:
+        error = _token(error_code, limit=80) or "target_write_failed"
+        with self._transaction() as conn:
+            changed = conn.execute(
+                "UPDATE outbox SET state='failed',retry_count=retry_count+1,error_code=?,updated_at=? WHERE event_id=? AND migration_epoch=?",
+                (error, float(self._clock()), _token(event_id), _token(migration_epoch)),
+            ).rowcount
+            if changed != 1:
+                raise OutboxError("outbox_event_missing")
+
+    def advance_revision(self, stream_key: str, migration_epoch: str, *, expected: int, target: int) -> str:
+        stream = _token(stream_key)
+        epoch = _token(migration_epoch)
+        if not stream or expected < 0 or target != expected + 1:
+            raise OutboxError("revision_request_invalid")
+        with self._transaction() as conn:
+            if conn.execute("SELECT 1 FROM migration_epochs WHERE migration_epoch=?", (epoch,)).fetchone() is None:
+                raise StaleMigrationEpoch("migration_epoch_missing")
+            row = conn.execute(
+                "SELECT revision FROM revisions WHERE stream_key=? AND migration_epoch=?", (stream, epoch)
+            ).fetchone()
+            current = int(row["revision"]) if row is not None else 0
+            if current == target:
+                return "duplicate"
+            if current != expected:
+                raise RevisionGap(f"revision_gap:{current}:{expected}:{target}")
+            conn.execute(
+                """INSERT INTO revisions(stream_key,migration_epoch,revision,updated_at) VALUES(?,?,?,?)
+                ON CONFLICT(stream_key,migration_epoch) DO UPDATE SET revision=excluded.revision,updated_at=excluded.updated_at""",
+                (stream, epoch, target, float(self._clock())),
+            )
+        return "advanced"
+
+    def add_tombstone(self, object_key: str, migration_epoch: str, *, revision: int, reason_code: str) -> str:
+        key = _token(object_key)
+        epoch = _token(migration_epoch)
+        reason = _token(reason_code, limit=80)
+        if not key or revision < 1 or not reason:
+            raise OutboxError("tombstone_invalid")
+        with self._transaction() as conn:
+            if conn.execute("SELECT 1 FROM migration_epochs WHERE migration_epoch=?", (epoch,)).fetchone() is None:
+                raise StaleMigrationEpoch("migration_epoch_missing")
+            row = conn.execute(
+                "SELECT revision,reason_code FROM tombstones WHERE object_key=? AND migration_epoch=?", (key, epoch)
+            ).fetchone()
+            if row is not None:
+                if row["revision"] == revision and row["reason_code"] == reason:
+                    return "duplicate"
+                raise OutboxConflict("tombstone_conflict")
+            conn.execute(
+                "INSERT INTO tombstones(object_key,migration_epoch,revision,reason_code,created_at) VALUES(?,?,?,?,?)",
+                (key, epoch, revision, reason, float(self._clock())),
+            )
+        return "created"
+
+    def tombstone(self, object_key: str, migration_epoch: str) -> dict[str, Any]:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT object_key,migration_epoch,revision,reason_code,created_at FROM tombstones WHERE object_key=? AND migration_epoch=?",
+                (_token(object_key), _token(migration_epoch)),
+            ).fetchone()
+        return dict(row) if row is not None else {}
+
+
+__all__ = [
+    "MAX_PAYLOAD_BYTES", "MIGRATION_STATES", "OUTBOX_STATES", "MigrationOutbox", "OutboxConflict",
+    "OutboxError", "OutboxItem", "RevisionGap", "StaleMigrationEpoch",
+]

--- a/core/namespace.py
+++ b/core/namespace.py
@@ -174,7 +174,7 @@ class AssurancePolicy:
             return AccessDecision(False, f"profile_{context.profile_status}")
         if context.kind == "pending":
             return AccessDecision(False, "namespace_pending_denied")
-        if context.kind != "persona_global" and context.assurance not in FORMAL_ASSURANCE:
+        if context.assurance not in FORMAL_ASSURANCE:
             return AccessDecision(False, "identity_assurance_insufficient")
         if context.kind == "group_shared" and purpose in {"relationship_read", "relationship_write", "profile_read", "profile_write"}:
             return AccessDecision(False, "group_shared_subject_access_denied")

--- a/core/namespace.py
+++ b/core/namespace.py
@@ -1,0 +1,194 @@
+"""REQ-041 strict namespace and identity-assurance contract.
+
+This module is intentionally pure and dependency free so Companion and Memory
+can validate the exact same boundary before either side enables new reads.
+Legacy callers do not use this module implicitly: missing context always fails
+closed and an explicit legacy switch must select the old path.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import re
+from typing import Any, ClassVar
+
+
+CONTRACT_NAME = "chat.namespace_context.v1"
+CONTRACT_VERSION = "1.0"
+NAMESPACE_KINDS = frozenset({"private", "group_member", "group_shared", "persona_global", "pending"})
+IDENTITY_ASSURANCE = frozenset({"unverified", "observed", "verified", "explicit_linked"})
+PROFILE_STATUS = frozenset({"active", "suspended", "quarantined", "deleted"})
+FORMAL_ASSURANCE = frozenset({"verified", "explicit_linked"})
+FORMAL_PURPOSES = frozenset({
+    "relationship_read", "relationship_write", "profile_read", "profile_write",
+    "memory_read", "memory_write", "rule_read", "rule_write", "cross_domain_projection",
+})
+CONTEXT_FIELDS = (
+    "contract_name", "contract_version", "contract_fingerprint", "kind", "identity_id", "group_id",
+    "assurance", "profile_status", "policy_version", "migration_epoch",
+)
+_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:@-]{0,127}")
+_VERSION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}")
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _shape() -> dict[str, Any]:
+    return {
+        "name": CONTRACT_NAME,
+        "version": CONTRACT_VERSION,
+        "fields": list(CONTEXT_FIELDS),
+        "kinds": sorted(NAMESPACE_KINDS),
+        "assurance": sorted(IDENTITY_ASSURANCE),
+        "profile_status": sorted(PROFILE_STATUS),
+        "formal_purposes": sorted(FORMAL_PURPOSES),
+    }
+
+
+CONTRACT_FINGERPRINT = hashlib.sha256(_canonical(_shape()).encode("utf-8")).hexdigest()[:16]
+
+
+def _token(value: Any, *, version: bool = False) -> str:
+    if not isinstance(value, str):
+        return ""
+    result = value.strip()
+    pattern = _VERSION_RE if version else _ID_RE
+    return result if pattern.fullmatch(result) else ""
+
+
+@dataclass(frozen=True, slots=True)
+class NamespaceContext:
+    kind: str
+    identity_id: str
+    group_id: str
+    assurance: str
+    profile_status: str
+    policy_version: str
+    migration_epoch: str
+
+    contract_name: ClassVar[str] = CONTRACT_NAME
+    contract_version: ClassVar[str] = CONTRACT_VERSION
+    contract_fingerprint: ClassVar[str] = CONTRACT_FINGERPRINT
+
+    def errors(self) -> tuple[str, ...]:
+        errors: list[str] = []
+        if self.kind not in NAMESPACE_KINDS:
+            errors.append("namespace_kind_invalid")
+        identity = _token(self.identity_id)
+        group = _token(self.group_id)
+        if self.kind in {"private", "group_member", "pending"} and not identity:
+            errors.append("namespace_identity_required")
+        if self.kind in {"group_shared", "persona_global"} and self.identity_id:
+            errors.append("namespace_identity_forbidden")
+        if self.kind in {"group_member", "group_shared"} and not group:
+            errors.append("namespace_group_required")
+        if self.kind in {"private", "persona_global", "pending"} and self.group_id:
+            errors.append("namespace_group_forbidden")
+        if self.assurance not in IDENTITY_ASSURANCE:
+            errors.append("namespace_assurance_invalid")
+        if self.profile_status not in PROFILE_STATUS:
+            errors.append("namespace_profile_status_invalid")
+        if not _token(self.policy_version, version=True):
+            errors.append("namespace_policy_version_required")
+        if not _token(self.migration_epoch, version=True):
+            errors.append("namespace_migration_epoch_required")
+        return tuple(dict.fromkeys(errors))
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "contract_name": CONTRACT_NAME,
+            "contract_version": CONTRACT_VERSION,
+            "contract_fingerprint": CONTRACT_FINGERPRINT,
+            "kind": self.kind,
+            "identity_id": self.identity_id,
+            "group_id": self.group_id,
+            "assurance": self.assurance,
+            "profile_status": self.profile_status,
+            "policy_version": self.policy_version,
+            "migration_epoch": self.migration_epoch,
+        }
+
+    def cache_scope(self) -> str:
+        identity_hash = hashlib.sha256(self.identity_id.encode("utf-8")).hexdigest()[:16] if self.identity_id else "none"
+        group_hash = hashlib.sha256(self.group_id.encode("utf-8")).hexdigest()[:16] if self.group_id else "none"
+        return f"{self.kind}:{identity_hash}:{group_hash}:{self.policy_version}:{self.migration_epoch}"
+
+
+def build_namespace_context(value: Any) -> NamespaceContext | None:
+    if not isinstance(value, dict):
+        return None
+    return NamespaceContext(
+        kind=str(value.get("kind") or "").strip(),
+        identity_id=str(value.get("identity_id") or "").strip(),
+        group_id=str(value.get("group_id") or "").strip(),
+        assurance=str(value.get("assurance") or "").strip(),
+        profile_status=str(value.get("profile_status") or "").strip(),
+        policy_version=str(value.get("policy_version") or "").strip(),
+        migration_epoch=str(value.get("migration_epoch") or "").strip(),
+    )
+
+
+def validate_namespace_context(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["namespace_context_missing"]
+    errors: list[str] = []
+    if set(value) != set(CONTEXT_FIELDS):
+        errors.append("namespace_context_fields_invalid")
+    if value.get("contract_name") != CONTRACT_NAME or value.get("contract_version") != CONTRACT_VERSION:
+        errors.append("namespace_contract_mismatch")
+    if value.get("contract_fingerprint") != CONTRACT_FINGERPRINT:
+        errors.append("namespace_contract_fingerprint_mismatch")
+    context = build_namespace_context(value)
+    errors.extend(context.errors() if context is not None else ("namespace_context_invalid",))
+    return list(dict.fromkeys(errors))
+
+
+@dataclass(frozen=True, slots=True)
+class AccessDecision:
+    allowed: bool
+    code: str
+
+
+class AssurancePolicy:
+    """Single fail-closed interpretation of assurance and profile lifecycle."""
+
+    @staticmethod
+    def authorize(context: NamespaceContext | None, purpose: str) -> AccessDecision:
+        if context is None:
+            return AccessDecision(False, "namespace_context_missing")
+        errors = context.errors()
+        if errors:
+            return AccessDecision(False, errors[0])
+        if purpose not in FORMAL_PURPOSES:
+            return AccessDecision(False, "namespace_purpose_invalid")
+        if context.profile_status != "active":
+            return AccessDecision(False, f"profile_{context.profile_status}")
+        if context.kind == "pending":
+            return AccessDecision(False, "namespace_pending_denied")
+        if context.kind != "persona_global" and context.assurance not in FORMAL_ASSURANCE:
+            return AccessDecision(False, "identity_assurance_insufficient")
+        if context.kind == "group_shared" and purpose in {"relationship_read", "relationship_write", "profile_read", "profile_write"}:
+            return AccessDecision(False, "group_shared_subject_access_denied")
+        if context.kind == "persona_global" and purpose not in {"rule_read", "rule_write"}:
+            return AccessDecision(False, "persona_global_purpose_denied")
+        return AccessDecision(True, "namespace_access_allowed")
+
+
+def contract_descriptor() -> dict[str, Any]:
+    return {**_shape(), "fingerprint": CONTRACT_FINGERPRINT}
+
+
+def contract_self_check() -> list[str]:
+    expected = hashlib.sha256(_canonical(_shape()).encode("utf-8")).hexdigest()[:16]
+    return [] if expected == CONTRACT_FINGERPRINT else ["namespace_contract_fingerprint_stale"]
+
+
+__all__ = [
+    "AccessDecision", "AssurancePolicy", "CONTRACT_FINGERPRINT", "CONTRACT_NAME", "CONTRACT_VERSION",
+    "CONTEXT_FIELDS", "FORMAL_ASSURANCE", "FORMAL_PURPOSES", "IDENTITY_ASSURANCE", "NAMESPACE_KINDS",
+    "NamespaceContext", "PROFILE_STATUS", "build_namespace_context", "contract_descriptor", "contract_self_check",
+    "validate_namespace_context",
+]

--- a/core/namespace.py
+++ b/core/namespace.py
@@ -25,7 +25,7 @@ FORMAL_PURPOSES = frozenset({
     "memory_read", "memory_write", "rule_read", "rule_write", "cross_domain_projection",
 })
 CONTEXT_FIELDS = (
-    "contract_name", "contract_version", "contract_fingerprint", "kind", "identity_id", "group_id",
+    "contract_name", "contract_version", "contract_fingerprint", "kind", "persona_id", "identity_id", "group_id",
     "assurance", "profile_status", "policy_version", "migration_epoch",
 )
 _ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:@-]{0,127}")
@@ -68,6 +68,7 @@ class NamespaceContext:
     profile_status: str
     policy_version: str
     migration_epoch: str
+    persona_id: str = "default"
 
     contract_name: ClassVar[str] = CONTRACT_NAME
     contract_version: ClassVar[str] = CONTRACT_VERSION
@@ -77,6 +78,8 @@ class NamespaceContext:
         errors: list[str] = []
         if self.kind not in NAMESPACE_KINDS:
             errors.append("namespace_kind_invalid")
+        if not _token(self.persona_id):
+            errors.append("namespace_persona_required")
         identity = _token(self.identity_id)
         group = _token(self.group_id)
         if self.kind in {"private", "group_member", "pending"} and not identity:
@@ -103,6 +106,7 @@ class NamespaceContext:
             "contract_version": CONTRACT_VERSION,
             "contract_fingerprint": CONTRACT_FINGERPRINT,
             "kind": self.kind,
+            "persona_id": self.persona_id,
             "identity_id": self.identity_id,
             "group_id": self.group_id,
             "assurance": self.assurance,
@@ -114,7 +118,8 @@ class NamespaceContext:
     def cache_scope(self) -> str:
         identity_hash = hashlib.sha256(self.identity_id.encode("utf-8")).hexdigest()[:16] if self.identity_id else "none"
         group_hash = hashlib.sha256(self.group_id.encode("utf-8")).hexdigest()[:16] if self.group_id else "none"
-        return f"{self.kind}:{identity_hash}:{group_hash}:{self.policy_version}:{self.migration_epoch}"
+        persona_hash = hashlib.sha256(self.persona_id.encode("utf-8")).hexdigest()[:16]
+        return f"{self.kind}:{persona_hash}:{identity_hash}:{group_hash}:{self.policy_version}:{self.migration_epoch}"
 
 
 def build_namespace_context(value: Any) -> NamespaceContext | None:
@@ -122,6 +127,7 @@ def build_namespace_context(value: Any) -> NamespaceContext | None:
         return None
     return NamespaceContext(
         kind=str(value.get("kind") or "").strip(),
+        persona_id=str(value.get("persona_id") or "").strip(),
         identity_id=str(value.get("identity_id") or "").strip(),
         group_id=str(value.get("group_id") or "").strip(),
         assurance=str(value.get("assurance") or "").strip(),

--- a/core/namespace_capability.py
+++ b/core/namespace_capability.py
@@ -17,7 +17,7 @@ CAPABILITY_NAME = "chat.namespace_memory.v1"
 CAPABILITY_VERSION = "1.0"
 RECORD_KINDS = ("evidence", "memory", "profile_fact", "rule", "summary")
 API_METHODS = (
-    "list_scoped_records", "read_scoped_record", "tombstone_scoped_namespace",
+    "erase_scoped_group_scopes", "list_scoped_records", "read_scoped_record", "tombstone_scoped_namespace",
     "tombstone_scoped_identity_scopes", "tombstone_scoped_record", "upsert_scoped_record",
 )
 CAPABILITY_FIELDS = (

--- a/core/namespace_capability.py
+++ b/core/namespace_capability.py
@@ -17,7 +17,7 @@ CAPABILITY_NAME = "chat.namespace_memory.v1"
 CAPABILITY_VERSION = "1.0"
 RECORD_KINDS = ("evidence", "memory", "profile_fact", "rule", "summary")
 API_METHODS = (
-    "erase_scoped_group_scopes", "list_scoped_records", "read_scoped_record", "tombstone_scoped_namespace",
+    "erase_scoped_group_scopes", "erase_scoped_persona_scopes", "list_scoped_records", "read_scoped_record", "tombstone_scoped_namespace",
     "tombstone_scoped_identity_scopes", "tombstone_scoped_record", "upsert_scoped_record",
 )
 CAPABILITY_FIELDS = (

--- a/core/namespace_capability.py
+++ b/core/namespace_capability.py
@@ -18,7 +18,7 @@ CAPABILITY_VERSION = "1.0"
 RECORD_KINDS = ("evidence", "memory", "profile_fact", "rule", "summary")
 API_METHODS = (
     "list_scoped_records", "read_scoped_record", "tombstone_scoped_namespace",
-    "tombstone_scoped_record", "upsert_scoped_record",
+    "tombstone_scoped_identity_scopes", "tombstone_scoped_record", "upsert_scoped_record",
 )
 CAPABILITY_FIELDS = (
     "capability_name", "capability_version", "namespace_contract_name", "namespace_contract_version",

--- a/core/namespace_capability.py
+++ b/core/namespace_capability.py
@@ -1,0 +1,99 @@
+"""REQ-041 namespace-memory capability negotiation contract."""
+from __future__ import annotations
+
+from typing import Any
+
+from .namespace import (
+    CONTRACT_FINGERPRINT as NAMESPACE_CONTRACT_FINGERPRINT,
+    CONTRACT_NAME as NAMESPACE_CONTRACT_NAME,
+    CONTRACT_VERSION as NAMESPACE_CONTRACT_VERSION,
+    CONTEXT_FIELDS,
+    FORMAL_PURPOSES,
+    NAMESPACE_KINDS,
+)
+
+
+CAPABILITY_NAME = "chat.namespace_memory.v1"
+CAPABILITY_VERSION = "1.0"
+RECORD_KINDS = ("evidence", "memory", "profile_fact", "rule", "summary")
+API_METHODS = ("list_scoped_records", "read_scoped_record", "tombstone_scoped_record", "upsert_scoped_record")
+CAPABILITY_FIELDS = (
+    "capability_name", "capability_version", "namespace_contract_name", "namespace_contract_version",
+    "namespace_contract_fingerprint", "context_fields", "supported_kinds", "supported_purposes",
+    "record_kinds", "methods", "available", "state", "error_code",
+)
+
+
+def namespace_capability_descriptor(
+    *, available: bool = False, methods: Any = (), error_code: str = "namespace_scoped_api_not_bound"
+) -> dict[str, Any]:
+    supplied = set(methods) if isinstance(methods, (list, tuple, set, frozenset)) else set()
+    resolved_methods = [item for item in API_METHODS if item in supplied]
+    ready = bool(available) and resolved_methods == list(API_METHODS)
+    return {
+        "capability_name": CAPABILITY_NAME,
+        "capability_version": CAPABILITY_VERSION,
+        "namespace_contract_name": NAMESPACE_CONTRACT_NAME,
+        "namespace_contract_version": NAMESPACE_CONTRACT_VERSION,
+        "namespace_contract_fingerprint": NAMESPACE_CONTRACT_FINGERPRINT,
+        "context_fields": list(CONTEXT_FIELDS),
+        "supported_kinds": sorted(NAMESPACE_KINDS),
+        "supported_purposes": sorted(FORMAL_PURPOSES),
+        "record_kinds": list(RECORD_KINDS),
+        "methods": resolved_methods,
+        "available": ready,
+        "state": "ready" if ready else "degraded",
+        "error_code": "" if ready else str(error_code or "namespace_scoped_api_unavailable")[:80],
+    }
+
+
+def validate_namespace_capability(value: Any, *, require_available: bool = True) -> list[str]:
+    if not isinstance(value, dict):
+        return ["namespace_capability_missing"]
+    errors: list[str] = []
+    if set(value) != set(CAPABILITY_FIELDS):
+        errors.append("namespace_capability_fields_invalid")
+    expected = namespace_capability_descriptor(
+        available=bool(value.get("available")),
+        methods=value.get("methods"),
+        error_code=str(value.get("error_code") or "namespace_scoped_api_unavailable"),
+    )
+    for field in (
+        "capability_name", "capability_version", "namespace_contract_name", "namespace_contract_version",
+        "namespace_contract_fingerprint", "context_fields", "supported_kinds", "supported_purposes", "record_kinds",
+    ):
+        if value.get(field) != expected[field]:
+            errors.append(f"{field}_mismatch")
+    methods = value.get("methods")
+    if not isinstance(methods, list) or any(item not in API_METHODS for item in methods) or len(methods) != len(set(methods)):
+        errors.append("methods_invalid")
+    if type(value.get("available")) is not bool:
+        errors.append("available_invalid")
+    if value.get("state") not in {"ready", "degraded"}:
+        errors.append("state_invalid")
+    if value.get("available") is True and methods != list(API_METHODS):
+        errors.append("methods_incomplete")
+    if value.get("available") is True and (value.get("state") != "ready" or value.get("error_code") != ""):
+        errors.append("available_state_invalid")
+    if require_available and value.get("available") is not True:
+        errors.append("namespace_capability_unavailable")
+    return list(dict.fromkeys(errors))
+
+
+def negotiate_namespace_capability(value: Any) -> dict[str, Any]:
+    errors = validate_namespace_capability(value, require_available=True)
+    if errors:
+        return {"available": False, "state": "degraded", "code": errors[0], "mismatches": errors}
+    return {
+        "available": True,
+        "state": "ready",
+        "code": "namespace_capability_ready",
+        "mismatches": [],
+        "capability": dict(value),
+    }
+
+
+__all__ = [
+    "API_METHODS", "CAPABILITY_FIELDS", "CAPABILITY_NAME", "CAPABILITY_VERSION", "RECORD_KINDS",
+    "namespace_capability_descriptor", "negotiate_namespace_capability", "validate_namespace_capability",
+]

--- a/core/namespace_capability.py
+++ b/core/namespace_capability.py
@@ -16,7 +16,10 @@ from .namespace import (
 CAPABILITY_NAME = "chat.namespace_memory.v1"
 CAPABILITY_VERSION = "1.0"
 RECORD_KINDS = ("evidence", "memory", "profile_fact", "rule", "summary")
-API_METHODS = ("list_scoped_records", "read_scoped_record", "tombstone_scoped_record", "upsert_scoped_record")
+API_METHODS = (
+    "list_scoped_records", "read_scoped_record", "tombstone_scoped_namespace",
+    "tombstone_scoped_record", "upsert_scoped_record",
+)
 CAPABILITY_FIELDS = (
     "capability_name", "capability_version", "namespace_contract_name", "namespace_contract_version",
     "namespace_contract_fingerprint", "context_fields", "supported_kinds", "supported_purposes",

--- a/core/portrait.py
+++ b/core/portrait.py
@@ -111,7 +111,11 @@ def cross_scene_whitelisted_fact(
     alone is insufficient because work, schedule, location, and relationship
     details can be low-labelled yet still violate the frozen cross-scene policy.
     """
-    if _text(sensitivity, 24) != LOW_SENSITIVITY or _text(source_scope, 80) != "private":
+    normalized_scope = _text(source_scope, 80)
+    if (
+        _text(sensitivity, 24) != LOW_SENSITIVITY
+        or not (normalized_scope == "private" or normalized_scope.startswith("private@"))
+    ):
         return False
     normalized_dimension = _text(dimension, 80).lower()
     summary = _text(claim_summary, 180).lower()

--- a/core/portrait_namespace.py
+++ b/core/portrait_namespace.py
@@ -1,0 +1,88 @@
+"""REQ-041 namespace boundary for Memory-owned portrait data."""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from .namespace import AssurancePolicy, NamespaceContext, build_namespace_context
+
+
+def _legacy_scope(value: Any) -> str:
+    scope = str(value or "").strip()
+    if scope == "private":
+        return scope
+    if scope.startswith("group:") and len(scope) <= 240:
+        return scope
+    return ""
+
+
+def portrait_scope_kind(value: Any) -> str:
+    scope = str(value or "").strip()
+    if scope == "private" or scope.startswith("private@"):
+        return "private"
+    if scope.startswith("group:") or scope.startswith("group_member@"):
+        return "group_member"
+    return ""
+
+
+def portrait_scope_persona(value: Any) -> str:
+    scope = str(value or "").strip()
+    parts = scope.split("@")
+    if len(parts) != 3 or len(parts[1]) != 16:
+        return ""
+    return parts[1]
+
+
+def portrait_namespace_decision(
+    value: Any,
+    *,
+    person_id: Any,
+    legacy_scope: Any,
+    purpose: str,
+    namespace_present: bool | None = None,
+) -> dict[str, Any]:
+    """Resolve a portrait scope without ever embedding raw identity/group IDs."""
+    clean_person = str(person_id or "").strip()
+    clean_legacy = _legacy_scope(legacy_scope)
+    if not clean_person or not clean_legacy:
+        return {"ok": False, "code": "portrait_namespace_invalid", "state": "invalid"}
+    present = value is not None if namespace_present is None else bool(namespace_present)
+    if not present:
+        return {
+            "ok": True,
+            "code": "portrait_namespace_legacy",
+            "state": "legacy",
+            "source_scope": clean_legacy,
+            "legacy_scope": clean_legacy,
+            "context": None,
+        }
+    if value is None:
+        return {"ok": False, "code": "portrait_namespace_invalid", "state": "invalid"}
+    context = build_namespace_context(value)
+    if context is None or context.errors():
+        return {"ok": False, "code": "portrait_namespace_invalid", "state": "invalid"}
+    decision = AssurancePolicy.authorize(context, purpose)
+    if not decision.allowed:
+        return {"ok": False, "code": decision.code, "state": "denied"}
+    expected_kind = "private" if clean_legacy == "private" else "group_member"
+    if (
+        context.kind != expected_kind
+        or context.identity_id != clean_person
+        or context.profile_status != "active"
+    ):
+        return {"ok": False, "code": "portrait_namespace_mismatch", "state": "invalid"}
+    persona_digest = hashlib.sha256(context.persona_id.encode("utf-8")).hexdigest()[:16]
+    scope_digest = hashlib.sha256(context.cache_scope().encode("utf-8")).hexdigest()[:48]
+    return {
+        "ok": True,
+        "code": "portrait_namespace_exact",
+        "state": "exact",
+        "source_scope": f"{context.kind}@{persona_digest}@{scope_digest}",
+        "legacy_scope": clean_legacy if context.persona_id == "default" else "",
+        "context": context,
+    }
+
+
+__all__ = [
+    "portrait_namespace_decision", "portrait_scope_kind", "portrait_scope_persona",
+]

--- a/core/portrait_service.py
+++ b/core/portrait_service.py
@@ -15,6 +15,7 @@ from .portrait import (
     extract_explicit_candidates,
     portrait_access_decision,
 )
+from .portrait_namespace import portrait_namespace_decision
 
 
 class PortraitService:
@@ -30,19 +31,58 @@ class PortraitService:
                 return value
         return None
 
-    async def sync_profile_context(self, *, event: Any = None, req: Any = None) -> dict[str, Any]:
+    @staticmethod
+    def _namespace_context(event: Any = None, req: Any = None) -> tuple[bool, Any]:
+        for source in (event, req):
+            if source is None:
+                continue
+            if isinstance(source, dict) and "namespace_context" in source:
+                return True, source.get("namespace_context")
+            if hasattr(source, "private_companion_namespace_context"):
+                return True, getattr(source, "private_companion_namespace_context", None)
+        return False, None
+
+    async def sync_profile_context(
+        self,
+        *,
+        event: Any = None,
+        req: Any = None,
+        legacy_scope: str = "private",
+    ) -> dict[str, Any]:
         dto = self._profile_context(event, req)
         errors = validate_profile_dto(dto)
         if errors:
             return {"ok": False, "code": "bridge_contract_mismatch", "errors": errors, "dto": None}
         assert isinstance(dto, dict)
         person_ref = build_person_ref(dto["person_ref"])
-        result = await self.store.upsert_portrait_person_projection(person_ref, dto["capability_summary"])
+        namespace_present, namespace_value = self._namespace_context(event, req)
+        namespace = portrait_namespace_decision(
+            namespace_value,
+            person_id=person_ref.get("person_id"),
+            legacy_scope=legacy_scope,
+            purpose="profile_write",
+            namespace_present=namespace_present,
+        )
+        if not namespace.get("ok"):
+            return {"ok": False, "code": namespace.get("code"), "errors": [], "dto": dto}
+        result = await self.store.upsert_portrait_person_projection(
+            person_ref,
+            dto["capability_summary"],
+            source_scope=str(namespace.get("source_scope") or ""),
+        )
         if not result.get("ok"):
             return {"ok": False, "code": result.get("code", "bridge_degraded"), "errors": [], "dto": dto}
         if person_ref["profile_status"] != "active" or person_ref["identity_assurance"] not in {"observed", "verified", "explicit_linked"}:
             return {"ok": False, "code": "bridge_person_mismatch", "errors": [], "dto": dto}
-        return {"ok": True, "code": "profile_exact", "errors": [], "dto": dto, "person_ref": person_ref}
+        return {
+            "ok": True,
+            "code": "profile_exact",
+            "errors": [],
+            "dto": dto,
+            "person_ref": person_ref,
+            "source_scope": str(namespace.get("source_scope") or ""),
+            "legacy_scope": str(namespace.get("legacy_scope") or ""),
+        }
 
     async def capture_user_message(self, ctx: SessionContext, *, event: Any = None, req: Any = None) -> dict[str, Any]:
         """Capture only a sender's own message as portrait evidence.
@@ -50,7 +90,10 @@ class PortraitService:
         The raw message is used transiently to derive a hash and deterministic
         explicit candidate.  It is never copied to the portrait tables.
         """
-        synced = await self.sync_profile_context(event=event, req=req)
+        scope = self._scope_for_context(ctx)
+        if not scope:
+            return {"ok": False, "code": "bridge_person_mismatch", "facts": 0}
+        synced = await self.sync_profile_context(event=event, req=req, legacy_scope=scope)
         if not synced.get("ok"):
             return {"ok": False, "code": synced.get("code", "bridge_degraded"), "facts": 0}
         person_ref = synced["person_ref"]
@@ -62,9 +105,7 @@ class PortraitService:
                 "facts": 0,
                 "person_id": person_ref["person_id"],
             }
-        scope = self._scope_for_context(ctx)
-        if not scope:
-            return {"ok": False, "code": "bridge_person_mismatch", "facts": 0}
+        scope = str(synced.get("source_scope") or "")
         evidence = build_evidence(
             person_ref=person_ref,
             scope=scope,
@@ -110,6 +151,20 @@ class PortraitService:
         if not decision["candidates_allowed"]:
             return {"ok": False, "code": decision["code"], "items": [], "decision": decision}
         person_ref = request.get("person_ref") if isinstance(request.get("person_ref"), dict) else {}
+        namespace = portrait_namespace_decision(
+            request.get("namespace_context"),
+            person_id=request.get("target_person_id"),
+            legacy_scope=request.get("scope"),
+            purpose="profile_read",
+            namespace_present="namespace_context" in request,
+        )
+        if not namespace.get("ok"):
+            return {
+                "ok": False,
+                "code": namespace.get("code", "portrait_namespace_invalid"),
+                "items": [],
+                "decision": decision,
+            }
         projection = await self.store.portrait_projection_decision(person_ref)
         if not projection.get("ok"):
             return {
@@ -121,7 +176,8 @@ class PortraitService:
         target = clean_text(request.get("target_person_id"), 80)
         result = await self.store.portrait_summary(
             target,
-            scope=clean_text(request.get("scope"), 80),
+            scope=str(namespace.get("source_scope") or ""),
+            legacy_scope=str(namespace.get("legacy_scope") or ""),
             limit=max(1, min(16, int(limit))),
             low_only=True,
             usage_min_confidence=self.config.float("portrait.usage_min_confidence", 0.75),

--- a/core/scoped_domain_contract.py
+++ b/core/scoped_domain_contract.py
@@ -1,0 +1,132 @@
+"""REQ-041 payload contract for profile, memory and learning projections."""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+
+SCHEMA_VERSION = "req041.scoped-domain.v1"
+DOMAINS = frozenset({"profile", "memory", "learning"})
+SOURCE_KINDS = frozenset({"private", "group_member", "group_shared", "persona_global"})
+APPROVAL_STATES = frozenset({"not_applicable", "pending", "approved", "rejected"})
+DOMAIN_RECORD_KINDS = {
+    "profile": frozenset({"profile_fact"}),
+    "memory": frozenset({"memory", "summary"}),
+    "learning": frozenset({"rule", "evidence"}),
+}
+_FORBIDDEN_KEYS = frozenset({
+    "relationship_score", "relationship_role", "relationship_mode", "owner", "authorized",
+    "tool_permission", "tool_permissions", "proactive_permission", "raw_prompt", "system_prompt",
+})
+
+
+class ScopedDomainContractError(ValueError):
+    pass
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _safe(value: Any, *, depth: int = 0) -> Any:
+    if depth > 8:
+        raise ScopedDomainContractError("scoped_domain_content_too_deep")
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ScopedDomainContractError("scoped_domain_content_non_finite")
+        return value
+    if isinstance(value, list):
+        return [_safe(item, depth=depth + 1) for item in value[:512]]
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for raw_key, item in list(value.items())[:512]:
+            if not isinstance(raw_key, str) or not raw_key or len(raw_key) > 96:
+                raise ScopedDomainContractError("scoped_domain_content_key_invalid")
+            key = raw_key.strip()
+            if key.lower() in _FORBIDDEN_KEYS:
+                raise ScopedDomainContractError("scoped_domain_privilege_field_denied")
+            result[key] = _safe(item, depth=depth + 1)
+        return result
+    raise ScopedDomainContractError("scoped_domain_content_type_invalid")
+
+
+def build_scoped_domain_payload(
+    *,
+    domain: str,
+    source_kind: str,
+    content: Any,
+    source_revision: int = 0,
+    approval_state: str = "not_applicable",
+    approved_by: str = "",
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "domain": str(domain or "").strip(),
+        "source_kind": str(source_kind or "").strip(),
+        "source_revision": max(0, int(source_revision or 0)),
+        "approval_state": str(approval_state or "").strip(),
+        "approved_by": str(approved_by or "").strip(),
+        "content": _safe(content),
+    }
+    validate_scoped_domain_payload(None, "", payload, envelope_only=True)
+    payload["content_hash"] = hashlib.sha256(_canonical(payload["content"]).encode("utf-8")).hexdigest()
+    return payload
+
+
+def validate_scoped_domain_payload(
+    context: Any,
+    record_kind: str,
+    payload: Any,
+    *,
+    envelope_only: bool = False,
+) -> None:
+    if not isinstance(payload, dict):
+        raise ScopedDomainContractError("scoped_domain_payload_invalid")
+    required = {
+        "schema_version", "domain", "source_kind", "source_revision", "approval_state", "approved_by", "content"
+    }
+    allowed = required | {"content_hash"}
+    if frozenset(payload) not in {frozenset(required), frozenset(allowed)}:
+        raise ScopedDomainContractError("scoped_domain_payload_fields_invalid")
+    domain = str(payload.get("domain") or "")
+    source_kind = str(payload.get("source_kind") or "")
+    approval = str(payload.get("approval_state") or "")
+    approved_by = str(payload.get("approved_by") or "")
+    if payload.get("schema_version") != SCHEMA_VERSION or domain not in DOMAINS:
+        raise ScopedDomainContractError("scoped_domain_schema_invalid")
+    if source_kind not in SOURCE_KINDS or approval not in APPROVAL_STATES:
+        raise ScopedDomainContractError("scoped_domain_source_invalid")
+    if not isinstance(payload.get("source_revision"), int) or int(payload["source_revision"]) < 0:
+        raise ScopedDomainContractError("scoped_domain_revision_invalid")
+    content = _safe(payload.get("content"))
+    digest = hashlib.sha256(_canonical(content).encode("utf-8")).hexdigest()
+    if "content_hash" in payload and payload.get("content_hash") != digest:
+        raise ScopedDomainContractError("scoped_domain_content_hash_mismatch")
+    if envelope_only:
+        return
+    if record_kind not in DOMAIN_RECORD_KINDS[domain]:
+        raise ScopedDomainContractError("scoped_domain_record_kind_mismatch")
+    kind = str(getattr(context, "kind", "") or "")
+    if kind != source_kind:
+        raise ScopedDomainContractError("scoped_domain_namespace_mismatch")
+    if domain == "profile" and kind not in {"private", "group_member"}:
+        raise ScopedDomainContractError("scoped_profile_namespace_denied")
+    if domain == "memory" and kind == "persona_global":
+        raise ScopedDomainContractError("scoped_memory_persona_global_denied")
+    if domain != "learning" and approval != "not_applicable":
+        raise ScopedDomainContractError("scoped_domain_approval_invalid")
+    if domain == "learning":
+        if record_kind == "rule" and approval not in {"pending", "approved", "rejected"}:
+            raise ScopedDomainContractError("scoped_rule_approval_required")
+        if kind == "persona_global" and (approval != "approved" or approved_by != "administrator"):
+            raise ScopedDomainContractError("persona_global_rule_approval_required")
+
+
+__all__ = [
+    "APPROVAL_STATES", "DOMAINS", "DOMAIN_RECORD_KINDS", "SCHEMA_VERSION", "SOURCE_KINDS",
+    "ScopedDomainContractError", "build_scoped_domain_payload", "validate_scoped_domain_payload",
+]

--- a/core/scoped_domain_contract.py
+++ b/core/scoped_domain_contract.py
@@ -10,7 +10,7 @@ from typing import Any
 SCHEMA_VERSION = "req041.scoped-domain.v1"
 DOMAINS = frozenset({"profile", "memory", "learning"})
 SOURCE_KINDS = frozenset({"private", "group_member", "group_shared", "persona_global"})
-APPROVAL_STATES = frozenset({"not_applicable", "pending", "approved", "rejected"})
+APPROVAL_STATES = frozenset({"not_applicable", "pending", "approved", "rejected", "revoked"})
 DOMAIN_RECORD_KINDS = {
     "profile": frozenset({"profile_fact"}),
     "memory": frozenset({"memory", "summary"}),
@@ -120,9 +120,11 @@ def validate_scoped_domain_payload(
     if domain != "learning" and approval != "not_applicable":
         raise ScopedDomainContractError("scoped_domain_approval_invalid")
     if domain == "learning":
-        if record_kind == "rule" and approval not in {"pending", "approved", "rejected"}:
+        if record_kind == "rule" and approval not in {"pending", "approved", "rejected", "revoked"}:
             raise ScopedDomainContractError("scoped_rule_approval_required")
-        if kind == "persona_global" and (approval != "approved" or approved_by != "administrator"):
+        if kind == "persona_global" and (
+            approval not in {"approved", "rejected", "revoked"} or approved_by != "administrator"
+        ):
             raise ScopedDomainContractError("persona_global_rule_approval_required")
 
 

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -1,0 +1,327 @@
+"""REQ-041 revisioned namespace-scoped record store.
+
+This is the new-path storage primitive.  It never guesses a namespace and it
+does not fall back to legacy tables.  Callers must pass a validated context and
+an assurance-authorized purpose on every read and write.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+import hashlib
+import json
+from pathlib import Path
+import sqlite3
+import threading
+import time
+from typing import Any, Iterator
+
+from .namespace import AssurancePolicy, NamespaceContext
+
+
+MAX_RECORD_BYTES = 262144
+RECORD_KINDS = frozenset({"profile_fact", "memory", "rule", "evidence", "summary"})
+_PURPOSE_BY_KIND = {
+    "profile_fact": ("profile_read", "profile_write"),
+    "memory": ("memory_read", "memory_write"),
+    "summary": ("memory_read", "memory_write"),
+    "rule": ("rule_read", "rule_write"),
+    "evidence": ("rule_read", "rule_write"),
+}
+
+
+class ScopedStoreError(RuntimeError):
+    pass
+
+
+class ScopedRecordConflict(ScopedStoreError):
+    pass
+
+
+class ScopedRevisionGap(ScopedStoreError):
+    pass
+
+
+def _token(value: Any, limit: int = 128) -> str:
+    if not isinstance(value, str):
+        return ""
+    result = value.strip()
+    if not result or len(result) > limit or any(ord(ch) < 32 for ch in result):
+        return ""
+    return result
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _payload(value: Any) -> tuple[str, str]:
+    if not isinstance(value, dict):
+        raise ScopedStoreError("scoped_payload_invalid")
+    try:
+        encoded = _canonical(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ScopedStoreError("scoped_payload_invalid") from exc
+    if len(encoded.encode("utf-8")) > MAX_RECORD_BYTES:
+        raise ScopedStoreError("scoped_payload_too_large")
+    return encoded, hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+class ScopedStore:
+    def __init__(self, path: str | Path, *, clock: Any = None) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._clock = clock if callable(clock) else time.time
+        self._lock = threading.RLock()
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.path), timeout=15.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=FULL")
+        return conn
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                yield conn
+                if conn.in_transaction:
+                    conn.execute("COMMIT")
+            except Exception:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                raise
+            finally:
+                conn.close()
+
+    def _initialize(self) -> None:
+        with self._connection() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS scoped_records (
+                    namespace_scope TEXT NOT NULL,
+                    record_kind TEXT NOT NULL,
+                    record_id TEXT NOT NULL,
+                    revision INTEGER NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    policy_version TEXT NOT NULL,
+                    migration_epoch TEXT NOT NULL,
+                    deleted INTEGER NOT NULL DEFAULT 0,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY(namespace_scope, record_kind, record_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_scoped_records_list
+                    ON scoped_records(namespace_scope, record_kind, deleted, revision, record_id);
+                CREATE TABLE IF NOT EXISTS scoped_operations (
+                    event_id TEXT NOT NULL,
+                    migration_epoch TEXT NOT NULL,
+                    request_hash TEXT NOT NULL,
+                    result_code TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY(event_id, migration_epoch)
+                );
+                """
+            )
+
+    @staticmethod
+    def _authorize(context: NamespaceContext | None, record_kind: str, *, write: bool) -> None:
+        if record_kind not in RECORD_KINDS:
+            raise ScopedStoreError("scoped_record_kind_invalid")
+        purpose = _PURPOSE_BY_KIND[record_kind][1 if write else 0]
+        decision = AssurancePolicy.authorize(context, purpose)
+        if not decision.allowed:
+            raise ScopedStoreError(decision.code)
+
+    @staticmethod
+    def _scope(context: NamespaceContext) -> str:
+        # Durable ownership is stable across policy revisions and migration
+        # epochs.  Assurance/status/policy still gate each operation, but must
+        # not silently create a second physical namespace for the same owner.
+        # This local key is never emitted to logs; cache_scope() remains the
+        # redacted, revision-aware cache key.
+        return _canonical({
+            "kind": context.kind,
+            "identity_id": context.identity_id,
+            "group_id": context.group_id,
+        })
+
+    def upsert(
+        self,
+        context: NamespaceContext,
+        *,
+        record_kind: str,
+        record_id: str,
+        revision: int,
+        payload: dict[str, Any],
+        event_id: str,
+    ) -> str:
+        self._authorize(context, record_kind, write=True)
+        identifier = _token(record_id)
+        event = _token(event_id)
+        if not identifier or not event or revision < 1:
+            raise ScopedStoreError("scoped_envelope_invalid")
+        encoded, digest = _payload(payload)
+        scope = self._scope(context)
+        request_hash = hashlib.sha256(
+            _canonical({
+                "scope": scope, "kind": record_kind, "id": identifier, "revision": revision,
+                "payload_hash": digest, "policy_version": context.policy_version,
+            }).encode("utf-8")
+        ).hexdigest()
+        now = float(self._clock())
+        with self._transaction() as conn:
+            prior_operation = conn.execute(
+                "SELECT request_hash,result_code FROM scoped_operations WHERE event_id=? AND migration_epoch=?",
+                (event, context.migration_epoch),
+            ).fetchone()
+            if prior_operation is not None:
+                if prior_operation["request_hash"] != request_hash:
+                    raise ScopedRecordConflict("scoped_event_conflict")
+                return "duplicate"
+            row = conn.execute(
+                "SELECT revision,payload_hash,deleted FROM scoped_records WHERE namespace_scope=? AND record_kind=? AND record_id=?",
+                (scope, record_kind, identifier),
+            ).fetchone()
+            if row is None:
+                if revision != 1:
+                    raise ScopedRevisionGap(f"scoped_revision_gap:0:{revision}")
+                result = "created"
+            else:
+                current = int(row["revision"])
+                if int(row["deleted"]) == 1:
+                    raise ScopedRecordConflict("scoped_record_tombstoned")
+                if revision == current and row["payload_hash"] == digest:
+                    result = "duplicate"
+                elif revision != current + 1:
+                    raise ScopedRevisionGap(f"scoped_revision_gap:{current}:{revision}")
+                else:
+                    result = "updated"
+            if result != "duplicate":
+                conn.execute(
+                    """INSERT INTO scoped_records(
+                        namespace_scope,record_kind,record_id,revision,payload_json,payload_hash,
+                        policy_version,migration_epoch,deleted,updated_at
+                    ) VALUES(?,?,?,?,?,?,?,?,0,?)
+                    ON CONFLICT(namespace_scope,record_kind,record_id) DO UPDATE SET
+                        revision=excluded.revision,payload_json=excluded.payload_json,payload_hash=excluded.payload_hash,
+                        policy_version=excluded.policy_version,migration_epoch=excluded.migration_epoch,
+                        deleted=0,updated_at=excluded.updated_at""",
+                    (
+                        scope, record_kind, identifier, revision, encoded, digest,
+                        context.policy_version, context.migration_epoch, now,
+                    ),
+                )
+            conn.execute(
+                "INSERT INTO scoped_operations(event_id,migration_epoch,request_hash,result_code,created_at) VALUES(?,?,?,?,?)",
+                (event, context.migration_epoch, request_hash, result, now),
+            )
+        return result
+
+    def read(self, context: NamespaceContext, *, record_kind: str, record_id: str) -> dict[str, Any] | None:
+        self._authorize(context, record_kind, write=False)
+        identifier = _token(record_id)
+        if not identifier:
+            raise ScopedStoreError("scoped_record_id_invalid")
+        with self._connection() as conn:
+            row = conn.execute(
+                """SELECT revision,payload_json,payload_hash,policy_version,migration_epoch,updated_at
+                FROM scoped_records WHERE namespace_scope=? AND record_kind=? AND record_id=? AND deleted=0""",
+                (self._scope(context), record_kind, identifier),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "record_id": identifier,
+            "record_kind": record_kind,
+            "revision": int(row["revision"]),
+            "payload": json.loads(row["payload_json"]),
+            "payload_hash": row["payload_hash"],
+            "policy_version": row["policy_version"],
+            "migration_epoch": row["migration_epoch"],
+            "updated_at": row["updated_at"],
+        }
+
+    def list_records(self, context: NamespaceContext, *, record_kind: str, limit: int = 100) -> list[dict[str, Any]]:
+        self._authorize(context, record_kind, write=False)
+        safe_limit = max(1, min(1000, int(limit)))
+        with self._connection() as conn:
+            rows = conn.execute(
+                """SELECT record_id,revision,payload_json,payload_hash,policy_version,migration_epoch,updated_at
+                FROM scoped_records WHERE namespace_scope=? AND record_kind=? AND deleted=0
+                ORDER BY revision,record_id LIMIT ?""",
+                (self._scope(context), record_kind, safe_limit),
+            ).fetchall()
+        return [
+            {
+                "record_id": row["record_id"], "record_kind": record_kind, "revision": int(row["revision"]),
+                "payload": json.loads(row["payload_json"]), "payload_hash": row["payload_hash"],
+                "policy_version": row["policy_version"], "migration_epoch": row["migration_epoch"],
+                "updated_at": row["updated_at"],
+            }
+            for row in rows
+        ]
+
+    def tombstone(
+        self,
+        context: NamespaceContext,
+        *,
+        record_kind: str,
+        record_id: str,
+        revision: int,
+        event_id: str,
+    ) -> str:
+        self._authorize(context, record_kind, write=True)
+        identifier = _token(record_id)
+        event = _token(event_id)
+        if not identifier or not event or revision < 1:
+            raise ScopedStoreError("scoped_envelope_invalid")
+        scope = self._scope(context)
+        request_hash = hashlib.sha256(
+            _canonical({"scope": scope, "kind": record_kind, "id": identifier, "revision": revision, "delete": True}).encode("utf-8")
+        ).hexdigest()
+        now = float(self._clock())
+        with self._transaction() as conn:
+            prior = conn.execute(
+                "SELECT request_hash FROM scoped_operations WHERE event_id=? AND migration_epoch=?",
+                (event, context.migration_epoch),
+            ).fetchone()
+            if prior is not None:
+                if prior["request_hash"] != request_hash:
+                    raise ScopedRecordConflict("scoped_event_conflict")
+                return "duplicate"
+            row = conn.execute(
+                "SELECT revision,deleted FROM scoped_records WHERE namespace_scope=? AND record_kind=? AND record_id=?",
+                (scope, record_kind, identifier),
+            ).fetchone()
+            if row is None or revision != int(row["revision"]) + 1:
+                current = int(row["revision"]) if row is not None else 0
+                raise ScopedRevisionGap(f"scoped_revision_gap:{current}:{revision}")
+            if int(row["deleted"]) == 1:
+                raise ScopedRecordConflict("scoped_record_tombstoned")
+            conn.execute(
+                "UPDATE scoped_records SET revision=?,deleted=1,updated_at=? WHERE namespace_scope=? AND record_kind=? AND record_id=?",
+                (revision, now, scope, record_kind, identifier),
+            )
+            conn.execute(
+                "INSERT INTO scoped_operations(event_id,migration_epoch,request_hash,result_code,created_at) VALUES(?,?,?,?,?)",
+                (event, context.migration_epoch, request_hash, "tombstoned", now),
+            )
+        return "tombstoned"
+
+
+__all__ = [
+    "MAX_RECORD_BYTES", "RECORD_KINDS", "ScopedRecordConflict", "ScopedRevisionGap", "ScopedStore",
+    "ScopedStoreError",
+]

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -20,6 +20,8 @@ from .scoped_domain_contract import SCHEMA_VERSION, ScopedDomainContractError, v
 
 
 MAX_RECORD_BYTES = 262144
+_ERASED_PAYLOAD_JSON = "{}"
+_ERASED_PAYLOAD_HASH = hashlib.sha256(_ERASED_PAYLOAD_JSON.encode("utf-8")).hexdigest()
 RECORD_KINDS = frozenset({"profile_fact", "memory", "rule", "evidence", "summary"})
 _PURPOSE_BY_KIND = {
     "profile_fact": ("profile_read", "profile_write"),
@@ -83,7 +85,12 @@ class ScopedStore:
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA synchronous=FULL")
+        conn.execute("PRAGMA secure_delete=ON")
         return conn
+
+    def _truncate_wal(self) -> None:
+        with self._connection() as conn:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 
     @contextmanager
     def _connection(self) -> Iterator[sqlite3.Connection]:
@@ -423,13 +430,15 @@ class ScopedStore:
             if int(row["deleted"]) == 1:
                 raise ScopedRecordConflict("scoped_record_tombstoned")
             conn.execute(
-                "UPDATE scoped_records SET revision=?,deleted=1,updated_at=? WHERE namespace_scope=? AND record_kind=? AND record_id=?",
-                (revision, now, scope, record_kind, identifier),
+                """UPDATE scoped_records SET revision=?,payload_json=?,payload_hash=?,deleted=1,updated_at=?
+                   WHERE namespace_scope=? AND record_kind=? AND record_id=?""",
+                (revision, _ERASED_PAYLOAD_JSON, _ERASED_PAYLOAD_HASH, now, scope, record_kind, identifier),
             )
             conn.execute(
                 "INSERT INTO scoped_operations(event_id,migration_epoch,request_hash,result_code,created_at) VALUES(?,?,?,?,?)",
                 (event, context.migration_epoch, request_hash, "tombstoned", now),
             )
+        self._truncate_wal()
         return "tombstoned"
 
     def tombstone_namespace(
@@ -475,9 +484,12 @@ class ScopedStore:
             ).fetchall()
             for row in rows:
                 conn.execute(
-                    """UPDATE scoped_records SET revision=?,deleted=1,updated_at=?
+                    """UPDATE scoped_records SET revision=?,payload_json=?,payload_hash=?,deleted=1,updated_at=?
                        WHERE namespace_scope=? AND record_kind=? AND record_id=? AND deleted=0""",
-                    (int(row["revision"]) + 1, now, scope, row["record_kind"], row["record_id"]),
+                    (
+                        int(row["revision"]) + 1, _ERASED_PAYLOAD_JSON, _ERASED_PAYLOAD_HASH,
+                        now, scope, row["record_kind"], row["record_id"],
+                    ),
                 )
             result = {
                 "code": "namespace_tombstoned" if rows else "namespace_already_empty",
@@ -490,6 +502,7 @@ class ScopedStore:
                    ) VALUES(?,?,?,?,?,?)""",
                 (operation, context.migration_epoch, scope, request_hash, _canonical(result), now),
             )
+        self._truncate_wal()
         return result
 
     def tombstone_identity_scopes(
@@ -564,10 +577,11 @@ class ScopedStore:
                     scopes.add(str(row["namespace_scope"]))
             for row in rows:
                 conn.execute(
-                    """UPDATE scoped_records SET revision=?,deleted=1,updated_at=?
+                    """UPDATE scoped_records SET revision=?,payload_json=?,payload_hash=?,deleted=1,updated_at=?
                        WHERE namespace_scope=? AND record_kind=? AND record_id=? AND deleted=0""",
                     (
-                        int(row["revision"]) + 1, now, row["namespace_scope"],
+                        int(row["revision"]) + 1, _ERASED_PAYLOAD_JSON, _ERASED_PAYLOAD_HASH,
+                        now, row["namespace_scope"],
                         row["record_kind"], row["record_id"],
                     ),
                 )
@@ -583,6 +597,7 @@ class ScopedStore:
                    ) VALUES(?,?,?,?,?,?)""",
                 (operation, context.migration_epoch, target, request_hash, _canonical(result), now),
             )
+        self._truncate_wal()
         return result
 
 

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -72,6 +72,9 @@ class ScopedStore:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._clock = clock if callable(clock) else time.time
         self._lock = threading.RLock()
+        self._active_epoch = ""
+        self._active_policy_version = ""
+        self._epoch_revision = 0
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
@@ -132,17 +135,108 @@ class ScopedStore:
                     created_at REAL NOT NULL,
                     PRIMARY KEY(event_id, migration_epoch)
                 );
+                CREATE TABLE IF NOT EXISTS scoped_epoch_state (
+                    singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+                    migration_epoch TEXT NOT NULL,
+                    policy_version TEXT NOT NULL,
+                    revision INTEGER NOT NULL,
+                    updated_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS scoped_epoch_operations (
+                    operation_id TEXT PRIMARY KEY,
+                    request_hash TEXT NOT NULL,
+                    result_code TEXT NOT NULL,
+                    revision INTEGER NOT NULL,
+                    created_at REAL NOT NULL
+                );
                 """
             )
+            state = conn.execute(
+                "SELECT migration_epoch,policy_version,revision FROM scoped_epoch_state WHERE singleton=1"
+            ).fetchone()
+            if state is not None:
+                self._active_epoch = state["migration_epoch"]
+                self._active_policy_version = state["policy_version"]
+                self._epoch_revision = int(state["revision"])
 
-    @staticmethod
-    def _authorize(context: NamespaceContext | None, record_kind: str, *, write: bool) -> None:
+    def _authorize(self, context: NamespaceContext | None, record_kind: str, *, write: bool) -> None:
         if record_kind not in RECORD_KINDS:
             raise ScopedStoreError("scoped_record_kind_invalid")
         purpose = _PURPOSE_BY_KIND[record_kind][1 if write else 0]
         decision = AssurancePolicy.authorize(context, purpose)
         if not decision.allowed:
             raise ScopedStoreError(decision.code)
+        if self._active_epoch:
+            assert context is not None
+            if context.migration_epoch != self._active_epoch:
+                raise ScopedStoreError("scoped_migration_epoch_stale")
+            if context.policy_version != self._active_policy_version:
+                raise ScopedStoreError("scoped_policy_version_stale")
+
+    def epoch_status(self) -> dict[str, Any]:
+        return {
+            "bound": bool(self._active_epoch),
+            "migration_epoch": self._active_epoch,
+            "policy_version": self._active_policy_version,
+            "revision": self._epoch_revision,
+        }
+
+    def bind_epoch(
+        self,
+        *,
+        operation_id: str,
+        expected_previous_epoch: str,
+        migration_epoch: str,
+        policy_version: str,
+    ) -> str:
+        operation = _token(operation_id)
+        expected = _token(expected_previous_epoch) if expected_previous_epoch else ""
+        epoch = _token(migration_epoch)
+        policy = _token(policy_version, 64)
+        if not operation or not epoch or not policy or epoch == expected:
+            raise ScopedStoreError("scoped_epoch_binding_invalid")
+        request_hash = hashlib.sha256(
+            _canonical({"expected": expected, "epoch": epoch, "policy": policy}).encode("utf-8")
+        ).hexdigest()
+        now = float(self._clock())
+        with self._transaction() as conn:
+            prior = conn.execute(
+                "SELECT request_hash,result_code FROM scoped_epoch_operations WHERE operation_id=?",
+                (operation,),
+            ).fetchone()
+            if prior is not None:
+                if prior["request_hash"] != request_hash:
+                    raise ScopedRecordConflict("scoped_epoch_operation_conflict")
+                return "duplicate"
+            state = conn.execute(
+                "SELECT migration_epoch,policy_version,revision FROM scoped_epoch_state WHERE singleton=1"
+            ).fetchone()
+            current = state["migration_epoch"] if state is not None else ""
+            current_policy = state["policy_version"] if state is not None else ""
+            current_revision = int(state["revision"]) if state is not None else 0
+            if current == epoch and current_policy == policy:
+                result = "current"
+                revision = current_revision
+            else:
+                if current != expected:
+                    raise ScopedRecordConflict("scoped_epoch_compare_and_swap_failed")
+                revision = current_revision + 1
+                conn.execute(
+                    """INSERT INTO scoped_epoch_state(singleton,migration_epoch,policy_version,revision,updated_at)
+                       VALUES(1,?,?,?,?) ON CONFLICT(singleton) DO UPDATE SET
+                       migration_epoch=excluded.migration_epoch,policy_version=excluded.policy_version,
+                       revision=excluded.revision,updated_at=excluded.updated_at""",
+                    (epoch, policy, revision, now),
+                )
+                result = "bound" if current_revision == 0 else "rotated"
+            conn.execute(
+                "INSERT INTO scoped_epoch_operations(operation_id,request_hash,result_code,revision,created_at) VALUES(?,?,?,?,?)",
+                (operation, request_hash, result, revision, now),
+            )
+        self._active_epoch = epoch
+        self._active_policy_version = policy
+        self._epoch_revision = revision
+        return result
 
     @staticmethod
     def _scope(context: NamespaceContext) -> str:

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -492,6 +492,99 @@ class ScopedStore:
             )
         return result
 
+    def tombstone_identity_scopes(
+        self,
+        context: NamespaceContext,
+        *,
+        operation_id: str,
+        reason_code: str,
+        record_prefix: str = "req041-",
+    ) -> dict[str, Any]:
+        """Permanently tombstone one person's private/member projections atomically.
+
+        The caller must authorize with the person's formal private context.  We
+        intentionally discover every historical group-member scope inside the
+        same transaction so stale groups cannot be orphaned by a caller's
+        incomplete context list.  Group-shared and persona-global ownership is
+        never part of an individual archive.
+        """
+        decision = AssurancePolicy.authorize(context, "memory_write")
+        if not decision.allowed:
+            raise ScopedStoreError(decision.code)
+        if context.kind != "private" or context.group_id or not context.identity_id:
+            raise ScopedStoreError("scoped_identity_archive_context_invalid")
+        if self._active_epoch:
+            if context.migration_epoch != self._active_epoch:
+                raise ScopedStoreError("scoped_migration_epoch_stale")
+            if context.policy_version != self._active_policy_version:
+                raise ScopedStoreError("scoped_policy_version_stale")
+        operation = _token(operation_id)
+        reason = _token(reason_code, 80)
+        prefix = _token(record_prefix, 40)
+        if not operation or not reason or not prefix:
+            raise ScopedStoreError("scoped_identity_archive_invalid")
+        target = _canonical({
+            "kind": "identity_scopes",
+            "persona_id": context.persona_id,
+            "identity_id": context.identity_id,
+        })
+        request_hash = hashlib.sha256(
+            _canonical({"target": target, "reason": reason, "prefix": prefix}).encode("utf-8")
+        ).hexdigest()
+        now = float(self._clock())
+        with self._transaction() as conn:
+            prior = conn.execute(
+                "SELECT request_hash,result_json FROM scoped_namespace_operations WHERE operation_id=? AND migration_epoch=?",
+                (operation, context.migration_epoch),
+            ).fetchone()
+            if prior is not None:
+                if prior["request_hash"] != request_hash:
+                    raise ScopedRecordConflict("scoped_namespace_operation_conflict")
+                return json.loads(prior["result_json"])
+            candidates = conn.execute(
+                """SELECT namespace_scope,record_kind,record_id,revision FROM scoped_records
+                   WHERE deleted=0 AND record_id LIKE ? ORDER BY namespace_scope,record_kind,record_id""",
+                (f"{prefix}%",),
+            ).fetchall()
+            rows: list[sqlite3.Row] = []
+            scopes: set[str] = set()
+            for row in candidates:
+                try:
+                    owner = json.loads(row["namespace_scope"])
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    continue
+                if not isinstance(owner, dict):
+                    continue
+                if (
+                    owner.get("kind") in {"private", "group_member"}
+                    and owner.get("persona_id") == context.persona_id
+                    and owner.get("identity_id") == context.identity_id
+                ):
+                    rows.append(row)
+                    scopes.add(str(row["namespace_scope"]))
+            for row in rows:
+                conn.execute(
+                    """UPDATE scoped_records SET revision=?,deleted=1,updated_at=?
+                       WHERE namespace_scope=? AND record_kind=? AND record_id=? AND deleted=0""",
+                    (
+                        int(row["revision"]) + 1, now, row["namespace_scope"],
+                        row["record_kind"], row["record_id"],
+                    ),
+                )
+            result = {
+                "code": "identity_scopes_tombstoned" if rows else "identity_scopes_already_empty",
+                "count": len(rows),
+                "namespace_count": len(scopes),
+                "reason_code": reason,
+            }
+            conn.execute(
+                """INSERT INTO scoped_namespace_operations(
+                       operation_id,migration_epoch,namespace_scope,request_hash,result_json,created_at
+                   ) VALUES(?,?,?,?,?,?)""",
+                (operation, context.migration_epoch, target, request_hash, _canonical(result), now),
+            )
+        return result
+
 
 __all__ = [
     "MAX_RECORD_BYTES", "RECORD_KINDS", "ScopedRecordConflict", "ScopedRevisionGap", "ScopedStore",

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -16,6 +16,7 @@ import time
 from typing import Any, Iterator
 
 from .namespace import AssurancePolicy, NamespaceContext
+from .scoped_domain_contract import SCHEMA_VERSION, ScopedDomainContractError, validate_scoped_domain_payload
 
 
 MAX_RECORD_BYTES = 262144
@@ -247,6 +248,7 @@ class ScopedStore:
         # redacted, revision-aware cache key.
         return _canonical({
             "kind": context.kind,
+            "persona_id": context.persona_id,
             "identity_id": context.identity_id,
             "group_id": context.group_id,
         })
@@ -266,6 +268,13 @@ class ScopedStore:
         event = _token(event_id)
         if not identifier or not event or revision < 1:
             raise ScopedStoreError("scoped_envelope_invalid")
+        if str(record_id or "").startswith("req041-") or (
+            isinstance(payload, dict) and payload.get("schema_version") == SCHEMA_VERSION
+        ):
+            try:
+                validate_scoped_domain_payload(context, record_kind, payload)
+            except ScopedDomainContractError as exc:
+                raise ScopedStoreError(str(exc)) from exc
         encoded, digest = _payload(payload)
         scope = self._scope(context)
         request_hash = hashlib.sha256(

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -16,7 +16,12 @@ import time
 from typing import Any, Iterator
 
 from .namespace import AssurancePolicy, NamespaceContext
-from .scoped_domain_contract import SCHEMA_VERSION, ScopedDomainContractError, validate_scoped_domain_payload
+from .scoped_domain_contract import (
+    SCHEMA_VERSION,
+    ScopedDomainContractError,
+    build_scoped_domain_payload,
+    validate_scoped_domain_payload,
+)
 
 
 MAX_RECORD_BYTES = 262144
@@ -590,6 +595,111 @@ class ScopedStore:
                 "count": len(rows),
                 "namespace_count": len(scopes),
                 "reason_code": reason,
+            }
+            conn.execute(
+                """INSERT INTO scoped_namespace_operations(
+                       operation_id,migration_epoch,namespace_scope,request_hash,result_json,created_at
+                   ) VALUES(?,?,?,?,?,?)""",
+                (operation, context.migration_epoch, target, request_hash, _canonical(result), now),
+            )
+        self._truncate_wal()
+        return result
+
+    def erase_group_scopes(
+        self,
+        context: NamespaceContext,
+        *,
+        operation_id: str,
+        reason_code: str = "group_reset",
+        record_prefix: str = "req041-",
+    ) -> dict[str, Any]:
+        """Atomically empty one group's shared/member projections without banning reuse."""
+        decision = AssurancePolicy.authorize(context, "memory_write")
+        if not decision.allowed:
+            raise ScopedStoreError(decision.code)
+        if context.kind != "group_shared" or context.identity_id or not context.group_id:
+            raise ScopedStoreError("scoped_group_erase_context_invalid")
+        if self._active_epoch:
+            if context.migration_epoch != self._active_epoch:
+                raise ScopedStoreError("scoped_migration_epoch_stale")
+            if context.policy_version != self._active_policy_version:
+                raise ScopedStoreError("scoped_policy_version_stale")
+        operation = _token(operation_id)
+        reason = _token(reason_code, 80)
+        prefix = _token(record_prefix, 40)
+        if not operation or not reason or not prefix:
+            raise ScopedStoreError("scoped_group_erase_invalid")
+        target = _canonical({
+            "kind": "group_scopes", "persona_id": context.persona_id, "group_id": context.group_id,
+        })
+        request_hash = hashlib.sha256(
+            _canonical({"target": target, "reason": reason, "prefix": prefix}).encode("utf-8")
+        ).hexdigest()
+        now = float(self._clock())
+        with self._transaction() as conn:
+            prior = conn.execute(
+                "SELECT request_hash,result_json FROM scoped_namespace_operations WHERE operation_id=? AND migration_epoch=?",
+                (operation, context.migration_epoch),
+            ).fetchone()
+            if prior is not None:
+                if prior["request_hash"] != request_hash:
+                    raise ScopedRecordConflict("scoped_namespace_operation_conflict")
+                return json.loads(prior["result_json"])
+            candidates = conn.execute(
+                """SELECT namespace_scope,record_kind,record_id,revision,payload_json FROM scoped_records
+                   WHERE deleted=0 AND record_id LIKE ? ORDER BY namespace_scope,record_kind,record_id""",
+                (f"{prefix}%",),
+            ).fetchall()
+            rows: list[tuple[sqlite3.Row, str, str]] = []
+            scopes: set[str] = set()
+            for row in candidates:
+                try:
+                    owner = json.loads(row["namespace_scope"])
+                    payload = json.loads(row["payload_json"])
+                except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                    raise ScopedStoreError("scoped_group_erase_record_invalid") from exc
+                if not isinstance(owner, dict) or not isinstance(payload, dict):
+                    raise ScopedStoreError("scoped_group_erase_record_invalid")
+                if not (
+                    owner.get("kind") in {"group_shared", "group_member"}
+                    and owner.get("persona_id") == context.persona_id
+                    and owner.get("group_id") == context.group_id
+                ):
+                    continue
+                try:
+                    cleared = build_scoped_domain_payload(
+                        domain=str(payload.get("domain") or ""),
+                        source_kind=str(payload.get("source_kind") or owner.get("kind") or ""),
+                        content={}, source_revision=int(payload.get("source_revision") or 0) + 1,
+                        approval_state=str(payload.get("approval_state") or "not_applicable"),
+                        approved_by=str(payload.get("approved_by") or ""),
+                    )
+                    validate_scoped_domain_payload(
+                        NamespaceContext(
+                            kind=str(owner.get("kind") or ""), persona_id=str(owner.get("persona_id") or ""),
+                            identity_id=str(owner.get("identity_id") or ""), group_id=str(owner.get("group_id") or ""),
+                            assurance=context.assurance, profile_status=context.profile_status,
+                            policy_version=context.policy_version, migration_epoch=context.migration_epoch,
+                        ),
+                        str(row["record_kind"]), cleared,
+                    )
+                    encoded, digest = _payload(cleared)
+                except (TypeError, ValueError, ScopedDomainContractError, ScopedStoreError) as exc:
+                    raise ScopedStoreError("scoped_group_erase_record_invalid") from exc
+                rows.append((row, encoded, digest))
+                scopes.add(str(row["namespace_scope"]))
+            for row, encoded, digest in rows:
+                conn.execute(
+                    """UPDATE scoped_records SET revision=?,payload_json=?,payload_hash=?,updated_at=?
+                       WHERE namespace_scope=? AND record_kind=? AND record_id=? AND deleted=0""",
+                    (
+                        int(row["revision"]) + 1, encoded, digest, now, row["namespace_scope"],
+                        row["record_kind"], row["record_id"],
+                    ),
+                )
+            result = {
+                "code": "group_scopes_erased" if rows else "group_scopes_already_empty",
+                "count": len(rows), "namespace_count": len(scopes), "reason_code": reason,
             }
             conn.execute(
                 """INSERT INTO scoped_namespace_operations(

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -710,6 +710,108 @@ class ScopedStore:
         self._truncate_wal()
         return result
 
+    def erase_persona_scopes(
+        self,
+        context: NamespaceContext,
+        *,
+        operation_id: str,
+        reason_code: str = "persona_reset",
+        record_prefix: str = "req041-",
+    ) -> dict[str, Any]:
+        """Atomically empty every managed projection owned by one persona."""
+        decision = AssurancePolicy.authorize(context, "rule_write")
+        if not decision.allowed:
+            raise ScopedStoreError(decision.code)
+        if context.kind != "persona_global" or context.identity_id or context.group_id:
+            raise ScopedStoreError("scoped_persona_erase_context_invalid")
+        if self._active_epoch:
+            if context.migration_epoch != self._active_epoch:
+                raise ScopedStoreError("scoped_migration_epoch_stale")
+            if context.policy_version != self._active_policy_version:
+                raise ScopedStoreError("scoped_policy_version_stale")
+        operation = _token(operation_id)
+        reason = _token(reason_code, 80)
+        prefix = _token(record_prefix, 40)
+        if not operation or not reason or not prefix:
+            raise ScopedStoreError("scoped_persona_erase_invalid")
+        target = _canonical({"kind": "persona_scopes", "persona_id": context.persona_id})
+        request_hash = hashlib.sha256(
+            _canonical({"target": target, "reason": reason, "prefix": prefix}).encode("utf-8")
+        ).hexdigest()
+        now = float(self._clock())
+        with self._transaction() as conn:
+            prior = conn.execute(
+                "SELECT request_hash,result_json FROM scoped_namespace_operations WHERE operation_id=? AND migration_epoch=?",
+                (operation, context.migration_epoch),
+            ).fetchone()
+            if prior is not None:
+                if prior["request_hash"] != request_hash:
+                    raise ScopedRecordConflict("scoped_namespace_operation_conflict")
+                return json.loads(prior["result_json"])
+            candidates = conn.execute(
+                """SELECT namespace_scope,record_kind,record_id,revision,payload_json FROM scoped_records
+                   WHERE deleted=0 AND record_id LIKE ? ORDER BY namespace_scope,record_kind,record_id""",
+                (f"{prefix}%",),
+            ).fetchall()
+            rows: list[tuple[sqlite3.Row, str, str]] = []
+            scopes: set[str] = set()
+            kinds: set[str] = set()
+            for row in candidates:
+                try:
+                    owner = json.loads(row["namespace_scope"])
+                    payload = json.loads(row["payload_json"])
+                except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                    raise ScopedStoreError("scoped_persona_erase_record_invalid") from exc
+                if not isinstance(owner, dict) or not isinstance(payload, dict):
+                    raise ScopedStoreError("scoped_persona_erase_record_invalid")
+                if owner.get("persona_id") != context.persona_id:
+                    continue
+                try:
+                    cleared = build_scoped_domain_payload(
+                        domain=str(payload.get("domain") or ""),
+                        source_kind=str(payload.get("source_kind") or owner.get("kind") or ""),
+                        content={}, source_revision=int(payload.get("source_revision") or 0) + 1,
+                        approval_state=str(payload.get("approval_state") or "not_applicable"),
+                        approved_by=str(payload.get("approved_by") or ""),
+                    )
+                    validate_scoped_domain_payload(
+                        NamespaceContext(
+                            kind=str(owner.get("kind") or ""), persona_id=str(owner.get("persona_id") or ""),
+                            identity_id=str(owner.get("identity_id") or ""), group_id=str(owner.get("group_id") or ""),
+                            assurance=context.assurance, profile_status=context.profile_status,
+                            policy_version=context.policy_version, migration_epoch=context.migration_epoch,
+                        ),
+                        str(row["record_kind"]), cleared,
+                    )
+                    encoded, digest = _payload(cleared)
+                except (TypeError, ValueError, ScopedDomainContractError, ScopedStoreError) as exc:
+                    raise ScopedStoreError("scoped_persona_erase_record_invalid") from exc
+                rows.append((row, encoded, digest))
+                scopes.add(str(row["namespace_scope"]))
+                kinds.add(str(owner.get("kind") or ""))
+            for row, encoded, digest in rows:
+                conn.execute(
+                    """UPDATE scoped_records SET revision=?,payload_json=?,payload_hash=?,updated_at=?
+                       WHERE namespace_scope=? AND record_kind=? AND record_id=? AND deleted=0""",
+                    (
+                        int(row["revision"]) + 1, encoded, digest, now, row["namespace_scope"],
+                        row["record_kind"], row["record_id"],
+                    ),
+                )
+            result = {
+                "code": "persona_scopes_erased" if rows else "persona_scopes_already_empty",
+                "count": len(rows), "namespace_count": len(scopes),
+                "namespace_kinds": sorted(kinds), "reason_code": reason,
+            }
+            conn.execute(
+                """INSERT INTO scoped_namespace_operations(
+                       operation_id,migration_epoch,namespace_scope,request_hash,result_json,created_at
+                   ) VALUES(?,?,?,?,?,?)""",
+                (operation, context.migration_epoch, target, request_hash, _canonical(result), now),
+            )
+        self._truncate_wal()
+        return result
+
 
 __all__ = [
     "MAX_RECORD_BYTES", "RECORD_KINDS", "ScopedRecordConflict", "ScopedRevisionGap", "ScopedStore",

--- a/core/scoped_store.py
+++ b/core/scoped_store.py
@@ -150,6 +150,15 @@ class ScopedStore:
                     revision INTEGER NOT NULL,
                     created_at REAL NOT NULL
                 );
+                CREATE TABLE IF NOT EXISTS scoped_namespace_operations (
+                    operation_id TEXT NOT NULL,
+                    migration_epoch TEXT NOT NULL,
+                    namespace_scope TEXT NOT NULL,
+                    request_hash TEXT NOT NULL,
+                    result_json TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY(operation_id,migration_epoch)
+                );
                 """
             )
             state = conn.execute(
@@ -422,6 +431,66 @@ class ScopedStore:
                 (event, context.migration_epoch, request_hash, "tombstoned", now),
             )
         return "tombstoned"
+
+    def tombstone_namespace(
+        self,
+        context: NamespaceContext,
+        *,
+        operation_id: str,
+        reason_code: str,
+        record_prefix: str = "req041-",
+    ) -> dict[str, Any]:
+        purpose = "rule_write" if context.kind == "persona_global" else "memory_write"
+        decision = AssurancePolicy.authorize(context, purpose)
+        if not decision.allowed:
+            raise ScopedStoreError(decision.code)
+        if self._active_epoch and (
+            context.migration_epoch != self._active_epoch
+            or context.policy_version != self._active_policy_version
+        ):
+            raise ScopedStoreError("scoped_migration_epoch_stale")
+        operation = _token(operation_id)
+        reason = _token(reason_code, 80)
+        prefix = _token(record_prefix, 40)
+        if not operation or not reason or not prefix:
+            raise ScopedStoreError("scoped_namespace_tombstone_invalid")
+        scope = self._scope(context)
+        request_hash = hashlib.sha256(
+            _canonical({"scope": scope, "reason": reason, "prefix": prefix}).encode("utf-8")
+        ).hexdigest()
+        now = float(self._clock())
+        with self._transaction() as conn:
+            prior = conn.execute(
+                "SELECT request_hash,result_json FROM scoped_namespace_operations WHERE operation_id=? AND migration_epoch=?",
+                (operation, context.migration_epoch),
+            ).fetchone()
+            if prior is not None:
+                if prior["request_hash"] != request_hash:
+                    raise ScopedRecordConflict("scoped_namespace_operation_conflict")
+                return json.loads(prior["result_json"])
+            rows = conn.execute(
+                """SELECT record_kind,record_id,revision FROM scoped_records
+                   WHERE namespace_scope=? AND deleted=0 AND record_id LIKE ? ORDER BY record_kind,record_id""",
+                (scope, f"{prefix}%"),
+            ).fetchall()
+            for row in rows:
+                conn.execute(
+                    """UPDATE scoped_records SET revision=?,deleted=1,updated_at=?
+                       WHERE namespace_scope=? AND record_kind=? AND record_id=? AND deleted=0""",
+                    (int(row["revision"]) + 1, now, scope, row["record_kind"], row["record_id"]),
+                )
+            result = {
+                "code": "namespace_tombstoned" if rows else "namespace_already_empty",
+                "count": len(rows),
+                "reason_code": reason,
+            }
+            conn.execute(
+                """INSERT INTO scoped_namespace_operations(
+                       operation_id,migration_epoch,namespace_scope,request_hash,result_json,created_at
+                   ) VALUES(?,?,?,?,?,?)""",
+                (operation, context.migration_epoch, scope, request_hash, _canonical(result), now),
+            )
+        return result
 
 
 __all__ = [

--- a/core/service.py
+++ b/core/service.py
@@ -77,6 +77,7 @@ from .qq_history import QQHistoryReader
 from .reply_chain import ReplyChainResolver
 from .retrieval import RetrievalEngine
 from .store import MemoryStore
+from .scoped_store import ScopedStore
 from .summarizer import MemorySummarizer
 from .time_intent import TimeIntent, parse_time_intent
 from .turn_signal import analyze_turn_signal, message_terms
@@ -194,6 +195,7 @@ class MemoryCompanionService:
 
         self.store = MemoryStore(self.data_dir / "memory_companion.db")
         self.store.initialize()
+        self.scoped_store = ScopedStore(self.data_dir / "req041_scoped.db")
         self.portraits = PortraitService(self.store, self.config)
         normalized = self.store.normalize_legacy_manual_visibility()
         if normalized:

--- a/core/store.py
+++ b/core/store.py
@@ -14,6 +14,7 @@ from typing import Any
 from .identity import parse_scope_from_session
 from .models import EntityRef, MemoryRecord, clean_text, json_dumps, json_loads, new_id, stable_fingerprint, utc_now
 from .portrait import cross_scene_whitelisted_fact
+from .portrait_namespace import portrait_scope_kind, portrait_scope_persona
 
 
 class MemoryStore:
@@ -551,6 +552,15 @@ class MemoryStore:
                     updated_at TEXT NOT NULL DEFAULT ''
                 );
 
+                CREATE TABLE IF NOT EXISTS portrait_scope_capabilities (
+                    person_id TEXT NOT NULL DEFAULT '',
+                    source_scope TEXT NOT NULL DEFAULT '',
+                    capability_summary TEXT NOT NULL DEFAULT '{}',
+                    projection_revision INTEGER NOT NULL DEFAULT 0,
+                    updated_at TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY(person_id, source_scope)
+                );
+
                 CREATE TABLE IF NOT EXISTS portrait_evidence (
                     evidence_hash TEXT PRIMARY KEY,
                     person_id TEXT NOT NULL DEFAULT '',
@@ -715,6 +725,10 @@ class MemoryStore:
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_portrait_facts_person ON portrait_facts(person_id, status, sensitivity, updated_at DESC)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_portrait_scope_capabilities_person "
+                "ON portrait_scope_capabilities(person_id, updated_at DESC)"
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_portrait_suppressions_person ON portrait_suppressions(person_id, status)"
@@ -995,23 +1009,28 @@ class MemoryStore:
         self,
         person_ref: dict[str, Any],
         capability_summary: dict[str, Any],
+        *,
+        source_scope: str = "",
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
             self._upsert_portrait_person_projection_sync,
             deepcopy(person_ref),
             deepcopy(capability_summary),
+            source_scope,
         )
 
     def _upsert_portrait_person_projection_sync(
         self,
         person_ref: dict[str, Any],
         capability_summary: dict[str, Any],
+        source_scope: str,
     ) -> dict[str, Any]:
         person_id = clean_text(person_ref.get("person_id"), 80)
         identity_key = clean_text(person_ref.get("resolved_identity_key"), 96)
         revision = int(person_ref.get("projection_revision") or 0)
         assurance = clean_text(person_ref.get("identity_assurance"), 40)
         status = clean_text(person_ref.get("profile_status"), 40)
+        source_scope = clean_text(source_scope, 80)
         if (
             not person_id
             or not identity_key
@@ -1032,6 +1051,11 @@ class MemoryStore:
                 if old_revision == revision and previous["resolved_identity_key"] != identity_key:
                     return {"ok": False, "code": "bridge_person_mismatch", "state": "invalid"}
             portrait_revision = int(previous["portrait_revision"] or 0) if previous is not None else 0
+            durable_capability_summary = capability_summary
+            if previous is not None and source_scope and not (
+                source_scope == "private" or source_scope.startswith("private@")
+            ):
+                durable_capability_summary = json_loads(previous["capability_summary"], {})
             self._conn.execute(
                 """
                 INSERT INTO portrait_people(
@@ -1053,12 +1077,25 @@ class MemoryStore:
                     revision,
                     clean_text(person_ref.get("identity_assurance"), 40),
                     clean_text(person_ref.get("profile_status"), 40),
-                    json_dumps(capability_summary),
+                    json_dumps(durable_capability_summary),
                     portrait_revision,
                     now,
                     now,
                 ),
             )
+            if source_scope:
+                self._conn.execute(
+                    """
+                    INSERT INTO portrait_scope_capabilities(
+                        person_id, source_scope, capability_summary, projection_revision, updated_at
+                    ) VALUES(?,?,?,?,?)
+                    ON CONFLICT(person_id, source_scope) DO UPDATE SET
+                        capability_summary=excluded.capability_summary,
+                        projection_revision=excluded.projection_revision,
+                        updated_at=excluded.updated_at
+                    """,
+                    (person_id, source_scope, json_dumps(capability_summary), revision, now),
+                )
             self._conn.commit()
         return {"ok": True, "code": "profile_exact", "state": "ready", "portrait_revision": portrait_revision}
 
@@ -1155,12 +1192,50 @@ class MemoryStore:
         return age.total_seconds() <= max(1, freshness_days) * 86400
 
     @staticmethod
-    def _portrait_scope_allows_row(row: sqlite3.Row, requested_scope: str) -> bool:
+    def _portrait_scope_allows_row(
+        row: sqlite3.Row,
+        requested_scope: str,
+        legacy_scope: str = "",
+    ) -> bool:
         usable_scope = clean_text(row["usable_scope"], 80)
         source_scope = clean_text(row["source_scope"], 80)
         if usable_scope == "self_low_global":
-            return True
-        return usable_scope == "source_only" and bool(requested_scope) and source_scope == requested_scope
+            source_persona = portrait_scope_persona(source_scope)
+            requested_persona = portrait_scope_persona(requested_scope)
+            return not source_persona or (
+                bool(requested_persona) and source_persona == requested_persona
+            )
+        return usable_scope == "source_only" and bool(requested_scope) and source_scope in {
+            requested_scope,
+            legacy_scope,
+        }
+
+    def _portrait_scope_capability_sync(
+        self,
+        person_id: str,
+        source_scope: str,
+        *,
+        legacy_scope: str = "",
+    ) -> dict[str, Any]:
+        source_scope = clean_text(source_scope, 80)
+        row = self._conn.execute(
+            "SELECT capability_summary FROM portrait_scope_capabilities WHERE person_id=? AND source_scope=?",
+            (person_id, source_scope),
+        ).fetchone()
+        if row is not None:
+            value = json_loads(row["capability_summary"], {})
+            return value if isinstance(value, dict) else {}
+        if (
+            source_scope == "private"
+            or source_scope.startswith("group:")
+        ):
+            person = self._conn.execute(
+                "SELECT capability_summary FROM portrait_people WHERE person_id=?",
+                (person_id,),
+            ).fetchone()
+            value = json_loads(person["capability_summary"], {}) if person is not None else {}
+            return value if isinstance(value, dict) else {}
+        return {}
 
     def _bump_portrait_revision_sync(self, person_id: str) -> int:
         self._conn.execute(
@@ -1378,9 +1453,6 @@ class MemoryStore:
             person = self._conn.execute("SELECT * FROM portrait_people WHERE person_id=?", (person_id,)).fetchone()
             if person is None:
                 return {"ok": False, "code": "bridge_unavailable"}
-            capabilities = json_loads(person["capability_summary"], {})
-            if not bool(capabilities.get("portrait_learning_enabled")):
-                return {"ok": False, "code": "portrait_learning_disabled"}
             run = self._conn.execute(
                 "SELECT * FROM portrait_daily_runs WHERE person_id=? AND run_day=?", (person_id, run_day)
             ).fetchone()
@@ -1390,6 +1462,30 @@ class MemoryStore:
                 return {"ok": False, "code": "portrait_daily_limit", "attempts": attempts, "successes": successes}
             if attempts >= attempt_limit:
                 return {"ok": False, "code": "portrait_daily_limit", "attempts": attempts, "successes": successes}
+            pending_scopes = self._conn.execute(
+                """
+                SELECT DISTINCT f.source_scope
+                FROM portrait_learning_queue q
+                JOIN portrait_facts f ON f.id=q.fact_id
+                WHERE q.person_id=? AND q.state='pending' AND f.status='active'
+                """,
+                (person_id,),
+            ).fetchall()
+            if not any(
+                bool(
+                    self._portrait_scope_capability_sync(
+                        person_id,
+                        clean_text(row["source_scope"], 80),
+                        legacy_scope=(
+                            "private"
+                            if clean_text(row["source_scope"], 80) == "private"
+                            else ""
+                        ),
+                    ).get("portrait_learning_enabled")
+                )
+                for row in pending_scopes
+            ):
+                return {"ok": False, "code": "portrait_learning_disabled"}
             attempts += 1
             self._conn.execute(
                 """
@@ -1410,6 +1506,14 @@ class MemoryStore:
             ).fetchall()
             created = 0
             for row in rows:
+                row_scope = clean_text(row["source_scope"], 80)
+                row_capabilities = self._portrait_scope_capability_sync(
+                    person_id,
+                    row_scope,
+                    legacy_scope="private" if row_scope == "private" else "",
+                )
+                if not bool(row_capabilities.get("portrait_learning_enabled")):
+                    continue
                 evidence_hashes = json_loads(row["evidence_hashes"], [])
                 if self._portrait_distinct_statement_count_sync(evidence_hashes) < min_independent_evidence:
                     continue
@@ -1431,7 +1535,11 @@ class MemoryStore:
                     "derivation_kind": "independent_evidence_aggregate",
                     "epistemic_status": "inferred",
                     "source_scope": row["source_scope"],
-                    "usable_scope": "source_only" if row["source_scope"] != "private" else "self_low_global",
+                    "usable_scope": (
+                        "self_low_global"
+                        if portrait_scope_kind(row["source_scope"]) == "private"
+                        else "source_only"
+                    ),
                     "confidence": min(0.95, max(0.75, float(row["confidence"] or 0.0))),
                     "sensitivity": row["sensitivity"],
                     "evidence_hashes": evidence_hashes,
@@ -1461,6 +1569,7 @@ class MemoryStore:
         person_id: str,
         *,
         scope: str = "",
+        legacy_scope: str = "",
         limit: int = 8,
         low_only: bool = True,
         usage_min_confidence: float = 0.75,
@@ -1470,6 +1579,7 @@ class MemoryStore:
             self._portrait_summary_sync,
             person_id,
             scope,
+            legacy_scope,
             limit,
             low_only,
             usage_min_confidence,
@@ -1480,6 +1590,7 @@ class MemoryStore:
         self,
         person_id: str,
         scope: str,
+        legacy_scope: str,
         limit: int,
         low_only: bool,
         usage_min_confidence: float,
@@ -1487,6 +1598,7 @@ class MemoryStore:
     ) -> dict[str, Any]:
         person_id = clean_text(person_id, 80)
         scope = clean_text(scope, 80)
+        legacy_scope = clean_text(legacy_scope, 80)
         confidence_floor = max(0.0, min(1.0, float(usage_min_confidence or 0.75)))
         freshness_days = max(1, min(3650, int(inferred_freshness_days or 90)))
         with self._lock:
@@ -1502,7 +1614,9 @@ class MemoryStore:
                     "items": [],
                     "portrait_revision": int(person["portrait_revision"] or 0),
                 }
-            capabilities = json_loads(person["capability_summary"], {})
+            capabilities = self._portrait_scope_capability_sync(
+                person_id, scope, legacy_scope=legacy_scope
+            )
             if not bool(capabilities.get("portrait_usage_enabled")):
                 return {"ok": False, "code": "portrait_usage_disabled", "items": [], "portrait_revision": int(person["portrait_revision"] or 0)}
             query = "SELECT * FROM portrait_facts WHERE person_id=? AND status='active'"
@@ -1516,7 +1630,7 @@ class MemoryStore:
             rows = self._conn.execute(query, params).fetchall()
             items: list[dict[str, Any]] = []
             for row in rows:
-                if not self._portrait_scope_allows_row(row, scope):
+                if not self._portrait_scope_allows_row(row, scope, legacy_scope):
                     continue
                 if self._portrait_suppressed_sync(person_id, row["dimension"], row["normalized_claim_hash"], row["source_scope"]):
                     continue

--- a/main.py
+++ b/main.py
@@ -419,6 +419,7 @@ class MemoryCompanionPlugin(Star):
 
     async def terminate(self):
         global _ACTIVE_BRIDGE
+        self.memory_companion.deactivate()
         if _ACTIVE_BRIDGE is self.memory_companion:
             _ACTIVE_BRIDGE = None
         await self.service.aclose()

--- a/tests/test_req041_migration_recovery.py
+++ b/tests/test_req041_migration_recovery.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from core.migration_outbox import (
+    MigrationOutbox,
+    OutboxConflict,
+    OutboxError,
+    RevisionGap,
+    StaleMigrationEpoch,
+)
+from core.namespace import NamespaceContext
+
+
+EPOCH = "req041-20260810-001"
+POLICY = "req041-v1"
+
+
+def _context(**changes: str) -> NamespaceContext:
+    values = {
+        "kind": "private",
+        "identity_id": "person_aaaaaaaaaaaaaaaaaaaaaaaa",
+        "group_id": "",
+        "assurance": "verified",
+        "profile_status": "active",
+        "policy_version": POLICY,
+        "migration_epoch": EPOCH,
+    }
+    values.update(changes)
+    return NamespaceContext(**values)
+
+
+class MigrationOutboxTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "req041.sqlite3"
+        self.outbox = MigrationOutbox(self.path, clock=lambda: 100.0)
+        self.outbox.begin_epoch(EPOCH, policy_version=POLICY)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _enqueue(self, *, event: str = "event-1", revision: int = 1, payload=None) -> str:
+        return self.outbox.enqueue(
+            event_id=event,
+            source_revision=revision,
+            namespace=_context(),
+            migration_epoch=EPOCH,
+            policy_version=POLICY,
+            payload=payload or {"operation": "identity_shadow_upsert", "identity_ref": "person-a"},
+        )
+
+    def test_enqueue_is_durable_and_idempotent_across_restart(self) -> None:
+        self.assertEqual("enqueued", self._enqueue())
+        self.assertEqual("duplicate", self._enqueue())
+        reopened = MigrationOutbox(self.path, clock=lambda: 101.0)
+        pending = reopened.pending(EPOCH)
+        self.assertEqual(1, len(pending))
+        self.assertEqual("event-1", pending[0].event_id)
+        self.assertEqual("person-a", pending[0].payload["identity_ref"])
+        reopened.mark_applied("event-1", EPOCH, target_revision=1)
+        self.assertEqual([], reopened.pending(EPOCH))
+
+    def test_same_event_with_different_payload_is_conflict(self) -> None:
+        self._enqueue()
+        with self.assertRaises(OutboxConflict):
+            self._enqueue(payload={"operation": "identity_shadow_upsert", "identity_ref": "person-b"})
+
+    def test_payload_rejects_raw_conversation_material(self) -> None:
+        with self.assertRaisesRegex(OutboxError, "outbox_payload_invalid"):
+            self._enqueue(payload={"raw_text": "private message"})
+
+    def test_namespace_epoch_and_policy_must_match(self) -> None:
+        with self.assertRaisesRegex(StaleMigrationEpoch, "outbox_namespace_epoch_mismatch"):
+            self.outbox.enqueue(
+                event_id="event-x",
+                source_revision=1,
+                namespace=_context(migration_epoch="old-epoch"),
+                migration_epoch=EPOCH,
+                policy_version=POLICY,
+                payload={"operation": "noop"},
+            )
+        self.outbox.set_epoch_state(EPOCH, "verified", checkpoint="done")
+        with self.assertRaisesRegex(StaleMigrationEpoch, "migration_epoch_closed"):
+            self._enqueue(event="event-closed")
+
+    def test_failed_event_is_retriable_and_preserves_count(self) -> None:
+        self._enqueue()
+        self.outbox.mark_failed("event-1", EPOCH, error_code="target_timeout")
+        item = self.outbox.pending(EPOCH)[0]
+        self.assertEqual("failed", item.state)
+        self.assertEqual(1, item.retry_count)
+        self.assertEqual("target_timeout", item.error_code)
+
+    def test_revision_sequence_rejects_gap_and_accepts_duplicate(self) -> None:
+        self.assertEqual("advanced", self.outbox.advance_revision("identity:person-a", EPOCH, expected=0, target=1))
+        self.assertEqual("duplicate", self.outbox.advance_revision("identity:person-a", EPOCH, expected=0, target=1))
+        with self.assertRaises(RevisionGap):
+            self.outbox.advance_revision("identity:person-a", EPOCH, expected=2, target=3)
+        self.assertEqual("advanced", self.outbox.advance_revision("identity:person-a", EPOCH, expected=1, target=2))
+
+    def test_tombstone_is_durable_idempotent_and_conflict_safe(self) -> None:
+        self.assertEqual("created", self.outbox.add_tombstone("identity:person-a", EPOCH, revision=2, reason_code="unlink"))
+        self.assertEqual("duplicate", self.outbox.add_tombstone("identity:person-a", EPOCH, revision=2, reason_code="unlink"))
+        with self.assertRaises(OutboxConflict):
+            self.outbox.add_tombstone("identity:person-a", EPOCH, revision=3, reason_code="delete")
+        reopened = MigrationOutbox(self.path)
+        self.assertEqual(2, reopened.tombstone("identity:person-a", EPOCH)["revision"])
+
+    def test_epoch_checkpoint_survives_restart(self) -> None:
+        state = self.outbox.set_epoch_state(EPOCH, "replaying", checkpoint="identity:42")
+        self.assertEqual("identity:42", state["checkpoint"])
+        reopened = MigrationOutbox(self.path)
+        self.assertEqual("replaying", reopened.epoch_status(EPOCH)["state"])
+        self.assertEqual("identity:42", reopened.epoch_status(EPOCH)["checkpoint"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req041_namespace_capability.py
+++ b/tests/test_req041_namespace_capability.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import unittest
+
+from core.bridge import MemoryCompanionBridge
+from core.namespace_capability import (
+    API_METHODS,
+    namespace_capability_descriptor,
+    negotiate_namespace_capability,
+    validate_namespace_capability,
+)
+
+
+class NamespaceCapabilityTests(unittest.TestCase):
+    def test_complete_descriptor_negotiates_ready(self) -> None:
+        descriptor = namespace_capability_descriptor(available=True, methods=API_METHODS)
+        self.assertEqual([], validate_namespace_capability(descriptor))
+        self.assertTrue(negotiate_namespace_capability(descriptor)["available"])
+
+    def test_bridge_is_honest_until_scoped_api_is_bound(self) -> None:
+        bridge = MemoryCompanionBridge(SimpleNamespace())
+        descriptor = bridge.probe_namespace_context_capabilities()
+        self.assertFalse(descriptor["available"])
+        self.assertEqual("namespace_scoped_api_not_bound", descriptor["error_code"])
+        self.assertEqual([], validate_namespace_capability(descriptor, require_available=False))
+        self.assertEqual("namespace_capability_unavailable", negotiate_namespace_capability(descriptor)["code"])
+
+    def test_contract_mismatch_and_extra_field_fail_closed(self) -> None:
+        descriptor = namespace_capability_descriptor(available=True, methods=API_METHODS)
+        descriptor["namespace_contract_version"] = "2.0"
+        descriptor["extra"] = "unsafe"
+        errors = validate_namespace_capability(descriptor)
+        self.assertIn("namespace_capability_fields_invalid", errors)
+        self.assertIn("namespace_contract_version_mismatch", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req041_namespace_contract.py
+++ b/tests/test_req041_namespace_contract.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import unittest
+
+from core.namespace import (
+    AssurancePolicy,
+    CONTRACT_FINGERPRINT,
+    NamespaceContext,
+    build_namespace_context,
+    contract_self_check,
+    validate_namespace_context,
+)
+
+
+def _context(kind: str = "private", **changes: str) -> NamespaceContext:
+    values = {
+        "kind": kind,
+        "identity_id": "person_aaaaaaaaaaaaaaaaaaaaaaaa",
+        "group_id": "",
+        "assurance": "verified",
+        "profile_status": "active",
+        "policy_version": "req041-v1",
+        "migration_epoch": "shadow-20260810",
+    }
+    if kind == "group_member":
+        values["group_id"] = "group-100"
+    elif kind == "group_shared":
+        values["identity_id"] = ""
+        values["group_id"] = "group-100"
+    elif kind == "persona_global":
+        values["identity_id"] = ""
+    values.update(changes)
+    return NamespaceContext(**values)
+
+
+class NamespaceContractTests(unittest.TestCase):
+    def test_valid_private_context_round_trips_and_has_redacted_cache_scope(self) -> None:
+        context = _context()
+        payload = context.to_dict()
+        self.assertEqual([], validate_namespace_context(payload))
+        self.assertEqual(context, build_namespace_context(payload))
+        self.assertNotIn(context.identity_id, context.cache_scope())
+        self.assertEqual([], contract_self_check())
+        self.assertEqual(16, len(CONTRACT_FINGERPRINT))
+
+    def test_missing_or_extra_fields_fail_closed(self) -> None:
+        self.assertEqual(["namespace_context_missing"], validate_namespace_context(None))
+        payload = _context().to_dict()
+        payload["raw_text"] = "must never cross"
+        self.assertIn("namespace_context_fields_invalid", validate_namespace_context(payload))
+
+    def test_kind_field_combinations_are_strict(self) -> None:
+        self.assertIn("namespace_identity_required", _context(identity_id="").errors())
+        self.assertIn("namespace_group_required", _context("group_member", group_id="").errors())
+        self.assertIn("namespace_identity_forbidden", _context("group_shared", identity_id="person_x").errors())
+        self.assertIn("namespace_group_forbidden", _context(group_id="group-100").errors())
+
+    def test_assurance_policy_rejects_pending_unverified_and_inactive(self) -> None:
+        self.assertFalse(AssurancePolicy.authorize(None, "memory_read").allowed)
+        self.assertEqual(
+            "identity_assurance_insufficient",
+            AssurancePolicy.authorize(_context(assurance="observed"), "memory_read").code,
+        )
+        self.assertEqual(
+            "namespace_pending_denied",
+            AssurancePolicy.authorize(_context("pending", assurance="unverified"), "memory_read").code,
+        )
+        self.assertEqual(
+            "profile_quarantined",
+            AssurancePolicy.authorize(_context(profile_status="quarantined"), "memory_read").code,
+        )
+
+    def test_scope_specific_purposes_are_enforced(self) -> None:
+        self.assertTrue(AssurancePolicy.authorize(_context(), "relationship_read").allowed)
+        self.assertEqual(
+            "group_shared_subject_access_denied",
+            AssurancePolicy.authorize(_context("group_shared"), "profile_read").code,
+        )
+        self.assertTrue(AssurancePolicy.authorize(_context("group_shared"), "memory_read").allowed)
+        self.assertEqual(
+            "persona_global_purpose_denied",
+            AssurancePolicy.authorize(_context("persona_global"), "memory_read").code,
+        )
+        self.assertTrue(AssurancePolicy.authorize(_context("persona_global"), "rule_read").allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req041_namespace_contract.py
+++ b/tests/test_req041_namespace_contract.py
@@ -69,6 +69,12 @@ class NamespaceContractTests(unittest.TestCase):
             "profile_quarantined",
             AssurancePolicy.authorize(_context(profile_status="quarantined"), "memory_read").code,
         )
+        self.assertEqual(
+            "identity_assurance_insufficient",
+            AssurancePolicy.authorize(
+                _context("persona_global", assurance="unverified"), "rule_read"
+            ).code,
+        )
 
     def test_scope_specific_purposes_are_enforced(self) -> None:
         self.assertTrue(AssurancePolicy.authorize(_context(), "relationship_read").allowed)

--- a/tests/test_req041_portrait_namespace.py
+++ b/tests/test_req041_portrait_namespace.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "req041_portrait_memory"
+if PACKAGE not in sys.modules:
+    module = types.ModuleType(PACKAGE)
+    module.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE] = module
+
+from req041_portrait_memory.core.models import SessionContext
+from req041_portrait_memory.core.namespace import NamespaceContext
+from req041_portrait_memory.core.portrait_namespace import portrait_namespace_decision
+from req041_portrait_memory.core.portrait_service import PortraitService
+from req041_portrait_memory.core.store import MemoryStore
+from req041_portrait_memory.unified_profile_contract import build_profile_dto, build_portrait_request
+
+
+PERSON_ID = "person_" + "1" * 24
+PERSON_REF = {
+    "person_id": PERSON_ID,
+    "resolved_identity_key": "chat-origin-v1:" + "2" * 64,
+    "projection_revision": 1,
+    "identity_assurance": "verified",
+    "profile_status": "active",
+}
+
+
+class _Config:
+    @staticmethod
+    def int(_key: str, default: int) -> int:
+        return default
+
+    @staticmethod
+    def float(_key: str, default: float) -> float:
+        return default
+
+
+def _namespace(*, persona: str, kind: str = "private", group: str = "") -> dict[str, str]:
+    return NamespaceContext(
+        kind=kind,
+        persona_id=persona,
+        identity_id=PERSON_ID,
+        group_id=group,
+        assurance="verified",
+        profile_status="active",
+        policy_version="req041-v1",
+        migration_epoch="epoch-portrait-1",
+    ).to_dict()
+
+
+def _dto(mode: str) -> dict[str, object]:
+    return build_profile_dto(
+        person_ref=PERSON_REF,
+        capability_summary={
+            "private_companion_enabled": True,
+            "proactive_private_enabled": False,
+            "portrait_mode": mode,
+            "grant_source": "administrator",
+        },
+    )
+
+
+def _request(scope: str, namespace: dict[str, str]) -> dict[str, object]:
+    request = build_portrait_request(
+        person_ref=PERSON_REF,
+        requester_person_id=PERSON_ID,
+        target_person_id=PERSON_ID,
+        scope=scope,
+        purpose="summarize_to_subject",
+    )
+    request["namespace_context"] = dict(namespace)
+    return request
+
+
+class PortraitNamespaceTests(unittest.IsolatedAsyncioTestCase):
+    def make_service(self) -> tuple[MemoryStore, PortraitService]:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        store = MemoryStore(Path(temp.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store, PortraitService(store, _Config())
+
+    async def test_private_capability_survives_disabled_group_observation(self) -> None:
+        store, service = self.make_service()
+        private_ns = _namespace(persona="persona-a")
+        private_event = types.SimpleNamespace(
+            private_companion_unified_profile_context=_dto("learn_and_use"),
+            private_companion_namespace_context=private_ns,
+        )
+        captured = await service.capture_user_message(
+            SessionContext(
+                session_id="onebot:FriendMessage:10001",
+                scope="private",
+                platform="onebot",
+                user_id="10001",
+                message_id="private-1",
+                message_text="我喜欢烤肉",
+            ),
+            event=private_event,
+        )
+        self.assertTrue(captured["ok"])
+
+        group_ns = _namespace(
+            persona="persona-a", kind="group_member", group="group-hash-a"
+        )
+        group_event = types.SimpleNamespace(
+            private_companion_unified_profile_context=_dto("disabled"),
+            private_companion_namespace_context=group_ns,
+        )
+        disabled = await service.capture_user_message(
+            SessionContext(
+                session_id="onebot:GroupMessage:group-a",
+                scope="group",
+                platform="onebot",
+                group_id="group-a",
+                user_id="10001",
+                message_id="group-1",
+                message_text="我喜欢桌游",
+            ),
+            event=group_event,
+        )
+        self.assertEqual("portrait_learning_disabled", disabled["code"])
+
+        private_summary = await service.read_summary(_request("private", private_ns))
+        group_summary = await service.read_summary(
+            _request("group:onebot:group-a", group_ns)
+        )
+        self.assertTrue(private_summary["ok"])
+        self.assertEqual("portrait_usage_disabled", group_summary["code"])
+        with store._lock:
+            rows = store._conn.execute(
+                "SELECT source_scope,capability_summary FROM portrait_scope_capabilities WHERE person_id=?",
+                (PERSON_ID,),
+            ).fetchall()
+        self.assertEqual(2, len(rows))
+        self.assertEqual(2, len({row["source_scope"] for row in rows}))
+
+    async def test_persona_capabilities_do_not_overwrite_each_other(self) -> None:
+        _store, service = self.make_service()
+        enabled_ns = _namespace(persona="persona-a")
+        disabled_ns = _namespace(persona="persona-b")
+        for namespace, mode, message_id in (
+            (enabled_ns, "learn_and_use", "a-1"),
+            (disabled_ns, "disabled", "b-1"),
+        ):
+            await service.capture_user_message(
+                SessionContext(
+                    session_id=f"onebot:FriendMessage:{message_id}",
+                    scope="private",
+                    platform="onebot",
+                    user_id="10001",
+                    message_id=message_id,
+                    message_text="我喜欢烤肉",
+                ),
+                event=types.SimpleNamespace(
+                    private_companion_unified_profile_context=_dto(mode),
+                    private_companion_namespace_context=namespace,
+                ),
+            )
+        self.assertTrue((await service.read_summary(_request("private", enabled_ns)))["ok"])
+        self.assertEqual(
+            "portrait_usage_disabled",
+            (await service.read_summary(_request("private", disabled_ns)))["code"],
+        )
+
+    async def test_cross_scene_low_fact_stays_inside_its_persona(self) -> None:
+        _store, service = self.make_service()
+        persona_a = _namespace(persona="persona-a")
+        persona_b = _namespace(persona="persona-b")
+        await service.capture_user_message(
+            SessionContext(
+                session_id="onebot:FriendMessage:persona-a",
+                scope="private",
+                platform="onebot",
+                user_id="10001",
+                message_id="persona-a-food",
+                message_text="我喜欢烤肉",
+            ),
+            event=types.SimpleNamespace(
+                private_companion_unified_profile_context=_dto("learn_and_use"),
+                private_companion_namespace_context=persona_a,
+            ),
+        )
+        synced_b = await service.sync_profile_context(
+            event=types.SimpleNamespace(
+                private_companion_unified_profile_context=_dto("use_existing"),
+                private_companion_namespace_context=persona_b,
+            ),
+            legacy_scope="private",
+        )
+        self.assertTrue(synced_b["ok"])
+        self.assertIn("烤肉", str((await service.read_summary(_request("private", persona_a)))["items"]))
+        self.assertNotIn("烤肉", str((await service.read_summary(_request("private", persona_b)))["items"]))
+
+    async def test_group_a_and_group_b_source_only_facts_never_cross(self) -> None:
+        _store, service = self.make_service()
+        namespaces = {
+            "group-a": _namespace(
+                persona="persona-a", kind="group_member", group="group-hash-a"
+            ),
+            "group-b": _namespace(
+                persona="persona-a", kind="group_member", group="group-hash-b"
+            ),
+        }
+        for group_id, text in (
+            ("group-a", "我通常只在A群说苹果暗号"),
+            ("group-b", "我通常只在B群说香蕉暗号"),
+        ):
+            result = await service.capture_user_message(
+                SessionContext(
+                    session_id=f"onebot:GroupMessage:{group_id}",
+                    scope="group",
+                    platform="onebot",
+                    group_id=group_id,
+                    user_id="10001",
+                    message_id=f"{group_id}-fact",
+                    message_text=text,
+                ),
+                event=types.SimpleNamespace(
+                    private_companion_unified_profile_context=_dto("learn_and_use"),
+                    private_companion_namespace_context=namespaces[group_id],
+                ),
+            )
+            self.assertTrue(result["ok"])
+        group_a = await service.read_summary(
+            _request("group:onebot:group-a", namespaces["group-a"])
+        )
+        group_b = await service.read_summary(
+            _request("group:onebot:group-b", namespaces["group-b"])
+        )
+        self.assertIn("苹果", str(group_a["items"]))
+        self.assertNotIn("香蕉", str(group_a["items"]))
+        self.assertIn("香蕉", str(group_b["items"]))
+        self.assertNotIn("苹果", str(group_b["items"]))
+
+    async def test_scope_capability_and_fact_survive_store_restart(self) -> None:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        path = Path(temp.name) / "memory.db"
+        namespace = _namespace(persona="persona-a")
+        first = MemoryStore(path)
+        first.initialize()
+        service = PortraitService(first, _Config())
+        captured = await service.capture_user_message(
+            SessionContext(
+                session_id="onebot:FriendMessage:restart",
+                scope="private",
+                platform="onebot",
+                user_id="10001",
+                message_id="restart-fact",
+                message_text="我喜欢烤肉",
+            ),
+            event=types.SimpleNamespace(
+                private_companion_unified_profile_context=_dto("learn_and_use"),
+                private_companion_namespace_context=namespace,
+            ),
+        )
+        self.assertTrue(captured["ok"])
+        first.close()
+
+        reopened = MemoryStore(path)
+        reopened.initialize()
+        self.addCleanup(reopened.close)
+        summary = await PortraitService(reopened, _Config()).read_summary(
+            _request("private", namespace)
+        )
+        self.assertTrue(summary["ok"])
+        self.assertIn("烤肉", str(summary["items"]))
+
+    def test_invalid_or_wrong_identity_namespace_fails_closed(self) -> None:
+        valid = _namespace(persona="persona-a")
+        exact = portrait_namespace_decision(
+            valid, person_id=PERSON_ID, legacy_scope="private", purpose="profile_read"
+        )
+        self.assertTrue(exact["ok"])
+        self.assertTrue(str(exact["source_scope"]).startswith("private@"))
+        self.assertNotIn(PERSON_ID, str(exact["source_scope"]))
+        wrong = dict(valid)
+        wrong["identity_id"] = "person_" + "9" * 24
+        self.assertEqual(
+            "portrait_namespace_mismatch",
+            portrait_namespace_decision(
+                wrong, person_id=PERSON_ID, legacy_scope="private", purpose="profile_read"
+            )["code"],
+        )
+        malformed = dict(valid)
+        malformed.pop("migration_epoch")
+        self.assertEqual(
+            "portrait_namespace_invalid",
+            portrait_namespace_decision(
+                malformed, person_id=PERSON_ID, legacy_scope="private", purpose="profile_read"
+            )["code"],
+        )
+        self.assertEqual(
+            "portrait_namespace_invalid",
+            portrait_namespace_decision(
+                None,
+                person_id=PERSON_ID,
+                legacy_scope="private",
+                purpose="profile_read",
+                namespace_present=True,
+            )["code"],
+        )
+
+    def test_missing_namespace_keeps_explicit_legacy_compatibility_only(self) -> None:
+        decision = portrait_namespace_decision(
+            None,
+            person_id=PERSON_ID,
+            legacy_scope="group:onebot:group-a",
+            purpose="profile_read",
+        )
+        self.assertEqual("legacy", decision["state"])
+        self.assertEqual("group:onebot:group-a", decision["source_scope"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req041_scoped_bridge.py
+++ b/tests/test_req041_scoped_bridge.py
@@ -277,6 +277,35 @@ class ScopedBridgeTests(unittest.TestCase):
         )
         self.assertEqual({}, read["record"]["payload"]["content"])
 
+    def test_bridge_exposes_atomic_persona_scope_erase(self) -> None:
+        self._bind()
+        private = _context(persona_id="persona-a")
+        global_rules = _context(
+            kind="persona_global", identity="", group="", persona_id="persona-a",
+        )
+        self.assertTrue(self.bridge.upsert_scoped_record(
+            self.capability, private, record_kind="memory", record_id="req041-private", revision=1,
+            payload=build_scoped_domain_payload(
+                domain="memory", source_kind="private", content={"marker": "private"}, source_revision=1,
+            ), event_id="persona-erase-write-1",
+        )["ok"])
+        self.assertTrue(self.bridge.upsert_scoped_record(
+            self.capability, global_rules, record_kind="rule", record_id="req041-global", revision=1,
+            payload=build_scoped_domain_payload(
+                domain="learning", source_kind="persona_global", content={"rules": ["safe"]},
+                source_revision=1, approval_state="approved", approved_by="administrator",
+            ), event_id="persona-erase-write-2",
+        )["ok"])
+        result = self.bridge.erase_scoped_persona_scopes(
+            self.capability, global_rules, operation_id="persona-erase-1", reason_code="persona_reset",
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(2, result["count"])
+        read = self.bridge.read_scoped_record(
+            self.capability, private, record_kind="memory", record_id="req041-private",
+        )
+        self.assertEqual({}, read["record"]["payload"]["content"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_req041_scoped_bridge.py
+++ b/tests/test_req041_scoped_bridge.py
@@ -252,6 +252,31 @@ class ScopedBridgeTests(unittest.TestCase):
             self.capability, shared, record_kind="memory", record_id="req041-shared-memory",
         )["state"])
 
+    def test_bridge_exposes_atomic_group_scope_erase(self) -> None:
+        self._bind()
+        shared = _context(kind="group_shared", identity="", group="group-a")
+        member = _context(kind="group_member", group="group-a")
+        for index, (context, record_id, source_kind) in enumerate((
+            (shared, "req041-shared-memory", "group_shared"),
+            (member, "req041-member-memory", "group_member"),
+        ), start=1):
+            self.assertTrue(self.bridge.upsert_scoped_record(
+                self.capability, context, record_kind="memory", record_id=record_id, revision=1,
+                payload=build_scoped_domain_payload(
+                    domain="memory", source_kind=source_kind,
+                    content={"marker": record_id}, source_revision=1,
+                ), event_id=f"group-erase-write-{index}",
+            )["ok"])
+        result = self.bridge.erase_scoped_group_scopes(
+            self.capability, shared, operation_id="group-erase-1", reason_code="group_reset",
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(2, result["count"])
+        read = self.bridge.read_scoped_record(
+            self.capability, member, record_kind="memory", record_id="req041-member-memory",
+        )
+        self.assertEqual({}, read["record"]["payload"]["content"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_req041_scoped_bridge.py
+++ b/tests/test_req041_scoped_bridge.py
@@ -81,6 +81,63 @@ class ScopedBridgeTests(unittest.TestCase):
         self.assertTrue(ready["available"])
         self.assertEqual([], validate_namespace_capability(ready))
 
+    def test_all_scoped_methods_reject_before_epoch_binding(self) -> None:
+        private = _context()
+        group = _context(kind="group_shared", identity="", group="group-a")
+        persona = _context(kind="persona_global", identity="")
+        calls = (
+            lambda: self.bridge.read_scoped_record(
+                self.capability, private, record_kind="memory", record_id="x"
+            ),
+            lambda: self.bridge.list_scoped_records(
+                self.capability, private, record_kind="memory"
+            ),
+            lambda: self.bridge.upsert_scoped_record(
+                self.capability, private, record_kind="memory", record_id="x", revision=1,
+                payload={"value": "must-not-write"}, event_id="prebind-write",
+            ),
+            lambda: self.bridge.tombstone_scoped_record(
+                self.capability, private, record_kind="memory", record_id="x", revision=1,
+                event_id="prebind-delete",
+            ),
+            lambda: self.bridge.tombstone_scoped_namespace(
+                self.capability, private, operation_id="prebind-namespace", reason_code="test"
+            ),
+            lambda: self.bridge.tombstone_scoped_identity_scopes(
+                self.capability, private, operation_id="prebind-identity", reason_code="test"
+            ),
+            lambda: self.bridge.erase_scoped_group_scopes(
+                self.capability, group, operation_id="prebind-group", reason_code="test"
+            ),
+            lambda: self.bridge.erase_scoped_persona_scopes(
+                self.capability, persona, operation_id="prebind-persona", reason_code="test"
+            ),
+        )
+        for call in calls:
+            with self.subTest(call=call):
+                self.assertEqual("namespace_scoped_api_not_bound", call()["code"])
+        self.assertIsNone(self.store.read(
+            NamespaceContext(**{key: value for key, value in private.items() if not key.startswith("contract_")}),
+            record_kind="memory", record_id="x",
+        ))
+
+    def test_deactivate_revokes_old_capability_and_probe_immediately(self) -> None:
+        self._bind()
+        self.assertTrue(self.bridge.bridge_lifecycle_status()["active"])
+        self.bridge.deactivate()
+        self.assertFalse(self.bridge.bridge_lifecycle_status()["active"])
+        namespace_probe = self.bridge.probe_namespace_context_capabilities()
+        self.assertFalse(namespace_probe["available"])
+        self.assertEqual("bridge_inactive", namespace_probe["error_code"])
+        personal_probe = self.bridge.probe_bot_personal_memory_capabilities()
+        self.assertFalse(personal_probe["available"])
+        self.assertIn("bridge_inactive", personal_probe["warnings"])
+        denied = self.bridge.read_scoped_record(
+            self.capability, _context(), record_kind="memory", record_id="x"
+        )
+        self.assertEqual("bridge_inactive", denied["code"])
+        self.assertIsNone(self.bridge.register_private_companion(self.companion))
+
     def test_private_group_and_identity_sentinels_are_isolated_through_bridge(self) -> None:
         self._bind()
         contexts = (
@@ -154,6 +211,11 @@ class ScopedBridgeTests(unittest.TestCase):
         reopened_bridge = MemoryCompanionBridge(reopened_service)
         reopened_capability = reopened_bridge.register_private_companion(self.companion)
         self.assertTrue(reopened_bridge.probe_namespace_context_capabilities()["available"])
+        current = reopened_bridge.bind_namespace_migration_epoch(
+            reopened_capability, operation_id="bind-reload", expected_previous_epoch="",
+            migration_epoch=EPOCH, policy_version=POLICY,
+        )
+        self.assertEqual("current", current["code"])
         failed = reopened_bridge.bind_namespace_migration_epoch(
             reopened_capability, operation_id="rotate-bad", expected_previous_epoch="wrong",
             migration_epoch="req041-20260811-001", policy_version="req041-v2",

--- a/tests/test_req041_scoped_bridge.py
+++ b/tests/test_req041_scoped_bridge.py
@@ -8,6 +8,7 @@ import unittest
 from core.bridge import MemoryCompanionBridge
 from core.namespace import NamespaceContext
 from core.namespace_capability import validate_namespace_capability
+from core.scoped_domain_contract import build_scoped_domain_payload
 from core.scoped_store import ScopedStore
 
 
@@ -201,6 +202,25 @@ class ScopedBridgeTests(unittest.TestCase):
                 self.capability, context, record_kind="profile_fact", record_id="nickname"
             )["code"],
         )
+
+    def test_bridge_exposes_atomic_namespace_tombstone(self) -> None:
+        self._bind()
+        context = _context()
+        written = self.bridge.upsert_scoped_record(
+            self.capability, context, record_kind="memory", record_id="req041-private-memory-a",
+            revision=1, payload=build_scoped_domain_payload(
+                domain="memory", source_kind="private", content={"value": "a"}, source_revision=1,
+            ), event_id="write-a",
+        )
+        self.assertTrue(written["ok"])
+        result = self.bridge.tombstone_scoped_namespace(
+            self.capability, context, operation_id="archive-1", reason_code="person_archive",
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(1, result["count"])
+        self.assertEqual("not_found", self.bridge.read_scoped_record(
+            self.capability, context, record_kind="memory", record_id="req041-private-memory-a"
+        )["code"])
 
 
 if __name__ == "__main__":

--- a/tests/test_req041_scoped_bridge.py
+++ b/tests/test_req041_scoped_bridge.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+import unittest
+
+from core.bridge import MemoryCompanionBridge
+from core.namespace import NamespaceContext
+from core.namespace_capability import validate_namespace_capability
+from core.scoped_store import ScopedStore
+
+
+EPOCH = "req041-20260810-001"
+POLICY = "req041-v1"
+
+
+def _context(*, kind: str = "private", identity: str = "person-a", group: str = "", **changes: str):
+    values = {
+        "kind": kind,
+        "identity_id": identity,
+        "group_id": group,
+        "assurance": "verified",
+        "profile_status": "active",
+        "policy_version": POLICY,
+        "migration_epoch": EPOCH,
+    }
+    values.update(changes)
+    return NamespaceContext(**values).to_dict()
+
+
+class ScopedBridgeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "scoped.sqlite3"
+        self.store = ScopedStore(self.path, clock=lambda: 100.0)
+        self.companion = object()
+        self.context = SimpleNamespace(
+            get_all_stars=lambda: [
+                SimpleNamespace(
+                    star_cls=self.companion,
+                    root_dir_name="astrbot_plugin_private_companion",
+                    name="PrivateCompanion",
+                    activated=True,
+                )
+            ]
+        )
+        self.service = SimpleNamespace(scoped_store=self.store, context=self.context)
+        self.bridge = MemoryCompanionBridge(self.service)
+        self.capability = self.bridge.register_private_companion(self.companion)
+        self.assertIsNotNone(self.capability)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _bind(self, **changes: str):
+        values = {
+            "operation_id": "bind-1",
+            "expected_previous_epoch": "",
+            "migration_epoch": EPOCH,
+            "policy_version": POLICY,
+        }
+        values.update(changes)
+        return self.bridge.bind_namespace_migration_epoch(self.capability, **values)
+
+    def test_probe_is_unavailable_before_binding_and_ready_after(self) -> None:
+        before = self.bridge.probe_namespace_context_capabilities()
+        self.assertFalse(before["available"])
+        self.assertEqual("namespace_scoped_api_not_bound", before["error_code"])
+        self.assertEqual([], validate_namespace_capability(before, require_available=False))
+        denied = self.bridge.bind_namespace_migration_epoch(
+            object(), operation_id="bad", expected_previous_epoch="",
+            migration_epoch=EPOCH, policy_version=POLICY,
+        )
+        self.assertEqual("producer_capability_required", denied["code"])
+        bound = self._bind()
+        self.assertTrue(bound["ok"])
+        self.assertEqual("bound", bound["code"])
+        ready = self.bridge.probe_namespace_context_capabilities()
+        self.assertTrue(ready["available"])
+        self.assertEqual([], validate_namespace_capability(ready))
+
+    def test_private_group_and_identity_sentinels_are_isolated_through_bridge(self) -> None:
+        self._bind()
+        contexts = (
+            (_context(), "private"),
+            (_context(kind="group_member", group="group-a"), "group-a-person-a"),
+            (_context(kind="group_member", group="group-b"), "group-b-person-a"),
+            (_context(kind="group_member", identity="person-b", group="group-a"), "group-a-person-b"),
+        )
+        for index, (context, marker) in enumerate(contexts, start=1):
+            result = self.bridge.upsert_scoped_record(
+                self.capability, context, record_kind="memory", record_id="same-id", revision=1,
+                payload={"marker": marker}, event_id=f"write-{index}",
+            )
+            self.assertTrue(result["ok"])
+        observed = []
+        for context, _marker in contexts:
+            result = self.bridge.read_scoped_record(
+                self.capability, context, record_kind="memory", record_id="same-id"
+            )
+            observed.append(result["record"]["payload"]["marker"])
+        self.assertEqual([marker for _context_value, marker in contexts], observed)
+
+    def test_missing_context_pending_stale_epoch_and_stale_policy_fail_closed(self) -> None:
+        self._bind()
+        missing = _context()
+        missing.pop("group_id")
+        self.assertEqual(
+            "namespace_context_fields_invalid",
+            self.bridge.read_scoped_record(
+                self.capability, missing, record_kind="memory", record_id="x"
+            )["code"],
+        )
+        pending = _context(kind="pending", assurance="unverified")
+        self.assertEqual(
+            "namespace_pending_denied",
+            self.bridge.read_scoped_record(
+                self.capability, pending, record_kind="memory", record_id="x"
+            )["code"],
+        )
+        stale_epoch = _context(migration_epoch="old-epoch")
+        stale_policy = _context(policy_version="old-policy")
+        self.assertEqual(
+            "scoped_migration_epoch_stale",
+            self.bridge.read_scoped_record(
+                self.capability, stale_epoch, record_kind="memory", record_id="x"
+            )["code"],
+        )
+        self.assertEqual(
+            "scoped_policy_version_stale",
+            self.bridge.read_scoped_record(
+                self.capability, stale_policy, record_kind="memory", record_id="x"
+            )["code"],
+        )
+
+    def test_epoch_binding_persists_and_rotation_is_compare_and_swap(self) -> None:
+        self._bind()
+        self.bridge.upsert_scoped_record(
+            self.capability, _context(), record_kind="memory", record_id="m1", revision=1,
+            payload={"value": "stable"}, event_id="write-1",
+        )
+        reopened_store = ScopedStore(self.path, clock=lambda: 200.0)
+        reopened_service = SimpleNamespace(scoped_store=reopened_store, context=self.context)
+        reopened_bridge = MemoryCompanionBridge(reopened_service)
+        reopened_capability = reopened_bridge.register_private_companion(self.companion)
+        self.assertTrue(reopened_bridge.probe_namespace_context_capabilities()["available"])
+        failed = reopened_bridge.bind_namespace_migration_epoch(
+            reopened_capability, operation_id="rotate-bad", expected_previous_epoch="wrong",
+            migration_epoch="req041-20260811-001", policy_version="req041-v2",
+        )
+        self.assertEqual("scoped_epoch_compare_and_swap_failed", failed["code"])
+        rotated = reopened_bridge.bind_namespace_migration_epoch(
+            reopened_capability, operation_id="rotate-good", expected_previous_epoch=EPOCH,
+            migration_epoch="req041-20260811-001", policy_version="req041-v2",
+        )
+        self.assertEqual("rotated", rotated["code"])
+        new_context = _context(migration_epoch="req041-20260811-001", policy_version="req041-v2")
+        read = reopened_bridge.read_scoped_record(
+            reopened_capability, new_context, record_kind="memory", record_id="m1"
+        )
+        self.assertEqual("stable", read["record"]["payload"]["value"])
+        stale = reopened_bridge.read_scoped_record(
+            reopened_capability, _context(), record_kind="memory", record_id="m1"
+        )
+        self.assertEqual("scoped_migration_epoch_stale", stale["code"])
+
+    def test_idempotency_conflict_list_and_tombstone_are_preserved(self) -> None:
+        self._bind()
+        context = _context()
+        create = dict(
+            record_kind="profile_fact", record_id="nickname", revision=1,
+            payload={"value": "A"}, event_id="write-1",
+        )
+        self.assertEqual("created", self.bridge.upsert_scoped_record(self.capability, context, **create)["code"])
+        self.assertEqual("duplicate", self.bridge.upsert_scoped_record(self.capability, context, **create)["code"])
+        conflict = self.bridge.upsert_scoped_record(
+            self.capability, context, **{**create, "payload": {"value": "B"}}
+        )
+        self.assertEqual("scoped_event_conflict", conflict["code"])
+        listed = self.bridge.list_scoped_records(
+            self.capability, context, record_kind="profile_fact", limit=10
+        )
+        self.assertEqual(["nickname"], [item["record_id"] for item in listed["records"]])
+        deleted = self.bridge.tombstone_scoped_record(
+            self.capability, context, record_kind="profile_fact", record_id="nickname",
+            revision=2, event_id="delete-1",
+        )
+        self.assertEqual("tombstoned", deleted["code"])
+        self.assertEqual(
+            "not_found",
+            self.bridge.read_scoped_record(
+                self.capability, context, record_kind="profile_fact", record_id="nickname"
+            )["code"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req041_scoped_bridge.py
+++ b/tests/test_req041_scoped_bridge.py
@@ -222,6 +222,36 @@ class ScopedBridgeTests(unittest.TestCase):
             self.capability, context, record_kind="memory", record_id="req041-private-memory-a"
         )["code"])
 
+    def test_bridge_exposes_atomic_identity_scope_tombstone(self) -> None:
+        self._bind()
+        private = _context()
+        member = _context(kind="group_member", group="group-a")
+        shared = _context(kind="group_shared", identity="", group="group-a")
+        for index, (context, record_id, source_kind) in enumerate((
+            (private, "req041-private-memory", "private"),
+            (member, "req041-member-memory", "group_member"),
+            (shared, "req041-shared-memory", "group_shared"),
+        ), start=1):
+            written = self.bridge.upsert_scoped_record(
+                self.capability, context, record_kind="memory", record_id=record_id, revision=1,
+                payload=build_scoped_domain_payload(
+                    domain="memory", source_kind=source_kind,
+                    content={"marker": record_id}, source_revision=1,
+                ), event_id=f"archive-write-{index}",
+            )
+            self.assertTrue(written["ok"])
+        result = self.bridge.tombstone_scoped_identity_scopes(
+            self.capability, private, operation_id="archive-person-1", reason_code="person_archive",
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(2, result["count"])
+        self.assertEqual("not_found", self.bridge.read_scoped_record(
+            self.capability, member, record_kind="memory", record_id="req041-member-memory",
+        )["code"])
+        self.assertEqual("ready", self.bridge.read_scoped_record(
+            self.capability, shared, record_kind="memory", record_id="req041-shared-memory",
+        )["state"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_req041_scoped_bridge.py
+++ b/tests/test_req041_scoped_bridge.py
@@ -112,6 +112,14 @@ class ScopedBridgeTests(unittest.TestCase):
                 self.capability, missing, record_kind="memory", record_id="x"
             )["code"],
         )
+        missing_persona = _context()
+        missing_persona.pop("persona_id")
+        self.assertEqual(
+            "namespace_context_fields_invalid",
+            self.bridge.read_scoped_record(
+                self.capability, missing_persona, record_kind="memory", record_id="x"
+            )["code"],
+        )
         pending = _context(kind="pending", assurance="unverified")
         self.assertEqual(
             "namespace_pending_denied",

--- a/tests/test_req041_scoped_domain_contract.py
+++ b/tests/test_req041_scoped_domain_contract.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import unittest
+
+from core.namespace import NamespaceContext
+from core.scoped_domain_contract import (
+    ScopedDomainContractError,
+    build_scoped_domain_payload,
+    validate_scoped_domain_payload,
+)
+
+
+def _context(kind: str, *, persona: str = "default", identity: str = "person-a", group: str = "") -> NamespaceContext:
+    return NamespaceContext(
+        kind=kind, persona_id=persona, identity_id=identity, group_id=group,
+        assurance="verified", profile_status="active", policy_version="req041-v1",
+        migration_epoch="epoch-1",
+    )
+
+
+class ScopedDomainContractTests(unittest.TestCase):
+    def test_profile_memory_and_learning_match_namespace_and_kind(self) -> None:
+        profile = build_scoped_domain_payload(domain="profile", source_kind="private", content={"nickname": "A"})
+        validate_scoped_domain_payload(_context("private"), "profile_fact", profile)
+        memory = build_scoped_domain_payload(domain="memory", source_kind="group_shared", content={"topic": "x"})
+        validate_scoped_domain_payload(_context("group_shared", identity="", group="g"), "memory", memory)
+        rule = build_scoped_domain_payload(
+            domain="learning", source_kind="private", content={"style": "x"}, approval_state="pending"
+        )
+        validate_scoped_domain_payload(_context("private"), "rule", rule)
+
+    def test_cross_domain_and_privilege_fields_are_denied(self) -> None:
+        payload = build_scoped_domain_payload(domain="memory", source_kind="private", content={"value": "x"})
+        with self.assertRaisesRegex(ScopedDomainContractError, "record_kind_mismatch"):
+            validate_scoped_domain_payload(_context("private"), "profile_fact", payload)
+        with self.assertRaisesRegex(ScopedDomainContractError, "privilege_field_denied"):
+            build_scoped_domain_payload(
+                domain="profile", source_kind="private", content={"relationship_role": "owner"}
+            )
+
+    def test_persona_global_rule_requires_explicit_admin_approval(self) -> None:
+        pending = build_scoped_domain_payload(
+            domain="learning", source_kind="persona_global", content={"style": "x"}, approval_state="pending"
+        )
+        with self.assertRaisesRegex(ScopedDomainContractError, "persona_global_rule_approval_required"):
+            validate_scoped_domain_payload(_context("persona_global", identity=""), "rule", pending)
+        approved = build_scoped_domain_payload(
+            domain="learning", source_kind="persona_global", content={"style": "x"},
+            approval_state="approved", approved_by="administrator",
+        )
+        validate_scoped_domain_payload(_context("persona_global", identity=""), "rule", approved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req041_scoped_domain_contract.py
+++ b/tests/test_req041_scoped_domain_contract.py
@@ -50,6 +50,19 @@ class ScopedDomainContractTests(unittest.TestCase):
         )
         validate_scoped_domain_payload(_context("persona_global", identity=""), "rule", approved)
 
+    def test_rejected_and_revoked_rules_remain_auditable_but_require_admin_for_global(self) -> None:
+        for state in ("rejected", "revoked"):
+            private = build_scoped_domain_payload(
+                domain="learning", source_kind="private", content={"rule_id": "opaque"},
+                source_revision=3, approval_state=state, approved_by="administrator",
+            )
+            validate_scoped_domain_payload(_context("private"), "rule", private)
+            global_rule = build_scoped_domain_payload(
+                domain="learning", source_kind="persona_global", content={"rule_id": "opaque"},
+                source_revision=3, approval_state=state, approved_by="administrator",
+            )
+            validate_scoped_domain_payload(_context("persona_global", identity=""), "rule", global_rule)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_req041_scoped_retrieval.py
+++ b/tests/test_req041_scoped_retrieval.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 from core.namespace import NamespaceContext
+from core.scoped_domain_contract import build_scoped_domain_payload
 from core.scoped_store import ScopedRecordConflict, ScopedRevisionGap, ScopedStore, ScopedStoreError
 
 
@@ -124,6 +125,48 @@ class ScopedStoreTests(unittest.TestCase):
             "created",
             self.store.upsert(shared, record_kind="memory", record_id="group-topic", revision=1, payload={"value": "topic"}, event_id="event-2"),
         )
+
+    def test_namespace_tombstone_is_atomic_idempotent_and_prevents_resurrection(self) -> None:
+        self.store.upsert(
+            self.private, record_kind="memory", record_id="req041-private-memory-a", revision=1,
+            payload=build_scoped_domain_payload(
+                domain="memory", source_kind="private", content={"value": "a"}, source_revision=1,
+            ), event_id="write-a",
+        )
+        self.store.upsert(
+            self.private, record_kind="rule", record_id="req041-private-rule-a", revision=1,
+            payload=build_scoped_domain_payload(
+                domain="learning", source_kind="private", content={"value": "rule"},
+                source_revision=1, approval_state="approved", approved_by="user",
+            ), event_id="write-rule",
+        )
+        self.store.upsert(
+            self.private, record_kind="memory", record_id="legacy-unmanaged", revision=1,
+            payload={"value": "keep"}, event_id="write-legacy",
+        )
+        result = self.store.tombstone_namespace(
+            self.private, operation_id="archive-1", reason_code="person_archive",
+        )
+        self.assertEqual(2, result["count"])
+        self.assertEqual(result, self.store.tombstone_namespace(
+            self.private, operation_id="archive-1", reason_code="person_archive",
+        ))
+        self.assertIsNone(self.store.read(self.private, record_kind="memory", record_id="req041-private-memory-a"))
+        self.assertEqual("keep", self.store.read(
+            self.private, record_kind="memory", record_id="legacy-unmanaged"
+        )["payload"]["value"])
+        with self.assertRaisesRegex(ScopedRecordConflict, "scoped_record_tombstoned"):
+            self.store.upsert(
+                self.private, record_kind="memory", record_id="req041-private-memory-a", revision=3,
+                payload=build_scoped_domain_payload(
+                    domain="memory", source_kind="private", content={"value": "resurrect"},
+                    source_revision=3,
+                ), event_id="resurrect-a",
+            )
+        with self.assertRaisesRegex(ScopedRecordConflict, "scoped_namespace_operation_conflict"):
+            self.store.tombstone_namespace(
+                self.private, operation_id="archive-1", reason_code="different_reason",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_req041_scoped_retrieval.py
+++ b/tests/test_req041_scoped_retrieval.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from core.namespace import NamespaceContext
+from core.scoped_store import ScopedRecordConflict, ScopedRevisionGap, ScopedStore, ScopedStoreError
+
+
+def _context(kind: str, *, identity: str = "person-a", group: str = "") -> NamespaceContext:
+    return NamespaceContext(
+        kind=kind,
+        identity_id=identity,
+        group_id=group,
+        assurance="verified",
+        profile_status="active",
+        policy_version="req041-v1",
+        migration_epoch="shadow-20260810",
+    )
+
+
+class ScopedStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.store = ScopedStore(Path(self.tmp.name) / "scoped.sqlite3", clock=lambda: 100.0)
+        self.private = _context("private")
+        self.group_a = _context("group_member", group="group-a")
+        self.group_b = _context("group_member", group="group-b")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_private_group_a_and_group_b_are_physically_isolated(self) -> None:
+        contexts = ((self.private, "private-sentinel"), (self.group_a, "group-a-sentinel"), (self.group_b, "group-b-sentinel"))
+        for index, (context, marker) in enumerate(contexts, start=1):
+            self.assertEqual(
+                "created",
+                self.store.upsert(
+                    context,
+                    record_kind="memory",
+                    record_id="same-record-id",
+                    revision=1,
+                    payload={"marker": marker},
+                    event_id=f"event-{index}",
+                ),
+            )
+        self.assertEqual("private-sentinel", self.store.read(self.private, record_kind="memory", record_id="same-record-id")["payload"]["marker"])
+        self.assertEqual("group-a-sentinel", self.store.read(self.group_a, record_kind="memory", record_id="same-record-id")["payload"]["marker"])
+        self.assertEqual("group-b-sentinel", self.store.read(self.group_b, record_kind="memory", record_id="same-record-id")["payload"]["marker"])
+
+    def test_another_identity_in_same_group_is_isolated(self) -> None:
+        other = _context("group_member", identity="person-b", group="group-a")
+        self.store.upsert(self.group_a, record_kind="profile_fact", record_id="nickname", revision=1, payload={"value": "A"}, event_id="a-1")
+        self.assertIsNone(self.store.read(other, record_kind="profile_fact", record_id="nickname"))
+
+    def test_policy_and_epoch_changes_do_not_create_a_second_owner_namespace(self) -> None:
+        self.store.upsert(
+            self.private, record_kind="memory", record_id="m1", revision=1,
+            payload={"value": "stable"}, event_id="event-1",
+        )
+        next_epoch = NamespaceContext(
+            kind="private", identity_id="person-a", group_id="", assurance="explicit_linked",
+            profile_status="active", policy_version="req041-v2", migration_epoch="shadow-20260811",
+        )
+        self.assertEqual("stable", self.store.read(next_epoch, record_kind="memory", record_id="m1")["payload"]["value"])
+
+    def test_pending_unverified_and_missing_context_fail_closed(self) -> None:
+        pending = _context("pending")
+        unverified = NamespaceContext(**{**self.private.__dict__, "assurance": "unverified"}) if hasattr(self.private, "__dict__") else NamespaceContext(
+            kind="private", identity_id="person-a", group_id="", assurance="unverified", profile_status="active",
+            policy_version="req041-v1", migration_epoch="shadow-20260810",
+        )
+        with self.assertRaisesRegex(ScopedStoreError, "namespace_pending_denied"):
+            self.store.read(pending, record_kind="memory", record_id="x")
+        with self.assertRaisesRegex(ScopedStoreError, "identity_assurance_insufficient"):
+            self.store.read(unverified, record_kind="memory", record_id="x")
+        with self.assertRaisesRegex(ScopedStoreError, "namespace_context_missing"):
+            self.store.read(None, record_kind="memory", record_id="x")  # type: ignore[arg-type]
+
+    def test_revision_and_event_id_are_idempotent_and_conflict_safe(self) -> None:
+        create = dict(record_kind="memory", record_id="m1", revision=1, payload={"value": 1}, event_id="event-1")
+        self.assertEqual("created", self.store.upsert(self.private, **create))
+        self.assertEqual("duplicate", self.store.upsert(self.private, **create))
+        with self.assertRaises(ScopedRecordConflict):
+            self.store.upsert(self.private, **{**create, "payload": {"value": 2}})
+        with self.assertRaises(ScopedRevisionGap):
+            self.store.upsert(self.private, record_kind="memory", record_id="m1", revision=3, payload={"value": 3}, event_id="event-3")
+        self.assertEqual(
+            "updated",
+            self.store.upsert(self.private, record_kind="memory", record_id="m1", revision=2, payload={"value": 2}, event_id="event-2"),
+        )
+
+    def test_tombstone_is_next_revision_and_prevents_resurrection(self) -> None:
+        self.store.upsert(self.private, record_kind="memory", record_id="m1", revision=1, payload={"value": 1}, event_id="event-1")
+        self.assertEqual("tombstoned", self.store.tombstone(self.private, record_kind="memory", record_id="m1", revision=2, event_id="delete-1"))
+        self.assertIsNone(self.store.read(self.private, record_kind="memory", record_id="m1"))
+        self.assertEqual("duplicate", self.store.tombstone(self.private, record_kind="memory", record_id="m1", revision=2, event_id="delete-1"))
+        with self.assertRaisesRegex(ScopedRecordConflict, "scoped_record_tombstoned"):
+            self.store.upsert(self.private, record_kind="memory", record_id="m1", revision=3, payload={"value": 3}, event_id="event-3")
+
+    def test_group_shared_cannot_store_subject_profile(self) -> None:
+        shared = _context("group_shared", identity="", group="group-a")
+        with self.assertRaisesRegex(ScopedStoreError, "group_shared_subject_access_denied"):
+            self.store.upsert(shared, record_kind="profile_fact", record_id="nickname", revision=1, payload={"value": "x"}, event_id="event-1")
+        self.assertEqual(
+            "created",
+            self.store.upsert(shared, record_kind="memory", record_id="group-topic", revision=1, payload={"value": "topic"}, event_id="event-2"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req041_scoped_retrieval.py
+++ b/tests/test_req041_scoped_retrieval.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from contextlib import closing
 from pathlib import Path
+import sqlite3
 import tempfile
 import unittest
 
@@ -116,6 +118,12 @@ class ScopedStoreTests(unittest.TestCase):
         self.assertEqual("duplicate", self.store.tombstone(self.private, record_kind="memory", record_id="m1", revision=2, event_id="delete-1"))
         with self.assertRaisesRegex(ScopedRecordConflict, "scoped_record_tombstoned"):
             self.store.upsert(self.private, record_kind="memory", record_id="m1", revision=3, payload={"value": 3}, event_id="event-3")
+        with closing(sqlite3.connect(self.store.path)) as connection:
+            payload_json, payload_hash = connection.execute(
+                "SELECT payload_json,payload_hash FROM scoped_records WHERE record_id='m1'"
+            ).fetchone()
+        self.assertEqual("{}", payload_json)
+        self.assertEqual(64, len(payload_hash))
 
     def test_group_shared_cannot_store_subject_profile(self) -> None:
         shared = _context("group_shared", identity="", group="group-a")
@@ -196,6 +204,11 @@ class ScopedStoreTests(unittest.TestCase):
         ))
         for context, record_id, _source_kind in contexts[:3]:
             self.assertIsNone(self.store.read(context, record_kind="memory", record_id=record_id))
+        with closing(sqlite3.connect(self.store.path)) as connection:
+            erased = connection.execute(
+                "SELECT payload_json FROM scoped_records WHERE deleted=1 ORDER BY record_id"
+            ).fetchall()
+        self.assertEqual([("{}",), ("{}",), ("{}",)], erased)
         self.assertIsNotNone(self.store.read(shared, record_kind="memory", record_id="req041-group-shared"))
         self.assertIsNotNone(self.store.read(other, record_kind="memory", record_id="req041-other-private"))
         with self.assertRaisesRegex(ScopedStoreError, "scoped_identity_archive_context_invalid"):

--- a/tests/test_req041_scoped_retrieval.py
+++ b/tests/test_req041_scoped_retrieval.py
@@ -168,6 +168,45 @@ class ScopedStoreTests(unittest.TestCase):
                 self.private, operation_id="archive-1", reason_code="different_reason",
             )
 
+    def test_identity_archive_tombstones_private_and_all_member_scopes_only(self) -> None:
+        shared = _context("group_shared", identity="", group="group-a")
+        other = _context("private", identity="person-b")
+        contexts = (
+            (self.private, "req041-private-memory", "private"),
+            (self.group_a, "req041-group-a-member", "group_member"),
+            (self.group_b, "req041-group-b-member", "group_member"),
+            (shared, "req041-group-shared", "group_shared"),
+            (other, "req041-other-private", "private"),
+        )
+        for index, (context, record_id, source_kind) in enumerate(contexts, start=1):
+            self.store.upsert(
+                context, record_kind="memory", record_id=record_id, revision=1,
+                payload=build_scoped_domain_payload(
+                    domain="memory", source_kind=source_kind,
+                    content={"marker": record_id}, source_revision=1,
+                ), event_id=f"identity-archive-write-{index}",
+            )
+        result = self.store.tombstone_identity_scopes(
+            self.private, operation_id="person-archive-1", reason_code="person_archive",
+        )
+        self.assertEqual(3, result["count"])
+        self.assertEqual(3, result["namespace_count"])
+        self.assertEqual(result, self.store.tombstone_identity_scopes(
+            self.private, operation_id="person-archive-1", reason_code="person_archive",
+        ))
+        for context, record_id, _source_kind in contexts[:3]:
+            self.assertIsNone(self.store.read(context, record_kind="memory", record_id=record_id))
+        self.assertIsNotNone(self.store.read(shared, record_kind="memory", record_id="req041-group-shared"))
+        self.assertIsNotNone(self.store.read(other, record_kind="memory", record_id="req041-other-private"))
+        with self.assertRaisesRegex(ScopedStoreError, "scoped_identity_archive_context_invalid"):
+            self.store.tombstone_identity_scopes(
+                self.group_a, operation_id="bad-member-context", reason_code="person_archive",
+            )
+        with self.assertRaisesRegex(ScopedRecordConflict, "scoped_namespace_operation_conflict"):
+            self.store.tombstone_identity_scopes(
+                self.private, operation_id="person-archive-1", reason_code="different_reason",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_req041_scoped_retrieval.py
+++ b/tests/test_req041_scoped_retrieval.py
@@ -220,6 +220,55 @@ class ScopedStoreTests(unittest.TestCase):
                 self.private, operation_id="person-archive-1", reason_code="different_reason",
             )
 
+    def test_group_reset_erases_shared_and_all_members_but_allows_relearning(self) -> None:
+        shared_a = _context("group_shared", identity="", group="group-a")
+        member_a_other = _context("group_member", identity="person-b", group="group-a")
+        shared_b = _context("group_shared", identity="", group="group-b")
+        contexts = (
+            (shared_a, "req041-shared-a", "group_shared"),
+            (self.group_a, "req041-member-a", "group_member"),
+            (member_a_other, "req041-member-a-other", "group_member"),
+            (shared_b, "req041-shared-b", "group_shared"),
+            (self.private, "req041-private", "private"),
+        )
+        for index, (context, record_id, source_kind) in enumerate(contexts, start=1):
+            self.store.upsert(
+                context, record_kind="memory", record_id=record_id, revision=1,
+                payload=build_scoped_domain_payload(
+                    domain="memory", source_kind=source_kind,
+                    content={"sentinel": record_id}, source_revision=1,
+                ), event_id=f"group-reset-write-{index}",
+            )
+        result = self.store.erase_group_scopes(
+            shared_a, operation_id="group-reset-1", reason_code="group_reset",
+        )
+        self.assertEqual(3, result["count"])
+        self.assertEqual(3, result["namespace_count"])
+        for context, record_id, _source_kind in contexts[:3]:
+            record = self.store.read(context, record_kind="memory", record_id=record_id)
+            self.assertEqual({}, record["payload"]["content"])
+            self.assertEqual(2, record["revision"])
+        self.assertEqual("req041-shared-b", self.store.read(
+            shared_b, record_kind="memory", record_id="req041-shared-b"
+        )["payload"]["content"]["sentinel"])
+        self.assertEqual("req041-private", self.store.read(
+            self.private, record_kind="memory", record_id="req041-private"
+        )["payload"]["content"]["sentinel"])
+        self.assertEqual("updated", self.store.upsert(
+            self.group_a, record_kind="memory", record_id="req041-member-a", revision=3,
+            payload=build_scoped_domain_payload(
+                domain="memory", source_kind="group_member", content={"sentinel": "relearned"},
+                source_revision=3,
+            ), event_id="group-relearn",
+        ))
+        self.assertEqual("relearned", self.store.read(
+            self.group_a, record_kind="memory", record_id="req041-member-a"
+        )["payload"]["content"]["sentinel"])
+        with self.assertRaisesRegex(ScopedStoreError, "scoped_group_erase_context_invalid"):
+            self.store.erase_group_scopes(
+                self.group_a, operation_id="bad-group-reset", reason_code="group_reset",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_req041_scoped_retrieval.py
+++ b/tests/test_req041_scoped_retrieval.py
@@ -54,6 +54,23 @@ class ScopedStoreTests(unittest.TestCase):
         self.store.upsert(self.group_a, record_kind="profile_fact", record_id="nickname", revision=1, payload={"value": "A"}, event_id="a-1")
         self.assertIsNone(self.store.read(other, record_kind="profile_fact", record_id="nickname"))
 
+    def test_same_identity_and_group_are_isolated_between_personas(self) -> None:
+        other_persona = NamespaceContext(
+            kind="private", identity_id="person-a", group_id="", assurance="verified",
+            profile_status="active", policy_version="req041-v1", migration_epoch="shadow-20260810",
+            persona_id="persona-b",
+        )
+        self.store.upsert(
+            self.private, record_kind="memory", record_id="same-id", revision=1,
+            payload={"marker": "default"}, event_id="persona-default",
+        )
+        self.store.upsert(
+            other_persona, record_kind="memory", record_id="same-id", revision=1,
+            payload={"marker": "persona-b"}, event_id="persona-b",
+        )
+        self.assertEqual("default", self.store.read(self.private, record_kind="memory", record_id="same-id")["payload"]["marker"])
+        self.assertEqual("persona-b", self.store.read(other_persona, record_kind="memory", record_id="same-id")["payload"]["marker"])
+
     def test_policy_and_epoch_changes_do_not_create_a_second_owner_namespace(self) -> None:
         self.store.upsert(
             self.private, record_kind="memory", record_id="m1", revision=1,

--- a/tests/test_req041_scoped_retrieval.py
+++ b/tests/test_req041_scoped_retrieval.py
@@ -11,7 +11,9 @@ from core.scoped_domain_contract import build_scoped_domain_payload
 from core.scoped_store import ScopedRecordConflict, ScopedRevisionGap, ScopedStore, ScopedStoreError
 
 
-def _context(kind: str, *, identity: str = "person-a", group: str = "") -> NamespaceContext:
+def _context(
+    kind: str, *, identity: str = "person-a", group: str = "", persona: str = "default"
+) -> NamespaceContext:
     return NamespaceContext(
         kind=kind,
         identity_id=identity,
@@ -20,6 +22,7 @@ def _context(kind: str, *, identity: str = "person-a", group: str = "") -> Names
         profile_status="active",
         policy_version="req041-v1",
         migration_epoch="shadow-20260810",
+        persona_id=persona,
     )
 
 
@@ -267,6 +270,52 @@ class ScopedStoreTests(unittest.TestCase):
         with self.assertRaisesRegex(ScopedStoreError, "scoped_group_erase_context_invalid"):
             self.store.erase_group_scopes(
                 self.group_a, operation_id="bad-group-reset", reason_code="group_reset",
+            )
+
+    def test_persona_reset_erases_all_four_scoped_kinds_and_preserves_other_persona(self) -> None:
+        persona = "persona-a"
+        private = _context("private", persona=persona)
+        member = _context("group_member", group="group-a", persona=persona)
+        shared = _context("group_shared", identity="", group="group-a", persona=persona)
+        global_rules = _context("persona_global", identity="", persona=persona)
+        other = _context("private", persona="persona-b")
+        writes = (
+            (private, "memory", "req041-private", "memory", "private", "not_applicable", ""),
+            (member, "profile_fact", "req041-member", "profile", "group_member", "not_applicable", ""),
+            (shared, "memory", "req041-shared", "memory", "group_shared", "not_applicable", ""),
+            (global_rules, "rule", "req041-global", "learning", "persona_global", "approved", "administrator"),
+            (other, "memory", "req041-other", "memory", "private", "not_applicable", ""),
+        )
+        for index, (context, record_kind, record_id, domain, source, approval, approved_by) in enumerate(writes, start=1):
+            self.store.upsert(
+                context, record_kind=record_kind, record_id=record_id, revision=1,
+                payload=build_scoped_domain_payload(
+                    domain=domain, source_kind=source, content={"sentinel": record_id},
+                    source_revision=1, approval_state=approval, approved_by=approved_by,
+                ), event_id=f"persona-reset-write-{index}",
+            )
+        result = self.store.erase_persona_scopes(
+            global_rules, operation_id="persona-reset-1", reason_code="persona_reset",
+        )
+        self.assertEqual(4, result["count"])
+        self.assertEqual({"group_member", "group_shared", "persona_global", "private"}, set(result["namespace_kinds"]))
+        for context, record_kind, record_id, *_rest in writes[:4]:
+            record = self.store.read(context, record_kind=record_kind, record_id=record_id)
+            self.assertEqual({}, record["payload"]["content"])
+            self.assertEqual(2, record["revision"])
+        self.assertEqual("req041-other", self.store.read(
+            other, record_kind="memory", record_id="req041-other",
+        )["payload"]["content"]["sentinel"])
+        self.assertEqual("updated", self.store.upsert(
+            private, record_kind="memory", record_id="req041-private", revision=3,
+            payload=build_scoped_domain_payload(
+                domain="memory", source_kind="private", content={"sentinel": "relearned"},
+                source_revision=3,
+            ), event_id="persona-relearn",
+        ))
+        with self.assertRaisesRegex(ScopedStoreError, "scoped_persona_erase_context_invalid"):
+            self.store.erase_persona_scopes(
+                private, operation_id="bad-persona-reset", reason_code="persona_reset",
             )
 
 


### PR DESCRIPTION
# PR-A — Memory：严格命名空间与分域存储

> Draft PR：https://github.com/menglimi/astrbot_plugin_memory_companion/pull/8

> 本文可作为 GitHub PR 描述。建议先合并本 PR，再评审 Companion PR。

> 兼容矩阵详情已完整写入下文。Companion sender 跨仓缺口已在 `329c757` 修复；Memory 的 producer capability 门禁未放宽，old-new 与 old-old 保持相同的安全拒绝基线。

## PR 元数据

- 建议标题：`feat(req041): add strict namespaced memory and scoped migration storage`
- 仓库：`menglimi/astrbot_plugin_memory_companion`
- Base：`main` @ `67d8c1d5433d9e4c6006b0043110bc67cceaad64`
- Head：`codex/req041-unified-identity-isolated-context` @ `2b7525d28137260e0b8363602ac42d77fbb3b143`
- 版本元数据：`1.7.3`
- 规模：19 文件，+3,528 / -22，15 个提交
- 依赖：无必须先合并的 Companion 变更；本 PR 是 Companion PR-B 的存储合同前置。

## 摘要

本 PR 为 Memory 插件增加可验证的 namespace 合同、带 revision 的 scoped store、capability negotiation、画像分域和可恢复生命周期。它的目标不是在 Memory 中猜测“这个用户是谁”，而是要求调用方显式提供经授权的作用域，并在合同缺失、过期或不匹配时拒绝读写。

最终存储语义是：

- 同一人的私聊记忆使用 `person_private`；
- 同一人在某个群的局部资料使用 `group_member`；
- 群内共享语境使用 `group_shared`；
- Bot 人格级全局规则使用 `persona_global`；
- 任何一个域均不得默认回退到其他域。

## 背景与原问题

旧 Memory 接口主要以用户键和记录类型组织数据，无法从存储层证明一次读写属于私聊、某个群或人格全局。如果 Companion 只做身份统一而 Memory 仍使用模糊键，会引入更高风险的跨群、私群泄漏。

本 PR 在存储边界上解决以下问题：

1. 每次读写必须声明 namespace，不接受空作用域。
2. Companion 与 Memory 必须对 namespace 合同和能力版本达成一致。
3. 写入必须带 revision / epoch，可识别过期 bridge 与乱序写。
4. 画像和学习规则与普通记忆遵守同一分域语义。
5. archive、unlink、group reset、persona reset 必须有原子 tombstone 和恢复能力。

## 合同与数据模型

### NamespaceContext

所有新链路使用不可为空的 `NamespaceContext`，其约束包含：

- namespace kind；
- persona reference；
- person / group 作用域；
- identity assurance；
- policy version；
- migration epoch。

namespace 合同通过稳定指纹与 Companion 协商。指纹、版本或必需能力不匹配时，scoped bridge 不得开放新读写。

### Scoped record

新存储使用 namespace + domain + record type + idempotency key 生成稳定记录键，并保留：

- 单调 revision；
- migration epoch；
- 幂等键；
- 撤销/归档状态；
- 最小必要的审计元数据。

Bot Personal 记录 ID 合同与 Companion 对齐为 `domain | type | idempotency key` 的 SHA-256 确定性结果，避免同一事件在两个插件中产生不同 record ID。

## 主要变更

### 1. 严格 namespace 与能力协商

- `core/namespace.py`：namespace 数据类型、校验与合同指纹。
- `core/namespace_capability.py`：能力声明、无副作用 probe 和版本协商。
- `core/bridge.py`：只向通过合同验证的调用方暴露 scoped 操作。

### 2. Revisioned scoped store

- `core/scoped_store.py`：分域记录、幂等写、revision 比较、epoch 约束、tombstone。
- `core/store.py` / `core/service.py`：将新存储接入现有服务层，保留必要的旧路径兼容。
- `core/scoped_domain_contract.py`：固化 domain/type/idempotency 的跨插件约定。

### 3. 画像与检索隔离

- `core/portrait_namespace.py`：画像作用域和读取门禁。
- `core/portrait.py` / `core/portrait_service.py`：只在当前授权 namespace 中归纳和检索。
- `core/service.py`：生成阶段不会把另一个群或私聊的 payload 作为候选记忆。

### 4. 可恢复生命周期

- namespace tombstone 原子阻断后续读写；
- identity archive 原子归档相关作用域；
- group reset 仅清理目标群的 member/shared 域；
- persona reset 仅替换目标 persona 的 store；
- tombstone 后的 payload 可被安全擦除，不因旧 bridge 继续出现。

### 5. 审计保留

被撤销的学习规则保留 revoked 审计状态，但生成与检索必须排除 revoked 记录。这使“为何曾经学到/为何被撤销”可追溯，同时不让已撤销规则继续影响回复。

## 兼容性与迁移

- 本 PR 不要求用户手工重建记忆数据。
- 旧数据保留原样；新 scoped store 由 Companion 的迁移 coordinator/outbox 逐步写入。
- capability 不匹配时不会将旧 Memory 误认为已安全分域。
- 重复事件依靠幂等键和 revision 收敛；乱序旧修订不覆盖新修订。
- archive/reset 使用 tombstone 阻止已删数据被重放复活。

## 安全与隐私不变式

1. 空 namespace 直接拒绝，不默认回退。
2. `pending` / ambiguous identity 不得读取正式人物域。
3. 不同 group scope 不能互相检索。
4. `person_private` 不作为 `group_shared` 的候选源。
5. stale bridge、policy version 或 epoch 不匹配时拒绝新链路。
6. capability probe 不写数据。
7. 被 tombstone 或 revoked 的记录不参与生成。

## 性能与运维影响

- namespace 校验和 capability 协商为本地合同检查，不需要外部网络请求。
- scoped 检索在候选集进入上下文前缩小作用域，避免先全库检索再过滤。
- revision/tombstone 增加少量持久化元数据，换取可恢复和乱序安全。
- 实际线上延迟仍需在合并后按存储规模持续观测；本 PR 不声称无基线的固定 P95 目标。

## 验证证据

候选 HEAD `2b7525d28137260e0b8363602ac42d77fbb3b143` 已完成：

- Memory 全量：`415 passed, 2 warnings, 73 subtests passed`；
- warning 仅为 `audioop` / `register_star` 弃用警告；
- namespace/capability/scoped/recovery 合同定向回归通过；
- Python compileall 通过；
- `git diff --check` 通过；
- 官方 `upstream/main` @ `67d8c1d` 是候选 HEAD 祖先；
- 工作树干净。

### 四组合兼容矩阵

| 组合 | 运行时合同 | 跨插件 C1–C4 | Bot Personal sender | 结论 |
|---|---:|---:|---|---|
| 旧 Companion + 旧 Memory | `5 passed` | `5 passed / 2 failed` | `producer_capability_required` | 官方旧基线，fail-closed |
| 旧 Companion + 新 Memory | `5 passed` | `5 passed / 2 failed` | `producer_capability_required` | 与 old-old 一致，Memory-only 升级无新增回归 |
| 新 Companion + 旧 Memory | `5 passed` | `7 passed` | 成功 | Bot Personal 兼容；scoped namespace 明确降级 |
| 新 Companion + 新 Memory | `5 passed` | `7 passed` | 成功 | 目标组合全能力通过 |

旧 Companion 的两项 C1–C4 失败是旧测试直接绕过 producer capability 的已知基线；没有通过放宽 Memory 门禁让其“变绿”。修复后 Companion `329c757` 在旧/新 Memory 上都会传入运行时 capability。

宿主隔离验收另创建了 4 个 `--network none`、无端口、独立空数据目录的 AstrBot 实例；四组均加载两插件且 `RestartCount=0`，22 个 SQLite 均 `PRAGMA quick_check=ok`。临时容器与运行目录已删除，生产容器未变更。

## 风险与缓解

| 风险 | 等级 | 缓解 |
|---|---|---|
| 旧 Companion 不传 namespace | 中 | 旧路径保持兼容；新 scoped 能力只对协商通过的客户端开放 |
| 两插件合同版本漂移 | 高 | 指纹 + capability + 副作用自由 probe；不匹配时 fail-closed |
| tombstone 与延迟重放竞态 | 高 | 原子 tombstone、epoch/revision 校验、专项恢复测试 |
| 检索范围收紧导致可用记忆变少 | 中 | 这是安全预期；仅通过明确身份和作用域恢复，不放宽边界 |
| 存储元数据增长 | 低 | 有界索引与定期审计；不在运行路径复制聊天正文 |

## 发布与回滚

### 建议发布

1. 合并本 PR，发布兼容新 namespace capability 的 Memory 版本。
2. 确认旧 Companion 在该版本上仍可正常加载。
3. 再合并/发布 Companion PR-B，启用新协商与迁移链。
4. 观测 capability mismatch、scoped read denial、tombstone 和 replay 指标。

### 回滚

- 先回滚 Companion 新读，使用 legacy read；
- Memory 中新 scoped 数据保留但不用于生成，避免破坏性删除；
- 不回放过期 epoch，不去除 tombstone；
- 若需回滚 Memory 源码，先确认 Companion 已停止 scoped 读写。

## Reviewer guide

建议按以下顺序评审：

1. `core/namespace.py` 和 `core/namespace_capability.py`：先确认合同与 fail-closed 语义。
2. `core/scoped_domain_contract.py` 和 `core/scoped_store.py`：检查键、revision、epoch 和 tombstone。
3. `core/bridge.py` / `core/service.py`：检查调用边界与旧路径兼容。
4. `core/portrait_namespace.py` / `core/portrait_service.py`：检查画像检索是否越域。
5. archive/reset/recovery 测试：检查延迟事件不能复活已删数据。

## PR checklist

- [x] 新读写接口需要非空 namespace
- [x] capability probe 无副作用
- [x] 不同 person/group/persona 域有隔离测试
- [x] revision/epoch/tombstone 有乱序与恢复测试
- [x] revoked 学习记录保留审计但不参与生成
- [x] 全量测试、compileall、diff check 通过
- [x] 无数据模型破坏性覆盖脚本
- [x] 在个人 fork 确认 Memory 远端并推送 head 分支
- [x] 创建 Draft PR，待维护者确认发布/版本策略
- [x] 在 PR 中链接兼容矩阵，说明 Companion sender P1 已修复且未放宽 Memory 安全门禁
