### PR TITLE
feat: split summary providers by conversation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ astrbot_plugin_memory_companion
 ### 推荐初始配置
 
 1. 保持 `memory_capture.enabled=true`。
-2. 保持 `memory_summary.enabled=true`，并配置 `memory_summary.provider_id`。
+2. 保持 `memory_summary.enabled=true`，按需配置 `memory_summary.private_provider_id` / `memory_summary.group_provider_id`；不区分会话时仍可只配置兼容字段 `memory_summary.provider_id`。
 3. 保持 `memory_injection.enabled=true`。
 4. 检索模式使用 `retrieval.mode=auto`。
 5. 初期不急着启用 Embedding；记忆变多后再配置 Embedding Provider。
@@ -160,6 +160,8 @@ astrbot_plugin_memory_companion
 ### 阶段性总结
 
 `memory_summary` 控制时间线压缩为长期记忆的节奏。总结输入会作为不可信消息处理，提示词注入、角色覆盖和系统指令伪装会被标记与清洗，降低总结被带偏的概率。
+
+私聊和群聊可以分别选择总结模型：`memory_summary.private_provider_id` 只处理私聊时间线，`memory_summary.group_provider_id` 只处理群聊时间线。对应的 `private_fallback_provider_id` / `group_fallback_provider_id` 用于主模型失败时的备用尝试；未填写专用字段，或专用模型调用失败时，会兼容使用 `provider_id` / `fallback_provider_id`，再回退到当前会话模型。这样可以为群聊选择更轻量或更擅长多人对话的模型，同时不影响已有配置。
 
 如果日志显示请求 `127.0.0.1:11434` 超时，含义是本机 Ollama 没有在期限内生成总结，不是记忆数据库损坏。当前版本默认最多等待 60 秒、单个 Provider 只请求一次；失败后会尝试不同的备用 Provider，并完整保留尚未总结的时间线。可在这里换用更轻的本地模型或独立总结 Provider，并按机器性能调整“总结模型超时秒数”。
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -152,26 +152,54 @@
   },
   "memory_summary": {
     "description": "长期记忆总结",
-    "hint": "把时间线整理为可长期保存、可召回的阶段性记忆。模型、触发阈值和证据长度都在这里配置。",
+    "hint": "把时间线整理为可长期保存、可召回的阶段性记忆。私聊/群聊总结模型、触发阈值和证据长度都在这里配置。",
     "type": "object",
     "items": {
       "enabled": {
         "description": "启用阶段性总结",
-        "hint": "开启后，同一会话累计到阈值时会调用当前会话模型生成 conversation_summary 长期记忆。",
+        "hint": "开启后，同一会话累计到阈值时会按私聊/群聊范围选择总结模型，生成 conversation_summary 长期记忆。",
         "type": "bool",
         "default": true
       },
       "provider_id": {
-        "description": "总结模型提供商",
+        "description": "通用总结模型提供商（兼容回退）",
         "_special": "select_provider",
-        "hint": "选择用于阶段性记忆总结的 LLM 提供商。留空则使用当前会话正在使用的模型。",
+        "hint": "私聊或群聊专用 Provider 未配置或专用模型失败时使用此通用 Provider；留空则使用当前会话正在使用的模型。",
         "type": "string",
         "default": ""
       },
       "fallback_provider_id": {
-        "description": "备用总结模型提供商",
+        "description": "通用备用总结模型提供商（兼容回退）",
         "_special": "select_provider",
-        "hint": "主总结模型不可用或总结失败时使用。留空则直接回退当前会话模型。",
+        "hint": "对应专用备用 Provider 未配置时使用；专用主模型不可用或总结失败时也会尝试。留空则直接回退当前会话模型。",
+        "type": "string",
+        "default": ""
+      },
+      "private_provider_id": {
+        "description": "私聊总结模型提供商",
+        "_special": "select_provider",
+        "hint": "仅用于私聊时间线的阶段性总结。留空时回退到通用总结模型提供商。",
+        "type": "string",
+        "default": ""
+      },
+      "private_fallback_provider_id": {
+        "description": "私聊备用总结模型提供商",
+        "_special": "select_provider",
+        "hint": "私聊主总结模型失败时使用。留空时依次回退到通用备用 Provider 和当前会话模型。",
+        "type": "string",
+        "default": ""
+      },
+      "group_provider_id": {
+        "description": "群聊总结模型提供商",
+        "_special": "select_provider",
+        "hint": "仅用于群聊时间线的阶段性总结。留空时回退到通用总结模型提供商。",
+        "type": "string",
+        "default": ""
+      },
+      "group_fallback_provider_id": {
+        "description": "群聊备用总结模型提供商",
+        "_special": "select_provider",
+        "hint": "群聊主总结模型失败时使用。留空时依次回退到通用备用 Provider 和当前会话模型。",
         "type": "string",
         "default": ""
       },

--- a/core/audit.py
+++ b/core/audit.py
@@ -62,29 +62,78 @@ class MemoryAuditManager:
                 group_id=record.group_id,
             )
 
-        attempts = await self.service._summary_provider_attempts(ctx)
-        if not attempts:
-            raise RuntimeError("没有可用的记忆总结模型，无法生成审计预览")
         proposals: list[dict[str, Any]] = []
-        provider_id = ""
+        provider_ids: list[dict[str, str]] = []
         errors: list[str] = []
-        completed = False
-        for attempt in attempts:
-            provider = attempt.get("provider")
-            provider_id = clean_text(attempt.get("provider_id"), 120) or self.service._provider_runtime_id(provider)
-            try:
-                proposals = await self._request_proposals(provider, provider_id, prepared)
-                completed = True
-                break
-            except Exception as exc:
-                errors.append(clean_text(exc, 240))
-        if not completed:
+        prepared_by_scope: dict[str, list[dict[str, Any]]] = {}
+        for item in prepared:
+            record: MemoryRecord = item["record"]
+            record_scope = clean_text(record.scope, 40).lower()
+            scope_key = record_scope if record_scope in {"private", "group"} else "unknown"
+            prepared_by_scope.setdefault(scope_key, []).append(item)
+
+        for scope, scoped_candidates in prepared_by_scope.items():
+            scoped_ctx = self._context_for_scope(scoped_candidates[0]["record"], ctx, scope)
+            attempts = await self.service._summary_provider_attempts(scoped_ctx)
+            if not attempts:
+                errors.append(f"scope={scope}: no summary provider")
+                continue
+            completed = False
+            attempt_errors: list[str] = []
+            for attempt in attempts:
+                provider = attempt.get("provider")
+                provider_id = (
+                    clean_text(attempt.get("provider_id"), 120)
+                    or self.service._provider_runtime_id(provider)
+                )
+                try:
+                    scoped_proposals = await self._request_proposals(provider, provider_id, scoped_candidates)
+                    proposals.extend(scoped_proposals)
+                    provider_ids.append({"scope": scope, "provider_id": provider_id})
+                    completed = True
+                    break
+                except Exception as exc:
+                    attempt_errors.append(f"scope={scope}: {clean_text(exc, 240)}")
+            if not completed:
+                errors.extend(attempt_errors or [f"scope={scope}: provider returned no result"])
+                continue
+
+        if errors:
+            # Do not persist a partial audit preview: applying it would make
+            # the result look complete while one scope was never checked.
             raise RuntimeError(f"记忆审计模型未返回有效建议：{errors[-1]}")
+        if not provider_ids:
+            raise RuntimeError("没有可用的记忆总结模型，无法生成审计预览")
 
         accepted = self._validate_proposals(proposals, prepared, max_items)
-        batch = self._new_batch(accepted, candidate_count=len(prepared), provider_id=provider_id)
+        unique_provider_ids = list(
+            dict.fromkeys(item["provider_id"] for item in provider_ids if item["provider_id"])
+        )
+        batch = self._new_batch(
+            accepted,
+            candidate_count=len(prepared),
+            provider_id=unique_provider_ids[0] if len(unique_provider_ids) == 1 else "",
+            provider_ids=provider_ids,
+        )
         await asyncio.to_thread(self._write_batch, batch)
         return self._public_batch(batch)
+
+    @staticmethod
+    def _context_for_scope(
+        record: MemoryRecord,
+        fallback: SessionContext,
+        scope: str,
+    ) -> SessionContext:
+        resolved_scope = scope if scope in {"private", "group"} else "unknown"
+        return SessionContext(
+            session_id=record.session_id,
+            scope=resolved_scope,
+            platform=record.platform,
+            user_id=record.subject.id if record.subject.kind == "user" else "",
+            user_name=record.subject.name if record.subject.kind == "user" else "",
+            group_id=record.group_id,
+            bot_id=fallback.bot_id,
+        )
 
     async def status(self, batch_id: str) -> dict[str, Any]:
         return self._public_batch(await asyncio.to_thread(self._read_batch, batch_id))
@@ -432,6 +481,7 @@ class MemoryAuditManager:
         *,
         candidate_count: int,
         provider_id: str,
+        provider_ids: list[dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         now = datetime.now(timezone.utc)
         expire_hours = max(1, min(168, self.service.config.int("maintenance_audit.preview_expire_hours", 24)))
@@ -443,6 +493,7 @@ class MemoryAuditManager:
             "created_at": now.isoformat(timespec="seconds"),
             "expires_at": (now + timedelta(hours=expire_hours)).isoformat(timespec="seconds"),
             "provider_id": clean_text(provider_id, 120),
+            "provider_ids": provider_ids or [],
             "candidate_count": int(candidate_count),
             "backup_path": "",
             "items": items,

--- a/core/operations.py
+++ b/core/operations.py
@@ -183,6 +183,10 @@ def apply_preset(raw: dict[str, Any], name: str) -> dict[str, Any]:
         "preserved": [
             "memory_summary.provider_id",
             "memory_summary.fallback_provider_id",
+            "memory_summary.private_provider_id",
+            "memory_summary.private_fallback_provider_id",
+            "memory_summary.group_provider_id",
+            "memory_summary.group_fallback_provider_id",
             "retrieval.embedding_provider_id",
             "retrieval.rerank_provider_id",
         ],

--- a/core/service.py
+++ b/core/service.py
@@ -4030,12 +4030,37 @@ class MemoryCompanionService:
         return result
 
     async def _summary_provider_attempts(self, ctx: SessionContext) -> list[dict[str, Any]]:
+        """Resolve summary providers with private/group-specific overrides.
+
+        The original ``provider_id``/``fallback_provider_id`` pair remains a
+        shared compatibility fallback.  A scene-specific pair takes
+        precedence when configured, while the generic pair is still tried
+        before falling back to the provider currently active for the session.
+        This keeps existing installations working and lets private and group
+        timelines use independent models.
+        """
+        scope = clean_text(getattr(ctx, "scope", ""), 40).lower()
+        scene = "group" if scope == "group" else "private" if scope == "private" else ""
+        if not scene:
+            return await self._provider_attempts(
+                ctx,
+                prefix="memory_summary",
+                provider_key="provider_id",
+                fallback_provider_key="fallback_provider_id",
+                include_current=True,
+            )
+
+        # Resolve scene-specific providers first, then preserve the legacy
+        # generic pair as a second chance.  The helper de-duplicates provider
+        # IDs/objects so equal scene and generic settings are only called once.
         return await self._provider_attempts(
             ctx,
             prefix="memory_summary",
-            provider_key="provider_id",
-            fallback_provider_key="fallback_provider_id",
+            provider_key=f"{scene}_provider_id",
+            fallback_provider_key=f"{scene}_fallback_provider_id",
             include_current=True,
+            compatibility_provider_key="provider_id",
+            compatibility_fallback_provider_key="fallback_provider_id",
         )
 
     async def _provider_attempts(
@@ -4046,20 +4071,39 @@ class MemoryCompanionService:
         provider_key: str,
         fallback_provider_key: str,
         include_current: bool,
+        compatibility_provider_key: str = "",
+        compatibility_fallback_provider_key: str = "",
     ) -> list[dict[str, Any]]:
         attempts: list[dict[str, Any]] = []
         seen: set[str] = set()
         seen_provider_objects: set[int] = set()
-        configured = [
-            (
-                "primary",
-                clean_text(self.config.get(f"{prefix}.{provider_key}", ""), 120),
-            ),
-            (
-                "fallback",
-                clean_text(self.config.get(f"{prefix}.{fallback_provider_key}", ""), 120),
-            ),
-        ]
+        configured: list[tuple[str, str]] = []
+        primary_id = clean_text(self.config.get(f"{prefix}.{provider_key}", ""), 120)
+        fallback_id = clean_text(self.config.get(f"{prefix}.{fallback_provider_key}", ""), 120)
+        compatibility_primary_id = clean_text(
+            self.config.get(f"{prefix}.{compatibility_provider_key}", ""),
+            120,
+        ) if compatibility_provider_key else ""
+        compatibility_fallback_id = clean_text(
+            self.config.get(f"{prefix}.{compatibility_fallback_provider_key}", ""),
+            120,
+        ) if compatibility_fallback_provider_key else ""
+        # Prefer the scene-specific primary.  If it is unset, the generic
+        # primary keeps its historical position ahead of any scene fallback.
+        if primary_id:
+            configured.append(("primary", primary_id))
+        elif compatibility_primary_id:
+            configured.append(("primary", compatibility_primary_id))
+        if fallback_id:
+            configured.append(("fallback", fallback_id))
+        # A configured generic pair is still available after a scene override
+        # so an installation can migrate one scope at a time.
+        if primary_id and compatibility_primary_id:
+            configured.append(("compatibility_primary", compatibility_primary_id))
+        if not fallback_id and compatibility_fallback_id:
+            configured.append(("fallback", compatibility_fallback_id))
+        elif fallback_id and compatibility_fallback_id:
+            configured.append(("compatibility_fallback", compatibility_fallback_id))
         for source, provider_id in configured:
             if not provider_id:
                 continue

--- a/page_api.py
+++ b/page_api.py
@@ -1236,6 +1236,14 @@ class PluginPageApi:
                     "enabled": config.bool("memory_summary.enabled", True),
                     "provider_id": str(config.get("memory_summary.provider_id", "") or ""),
                     "fallback_provider_id": str(config.get("memory_summary.fallback_provider_id", "") or ""),
+                    "private_provider_id": str(config.get("memory_summary.private_provider_id", "") or ""),
+                    "private_fallback_provider_id": str(
+                        config.get("memory_summary.private_fallback_provider_id", "") or ""
+                    ),
+                    "group_provider_id": str(config.get("memory_summary.group_provider_id", "") or ""),
+                    "group_fallback_provider_id": str(
+                        config.get("memory_summary.group_fallback_provider_id", "") or ""
+                    ),
                     "min_events": config.int("memory_summary.min_events", 8),
                     "trigger_event_count": config.int("memory_summary.trigger_event_count", 12),
                     "trigger_interval_minutes": config.int("memory_summary.trigger_interval_minutes", 60),

--- a/pages/记忆面板/app.js
+++ b/pages/记忆面板/app.js
@@ -47,7 +47,7 @@ const SECONDARY_NAV = {
     { id: "maintenance", label: "维护 / 迁移 / 清理", sublabel: "维护、修复、导入与清理", badge: "维护" },
     { id: "conversation-import", label: "历史聊天导入", sublabel: "QQ 直读、文件与最近任务", badge: "导入" },
     { id: "config:memory_capture", label: "记忆捕获", sublabel: "记录用户消息与稳定事实", badge: "捕获" },
-    { id: "config:memory_summary", label: "长期总结", sublabel: "阶段总结模型与阈值", badge: "总结" },
+    { id: "config:memory_summary", label: "长期总结", sublabel: "私聊 / 群聊模型与阈值", badge: "总结" },
     { id: "config:historical_chat_import", label: "导入参数", sublabel: "QQ 分页与分段上限", badge: "参数" },
     { id: "config:conversation_memory", label: "连续对话", sublabel: "群聊片段与低信息保护", badge: "连续" },
     { id: "retrieval", label: "检索召回", sublabel: "候选、Embedding、Rerank", badge: "召回" },
@@ -91,7 +91,7 @@ const CONFIG_MODULE_GUIDES = {
   },
   memory_summary: {
     purpose: "把时间线整理成长期可召回的阶段性记忆，是从流水到长期记忆的主要入口。",
-    tune: "总结太慢时提高触发阈值；总结不及时或连续性弱时降低最少事件数和触发条数。",
+    tune: "可为私聊和群聊分别选择总结 Provider；总结太慢时提高触发阈值，总结不及时或连续性弱时降低最少事件数和触发条数。",
     avoid: "不要把单次总结事件上限调得过大，输入太长会降低总结质量。",
   },
   historical_chat_import: {
@@ -4070,12 +4070,17 @@ function renderSchemaConfigField(module, key, item = {}, value, data = {}) {
     if (current && !options.some((option) => option.id === current)) {
       options.push({ id: current, label: `${current}（当前配置）` });
     }
+    const providerPlaceholder = key === "private_provider_id" || key === "group_provider_id"
+      ? "留空沿用通用总结模型"
+      : key === "private_fallback_provider_id" || key === "group_fallback_provider_id"
+        ? "留空沿用通用备用模型"
+        : "留空使用当前会话模型";
     control = `
       <div class="provider-inline retrieval-provider-picker">
         <select data-config-provider-select="${escapeHtml(key)}">
           ${options.map((option) => `<option value="${escapeHtml(option.id || "")}"${String(option.id || "") === String(current || "") ? " selected" : ""}>${escapeHtml(option.label || option.id || "不指定")}</option>`).join("")}
         </select>
-        <input name="${escapeHtml(key)}" type="text" value="${escapeHtml(current)}" placeholder="留空使用当前会话模型" />
+        <input name="${escapeHtml(key)}" type="text" value="${escapeHtml(current)}" placeholder="${providerPlaceholder}" />
       </div>
     `;
   } else {

--- a/tests/test_memory_audit.py
+++ b/tests/test_memory_audit.py
@@ -26,8 +26,10 @@ class _Response:
 class _Provider:
     def __init__(self, payload: dict):
         self.payload = payload
+        self.prompts: list[str] = []
 
-    async def text_chat(self, **_kwargs):
+    async def text_chat(self, **kwargs):
+        self.prompts.append(str(kwargs.get("prompt") or ""))
         return _Response(self.payload)
 
 
@@ -158,6 +160,61 @@ class MemoryAuditTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(before.content, after.content)
         self.assertEqual(before.updated_at, after.updated_at)
         self.assertTrue((service.audit.root / f"{batch['batch_id']}.json").exists())
+
+    async def test_preview_routes_private_and_group_candidates_to_separate_models(self) -> None:
+        service, _root = self.make_service({"items": []})
+        await self.seed(service)
+        group_event_id = await service.store.add_timeline_event(
+            event_type="user_message",
+            session_id="qq:GroupMessage:g1",
+            scope="group",
+            subject_id="u2",
+            object_id="g1",
+            content="group fact",
+        )
+        await service.store.insert_memory(
+            MemoryRecord(
+                id="summary-group",
+                memory_type="conversation_summary",
+                subject=EntityRef.bot_self(),
+                object=EntityRef(kind="group", id="g1"),
+                scope="group",
+                session_id="qq:GroupMessage:g1",
+                group_id="g1",
+                visibility="group_public",
+                lifecycle="stable_memory",
+                content="group fact",
+                evidence="group fact",
+                metadata={
+                    "key_facts_with_refs": [
+                        {"fact": "group fact", "refs": [group_event_id]}
+                    ],
+                },
+            )
+        )
+        private_provider = _Provider({"items": []})
+        group_provider = _Provider({"items": []})
+        routed_scopes: list[str] = []
+
+        async def scoped_attempts(ctx):
+            routed_scopes.append(ctx.scope)
+            provider = group_provider if ctx.scope == "group" else private_provider
+            return [{"provider": provider, "provider_id": f"{ctx.scope}-provider"}]
+
+        service._summary_provider_attempts = scoped_attempts
+        batch = await service.audit.preview(SessionContext())
+
+        self.assertEqual({"private", "group"}, set(routed_scopes))
+        self.assertEqual(1, len(private_provider.prompts))
+        self.assertEqual(1, len(group_provider.prompts))
+        self.assertIn("summary-1", private_provider.prompts[0])
+        self.assertNotIn("summary-group", private_provider.prompts[0])
+        self.assertIn("summary-group", group_provider.prompts[0])
+        self.assertNotIn("summary-1", group_provider.prompts[0])
+        self.assertEqual(
+            {("private", "private-provider"), ("group", "group-provider")},
+            {(item["scope"], item["provider_id"]) for item in batch["provider_ids"]},
+        )
 
     async def test_apply_requires_confirmation_and_rollback_restores_content(self) -> None:
         proposal = {

--- a/tests/test_panel_regressions.py
+++ b/tests/test_panel_regressions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import unittest
 from pathlib import Path
@@ -9,6 +10,20 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class PanelRegressionTests(unittest.TestCase):
+    def test_summary_models_have_private_and_group_configuration(self) -> None:
+        schema = json.loads((ROOT / "_conf_schema.json").read_text(encoding="utf-8"))
+        summary_items = schema["memory_summary"]["items"]
+        for key in (
+            "private_provider_id",
+            "private_fallback_provider_id",
+            "group_provider_id",
+            "group_fallback_provider_id",
+        ):
+            self.assertEqual("select_provider", summary_items[key]["_special"])
+        script = (ROOT / "pages" / "记忆面板" / "app.js").read_text(encoding="utf-8")
+        self.assertIn('sublabel: "私聊 / 群聊模型与阈值"', script)
+        self.assertIn('key === "private_provider_id" || key === "group_provider_id"', script)
+
     def test_webview_actions_do_not_depend_on_native_dialogs(self) -> None:
         script = (ROOT / "pages" / "记忆面板" / "app.js").read_text(encoding="utf-8")
 

--- a/tests/test_summary_relationship.py
+++ b/tests/test_summary_relationship.py
@@ -645,6 +645,105 @@ class SummaryAndRelationshipTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("primary", attempts[0]["source"])
         self.assertIs(provider, attempts[0]["provider"])
 
+    async def test_summary_provider_attempts_use_scope_specific_models(self) -> None:
+        providers = {
+            "private-model": _TextProvider('{"summary":"private"}'),
+            "group-model": _TextProvider('{"summary":"group"}'),
+            "shared-model": _TextProvider('{"summary":"shared"}'),
+        }
+        requested: list[str] = []
+
+        async def get_provider_by_id(provider_id):
+            requested.append(str(provider_id))
+            return providers.get(str(provider_id))
+
+        context = SimpleNamespace(
+            get_provider_by_id=get_provider_by_id,
+            get_using_provider=lambda _session_id: None,
+        )
+        service = self.make_service(
+            {
+                "memory_summary": {
+                    "provider_id": "shared-model",
+                    "private_provider_id": "private-model",
+                    "group_provider_id": "group-model",
+                }
+            },
+            context=context,
+        )
+
+        private_attempts = await service._summary_provider_attempts(
+            SessionContext(session_id="private:u1", scope="private", user_id="u1")
+        )
+        group_attempts = await service._summary_provider_attempts(
+            SessionContext(session_id="group:g1", scope="group", group_id="g1")
+        )
+
+        self.assertEqual(["private-model", "shared-model"], requested[:2])
+        self.assertEqual("private-model", private_attempts[0]["provider_id"])
+        self.assertEqual("group-model", group_attempts[0]["provider_id"])
+        self.assertNotEqual(private_attempts[0]["provider"], group_attempts[0]["provider"])
+
+    async def test_summary_provider_attempts_fall_back_to_shared_model_when_scope_model_unset(self) -> None:
+        shared = _TextProvider('{"summary":"shared"}')
+
+        async def get_provider_by_id(provider_id):
+            return shared if provider_id == "shared-model" else None
+
+        context = SimpleNamespace(
+            get_provider_by_id=get_provider_by_id,
+            get_using_provider=lambda _session_id: None,
+        )
+        service = self.make_service(
+            {"memory_summary": {"provider_id": "shared-model"}},
+            context=context,
+        )
+
+        attempts = await service._summary_provider_attempts(
+            SessionContext(session_id="group:g1", scope="group", group_id="g1")
+        )
+
+        self.assertEqual(1, len(attempts))
+        self.assertEqual("primary", attempts[0]["source"])
+        self.assertEqual("shared-model", attempts[0]["provider_id"])
+
+    async def test_summary_provider_attempts_keep_scope_specific_fallbacks_separate(self) -> None:
+        providers = {
+            "private-model": _TextProvider('{"summary":"private"}'),
+            "private-fallback": _TextProvider('{"summary":"private fallback"}'),
+            "group-model": _TextProvider('{"summary":"group"}'),
+            "group-fallback": _TextProvider('{"summary":"group fallback"}'),
+        }
+
+        async def get_provider_by_id(provider_id):
+            return providers.get(str(provider_id))
+
+        context = SimpleNamespace(
+            get_provider_by_id=get_provider_by_id,
+            get_using_provider=lambda _session_id: None,
+        )
+        service = self.make_service(
+            {
+                "memory_summary": {
+                    "private_provider_id": "private-model",
+                    "private_fallback_provider_id": "private-fallback",
+                    "group_provider_id": "group-model",
+                    "group_fallback_provider_id": "group-fallback",
+                }
+            },
+            context=context,
+        )
+
+        private_attempts = await service._summary_provider_attempts(
+            SessionContext(session_id="private:u1", scope="private", user_id="u1")
+        )
+        group_attempts = await service._summary_provider_attempts(
+            SessionContext(session_id="group:g1", scope="group", group_id="g1")
+        )
+
+        self.assertEqual(["private-model", "private-fallback"], [item["provider_id"] for item in private_attempts])
+        self.assertEqual(["group-model", "group-fallback"], [item["provider_id"] for item in group_attempts])
+
     async def test_summary_reports_only_rows_actually_sent_to_provider(self) -> None:
         summarizer = MemorySummarizer(max_input_chars=1000, provider_timeout_seconds=1)
         rows = [


### PR DESCRIPTION
## 变更\n- 新增私聊与群聊独立的记忆总结 Provider 及备用 Provider 配置。\n- 保留旧 provider_id / fallback_provider_id 兼容回退。\n- 审计预览按 scope 分流，避免混合私聊和群聊摘要。\n- 更新配置 schema、管理面板、页面 API、文档和测试。\n\n## 验证\n- 完整 unittest：346 项通过\n- JSON schema、Python 编译、Node.js 语法检查、git diff --check 通过。