### PR TITLE
feat: 增加结构化用户画像降噪与可回滚治理

### DIFF
--- a/core/classifier.py
+++ b/core/classifier.py
@@ -5,6 +5,11 @@ from typing import Any
 
 from .identity import entity_for_current_target, entity_for_user, looks_like_command
 from .models import EntityRef, MemoryRecord, SessionContext, clean_text
+from .profile_quality import (
+    extract_profile_candidates,
+    profile_candidate_metadata,
+    profile_rejection_reason,
+)
 
 
 class MemoryClassifier:
@@ -93,31 +98,46 @@ class MemoryClassifier:
             "visibility": visibility,
             "sayability": "direct",
             "reality_level": "real_user_fact",
-            "lifecycle": "stable_memory",
-            "confidence": 0.82,
-            "importance": 0.68,
-            "review_status": "auto",
             "source_plugin": "memory_companion",
         }
 
-        fact = self._extract_preference_or_profile(ctx, text)
-        if fact:
+        profile_facts = self._extract_profile_facts(ctx, ctx.message_text)
+        facts = profile_facts or [self._extract_non_profile_memory(ctx, text)]
+        for fact in (item for item in facts if item):
+            metadata = {
+                "source_memory_id": source_memory_id,
+                "extractor": "rule_v2",
+                "owner_bot_id": clean_text(ctx.bot_id, 120),
+            }
+            if fact.get("profile_dimension"):
+                metadata.update(
+                    profile_candidate_metadata(fact, source_memory_id=source_memory_id)
+                )
+                metadata["independent_evidence_count"] = 1
+                metadata["evidence_count"] = 1
+            profile_state = clean_text(fact.get("profile_state"), 40) or "active"
             records.append(
                 MemoryRecord(
                     memory_type=fact["memory_type"],
                     content=fact["content"],
                     evidence=text,
                     tags=fact["tags"],
-                    metadata={
-                        "source_memory_id": source_memory_id,
-                        "extractor": "rule_v1",
-                        "owner_bot_id": clean_text(ctx.bot_id, 120),
-                    },
+                    lifecycle="stable_memory"
+                    if profile_state == "active"
+                    else "raw_event",
+                    confidence=float(fact.get("confidence") or 0.82),
+                    importance=float(fact.get("importance") or 0.68),
+                    review_status="auto" if profile_state == "active" else "pending",
+                    metadata=metadata,
                     **base,
                 )
             )
 
         return records
+
+    @staticmethod
+    def profile_rejection_reason(text: Any) -> str:
+        return profile_rejection_reason(text)
 
     def external_record(
         self,
@@ -198,39 +218,70 @@ class MemoryClassifier:
         return min(0.85, score)
 
     def _extract_preference_or_profile(self, ctx: SessionContext, text: str) -> dict[str, Any] | None:
+        facts = self._extract_profile_facts(ctx, text)
+        if facts:
+            return facts[0]
+        return self._extract_non_profile_memory(ctx, text)
+
+    def _extract_profile_facts(
+        self, ctx: SessionContext, text: str
+    ) -> list[dict[str, Any]]:
+        name = ctx.user_name or ctx.user_id or "当前用户"
+        facts: list[dict[str, Any]] = []
+        for candidate in extract_profile_candidates(text):
+            label = clean_text(candidate.get("label"), 40)
+            value = clean_text(candidate.get("profile_value"), 80)
+            facts.append(
+                {
+                    **candidate,
+                    "content": f"{name}明确表达过：{label} {value}",
+                    "tags": [
+                        "stable_fact",
+                        str(candidate["memory_type"]),
+                        label,
+                        str(candidate["profile_dimension"]),
+                    ],
+                }
+            )
+        return facts
+
+    def _extract_non_profile_memory(
+        self, ctx: SessionContext, text: str
+    ) -> dict[str, Any] | None:
+        """Keep non-profile legacy facts while requiring a direct full statement."""
         name = ctx.user_name or ctx.user_id or "当前用户"
         patterns = [
-            # 偏好 - 基础
-            (r"(?:我|咱|俺)(?:很|最|超|特别|有点|真的|真的好|超级)?喜欢(.{1,40})", "user_preference", "喜欢"),
-            (r"(?:我|咱|俺)(?:很|最|超|特别|真的)?讨厌(.{1,40})", "user_preference", "讨厌"),
-            (r"(?:我|咱|俺)(?:不喜欢|不爱|不太喜欢)(.{1,40})", "user_preference", "不喜欢"),
-            (r"(?:我|咱|俺)(?:最爱|超爱|最喜欢|特别喜欢|真的好爱)(.{1,40})", "user_preference", "最爱"),
-            (r"(?:我|咱|俺)(?:对|对于)(.{2,30})(?:过敏|不能吃|不能碰|受不了)", "user_preference", "过敏/禁忌"),
-            # 身份/画像
-            (r"(?:我|咱|俺)(?:的)?生日(?:是|在)?(.{2,20})", "user_profile", "生日"),
-            (r"(?:以后|之后)?(?:叫我|喊我)(.{1,20})", "user_profile", "称呼"),
-            (r"(?:我|咱|俺)(?:是|在)(?:做|干|从事)(.{2,40})", "user_profile", "职业"),
-            (r"(?:我|咱|俺)(?:是|在)(?:学|读)(?:的是?)?(.{2,40})", "user_profile", "专业/学业"),
-            (r"(?:我|咱|俺)(?:是|属于)(.{2,12})(?:座|型)", "user_profile", "星座/血型"),
-            (r"(?:我|咱|俺)(?:的)?(?:星座|血型)(?:是)?(.{2,12})", "user_profile", "星座/血型"),
             # 明确要求记住
-            (r"(?:记住|别忘了?|你要记得|务必记得|一定记得)(.{2,80})", "explicit_memory", "明确要求"),
+            (
+                r"^(?:请)?(?:记住|别忘了?|你要记得|务必记得|一定记得)(.{2,80})$",
+                "explicit_memory",
+                "明确要求",
+            ),
             # 承诺/约定
-            (r"(?:我|咱|俺)(?:保证|发誓|答应你|跟你约定|说好了)(.{2,60})", "explicit_memory", "承诺/约定"),
-            (r"(?:下次|以后|明天|回头|之后)(?:一定|肯定会|一定会|保证)(.{2,40})", "explicit_memory", "承诺"),
+            (
+                r"^(?:我|咱|俺)(?:保证|发誓|答应你|跟你约定|说好了)(.{2,60})$",
+                "explicit_memory",
+                "承诺/约定",
+            ),
+            (
+                r"^(?:下次|以后|明天|回头|之后)(?:一定|肯定会|一定会|保证)(.{2,40})$",
+                "explicit_memory",
+                "承诺",
+            ),
             # 关系表达
-            (r"(?:你|你呀)(?:是我|是咱)(?:最|特别|很)?(.{2,20})(?:朋友|伙伴|重要的人|信任的人)", "relationship_claim", "关系定位"),
-            (r"(?:我|咱|俺)(?:很|特别|真的|最)?(?:信任|依赖|在意|在乎|珍惜)(.{2,30})", "relationship_claim", "关系表达"),
-            # 情绪状态
-            (r"(?:我|咱|俺)(?:最近|今天|现在|这阵子|这会儿)?(?:很|有点|真的|好|特别)?(?:累|压力大|焦虑|低落|开心|难过|孤独|害怕|不安)(.{0,40})", "user_preference", "情绪状态"),
-            # 习惯
-            (r"(?:我|咱|俺)(?:一般|通常|习惯|每次|总是|经常)(.{2,40})", "user_habit", "习惯"),
-            # 边界/雷区
-            (r"(?:我|咱|俺)(?:不喜欢别人|讨厌别人|不希望)(.{2,40})", "user_preference", "边界"),
-            (r"(?:别问我|不要问我|不想聊)(.{0,30})", "user_preference", "雷区"),
+            (
+                r"^(?:你|你呀)(?:是我|是咱)(?:最|特别|很)?(.{2,20})(?:朋友|伙伴|重要的人|信任的人)$",
+                "relationship_claim",
+                "关系定位",
+            ),
+            (
+                r"^(?:我|咱|俺)(?:很|特别|真的|最)?(?:信任|依赖|在意|在乎|珍惜)(.{2,30})$",
+                "relationship_claim",
+                "关系表达",
+            ),
         ]
         for pattern, memory_type, label in patterns:
-            match = re.search(pattern, text)
+            match = re.fullmatch(pattern, text)
             if not match:
                 continue
             value = clean_text(match.group(1).strip(" ，。！？!?.：:"), 80)

--- a/core/commands.py
+++ b/core/commands.py
@@ -169,9 +169,8 @@ class MemoryCompanionCommandHandler:
     async def promote(self, memory_id: str = "") -> str:
         if not memory_id:
             return "用法：/mcomp promote <memory_id>"
-        ok_review = await self.service.store.update_review_status(memory_id, "auto")
-        ok_lifecycle = await self.service.store.update_memory_lifecycle(memory_id, "stable_memory")
-        return "已提升为稳定记忆。" if ok_review or ok_lifecycle else "没有找到这条记忆。"
+        ok = await self.service.store.update_review_status(memory_id, "auto")
+        return "已提升为稳定记忆。" if ok else "没有找到这条记忆。"
 
     async def archive(self, memory_id: str = "") -> str:
         if not memory_id:

--- a/core/injection.py
+++ b/core/injection.py
@@ -7,11 +7,18 @@ from typing import Any
 
 from .models import SearchResult, SessionContext, clean_text
 
+from .profile_quality import PROFILE_MEMORY_TYPES, profile_quality_decision
+
 MEMORY_COMPANION_INJECTION_HEADER = "<MemoryCompanion-Context>"
 MEMORY_COMPANION_INJECTION_FOOTER = "</MemoryCompanion-Context>"
 
 
 class InjectionComposer:
+    def __init__(self) -> None:
+        self.last_omission_diagnostics: list[dict[str, str]] = []
+        self.last_omission_reasons: list[str] = []
+        self.last_included_memory_ids: list[str] = []
+
     def compose(
         self,
         ctx: SessionContext,
@@ -32,6 +39,7 @@ class InjectionComposer:
         recent_fact_context: str = "",
         recent_cross_window_context: str = "",
     ) -> str:
+        results, slot_sections = self._filter_injection_results(results, slot_sections)
         if not results and not intent_context and not recent_fact_context and not recent_cross_window_context:
             return ""
 
@@ -154,6 +162,13 @@ class InjectionComposer:
         if len(text) > inner_limit:
             text = self._minimal_body(ctx, inner_limit, has_results=bool(results))
         return f"{MEMORY_COMPANION_INJECTION_HEADER}\n{text}\n{MEMORY_COMPANION_INJECTION_FOOTER}"
+
+    def diagnostic_snapshot(self) -> tuple[list[dict[str, str]], list[str]]:
+        """Return per-compose diagnostics detached from later requests."""
+        return (
+            [dict(item) for item in self.last_omission_diagnostics],
+            list(self.last_included_memory_ids),
+        )
 
     @staticmethod
     def _safe_text(value: Any, limit: int = 2000) -> str:
@@ -310,6 +325,11 @@ class InjectionComposer:
         detail_limit: int | None = None,
     ) -> str:
         memory = item.memory
+        if self._expression_value(item) == "tone":
+            return (
+                "- 语气提示：参考一条已校验的长期线索，保持自然、尊重和适当的熟悉感；"
+                "禁止复述、引用、猜测或还原该线索原文。"
+            )
         metadata = self._metadata_dict(memory)
         key_facts = metadata.get("key_facts")
         if isinstance(key_facts, list):
@@ -368,6 +388,142 @@ class InjectionComposer:
                 ]
             )
         return "- " + "；".join(part for part in parts if part)
+
+    def _filter_injection_results(
+        self,
+        results: list[SearchResult],
+        slot_sections: list[tuple[str, list[SearchResult]]] | None,
+    ) -> tuple[list[SearchResult], list[tuple[str, list[SearchResult]]] | None]:
+        """Apply the final expression and profile-quality guard.
+
+        Retrieval is not the only producer of injection candidates. This last
+        synchronous guard also covers fast paths and direct composer callers.
+        """
+        self.last_omission_diagnostics = []
+        self.last_omission_reasons = []
+        self.last_included_memory_ids = []
+        decision_cache: dict[str, tuple[bool, str, str]] = {}
+        diagnostic_keys: set[tuple[str, str]] = set()
+        included_ids: set[str] = set()
+
+        def item_key(item: SearchResult) -> str:
+            memory_id = clean_text(
+                getattr(getattr(item, "memory", None), "id", ""), 160
+            )
+            return memory_id or f"object:{id(item)}"
+
+        def record(
+            item: SearchResult, reason: str, *, expression: str, slot: str = ""
+        ) -> None:
+            memory_id = clean_text(
+                getattr(getattr(item, "memory", None), "id", ""), 160
+            )
+            key = (memory_id or item_key(item), reason)
+            if key in diagnostic_keys:
+                return
+            diagnostic_keys.add(key)
+            diagnostic = {
+                "id": memory_id,
+                "reason": reason,
+                "content": "",
+                "expression": expression,
+            }
+            if slot:
+                diagnostic["slot"] = clean_text(slot, 60)
+            self.last_omission_diagnostics.append(diagnostic)
+            self.last_omission_reasons.append(reason)
+
+        def decision(item: SearchResult) -> tuple[bool, str, str]:
+            key = item_key(item)
+            cached = decision_cache.get(key)
+            if cached is not None:
+                return cached
+            memory = getattr(item, "memory", None)
+            expression = self._expression_value(item)
+            allowed, reason = self._profile_injection_decision(memory)
+            if not allowed:
+                result = (False, f"injection_omitted:{reason}", expression)
+            elif expression == "uncertain":
+                result = (False, "injection_omitted:uncertain", expression)
+            elif expression == "candidate" and self._is_rule_profile(memory):
+                result = (False, "injection_omitted:candidate", expression)
+            else:
+                result = (True, "", expression)
+            decision_cache[key] = result
+            return result
+
+        def keep(item: SearchResult, *, slot: str = "") -> bool:
+            allowed, reason, expression = decision(item)
+            if not allowed:
+                record(item, reason, expression=expression, slot=slot)
+                return False
+            memory_id = clean_text(
+                getattr(getattr(item, "memory", None), "id", ""), 160
+            )
+            if memory_id and memory_id not in included_ids:
+                included_ids.add(memory_id)
+                self.last_included_memory_ids.append(memory_id)
+            if expression == "tone":
+                record(
+                    item,
+                    "injection_content_abstracted:tone",
+                    expression=expression,
+                    slot=slot,
+                )
+            return True
+
+        filtered_results = [item for item in (results or []) if keep(item)]
+        if slot_sections is None:
+            return filtered_results, None
+        filtered_sections: list[tuple[str, list[SearchResult]]] = []
+        for slot, items in slot_sections:
+            kept = [item for item in (items or []) if keep(item, slot=slot)]
+            if kept:
+                filtered_sections.append((slot, kept))
+        result_keys = {item_key(item) for item in filtered_results}
+        for _slot, items in filtered_sections:
+            for item in items:
+                key = item_key(item)
+                if key not in result_keys:
+                    result_keys.add(key)
+                    filtered_results.append(item)
+        return filtered_results, filtered_sections
+
+    @staticmethod
+    def _profile_injection_decision(memory: Any) -> tuple[bool, str]:
+        if memory is None:
+            return False, "missing_memory"
+        memory_type = clean_text(getattr(memory, "memory_type", ""), 80).lower()
+        metadata = InjectionComposer._metadata_dict(memory)
+        profile_state = clean_text(metadata.get("profile_state"), 40).lower()
+        review_status = clean_text(getattr(memory, "review_status", ""), 40).lower()
+        lifecycle = clean_text(getattr(memory, "lifecycle", ""), 40).lower()
+        is_profile = memory_type in PROFILE_MEMORY_TYPES or bool(profile_state)
+        if is_profile and review_status in {"pending", "rejected"}:
+            return False, f"profile_review_{review_status}"
+        if is_profile and lifecycle == "archived":
+            return False, "profile_state_archived"
+        if profile_state in {
+            "candidate",
+            "pending",
+            "rejected",
+            "superseded",
+            "archived",
+        }:
+            return False, f"profile_state_{profile_state}"
+        return profile_quality_decision(memory, require_active=True)
+
+    @staticmethod
+    def _is_rule_profile(memory: Any) -> bool:
+        if memory is None:
+            return False
+        memory_type = clean_text(getattr(memory, "memory_type", ""), 80).lower()
+        metadata = InjectionComposer._metadata_dict(memory)
+        extractor = clean_text(metadata.get("extractor"), 80).lower()
+        producer_kind = clean_text(metadata.get("producer_kind"), 80).lower()
+        return memory_type in PROFILE_MEMORY_TYPES and (
+            extractor.startswith("rule_") or producer_kind.startswith("rule_")
+        )
 
     @staticmethod
     def _redact_sensitive_text(value: Any) -> str:

--- a/core/portrait.py
+++ b/core/portrait.py
@@ -20,7 +20,7 @@ except ImportError:  # Existing standalone core.* test/import compatibility.
         validate_portrait_request,
     )
 from .models import clean_text
-
+from .profile_quality import RULE_EXTRACTOR, extract_profile_candidates
 
 PORTRAIT_TIERS = frozenset({"base", "intelligent"})
 SENSITIVITY_LEVELS = frozenset({"low", "sensitive", "high"})
@@ -34,13 +34,6 @@ PURPOSE_RESULT_CODES = {
 _SENSITIVE_TOKENS = (
     "疾病", "病", "过敏", "治疗", "药", "医院", "政治", "宗教", "信仰", "性", "住址", "地址",
     "定位", "行程", "财务", "工资", "密码", "账号", "身份证", "创伤", "自杀",
-)
-_EXPLICIT_PATTERNS = (
-    (r"(?:我|咱|俺)(?:很|最|超|特别|有点|真的|超级)?喜欢(.{1,40})", "preference", "like"),
-    (r"(?:我|咱|俺)(?:不喜欢|不爱|不太喜欢|讨厌)(.{1,40})", "preference", "dislike"),
-    (r"(?:以后|之后)?(?:叫我|喊我)(.{1,20})", "preferred_address", "address"),
-    (r"(?:我|咱|俺)(?:通常|一般|习惯|经常)(.{2,40})", "communication_preference", "habit"),
-    (r"(?:别问我|不要问我|不想聊)(.{0,30})", "boundary", "avoid"),
 )
 _CROSS_SCENE_PREFERENCE_MARKERS = (
     "吃", "喝", "食物", "料理", "烤肉", "火锅", "甜品", "咖啡", "茶",
@@ -126,38 +119,55 @@ def cross_scene_whitelisted_fact(
     return False
 
 
-def extract_explicit_candidates(text: Any) -> list[dict[str, str]]:
+def extract_explicit_candidates(text: Any) -> list[dict[str, Any]]:
     """Extract only self-contained first-person statements without context text."""
-    source = _text(text, 1800)
-    if not source:
-        return []
-    results: list[dict[str, str]] = []
-    for pattern, dimension, kind in _EXPLICIT_PATTERNS:
-        match = re.search(pattern, source)
-        if not match:
+    results: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in extract_profile_candidates(text):
+        dimension = _text(candidate.get("profile_dimension"), 80)
+        kind = _text(candidate.get("kind"), 40)
+        value = _text(candidate.get("profile_value"), 80)
+        normalized_value = _text(candidate.get("normalized_value"), 80)
+        summary = _text(candidate.get("claim_summary"), 180)
+        if (
+            not dimension
+            or not kind
+            or not value
+            or not normalized_value
+            or not summary
+        ):
             continue
-        claim = _text(match.group(1).strip(" ，。！？!?.：:"), 80)
-        if not claim:
+        claim_hash = normalized_claim_hash(dimension, f"{kind}:{normalized_value}")
+        if claim_hash in seen:
             continue
-        summary = {
-            "like": f"喜欢 {claim}",
-            "dislike": f"不喜欢 {claim}",
-            "address": f"希望被称为 {claim}",
-            "habit": f"沟通习惯：{claim}",
-            "avoid": f"不希望聊 {claim}" if claim else "有明确不想聊的内容",
-        }[kind]
+        seen.add(claim_hash)
         item = {
             "dimension": dimension,
-            "normalized_claim_hash": normalized_claim_hash(dimension, f"{kind}:{claim}"),
-            "claim_summary": _text(summary, 180),
-            "sensitivity": classify_sensitivity(claim),
+            "profile_dimension": dimension,
+            "profile_value": value,
+            "normalized_value": normalized_value,
+            "profile_polarity": kind,
+            "profile_cardinality": _text(candidate.get("profile_cardinality"), 16)
+            or "multi",
+            "normalized_claim_hash": claim_hash,
+            "claim_summary": summary,
+            "sensitivity": classify_sensitivity(f"{value} {summary}"),
             "producer_kind": "rule_explicit",
-            "producer_version": "req036.rule.v1",
+            "producer_version": "req036.rule.v2",
+            "extractor": RULE_EXTRACTOR,
             "derivation_kind": "explicit_statement",
             "epistemic_status": "explicit",
+            "extraction_quality": _text(candidate.get("extraction_quality"), 40)
+            or "explicit",
+            "extraction_quality_score": float(
+                candidate.get("extraction_quality_score") or 0.0
+            ),
+            "evidence_strength": _text(candidate.get("evidence_strength"), 40)
+            or "direct_statement",
+            "profile_state": _text(candidate.get("profile_state"), 40) or "candidate",
+            "quality_gate_passed": bool(candidate.get("quality_gate_passed")),
         }
-        if item not in results:
-            results.append(item)
+        results.append(item)
     return results
 
 

--- a/core/portrait_service.py
+++ b/core/portrait_service.py
@@ -65,6 +65,14 @@ class PortraitService:
         scope = self._scope_for_context(ctx)
         if not scope:
             return {"ok": False, "code": "bridge_person_mismatch", "facts": 0}
+        candidates = extract_explicit_candidates(ctx.message_text)
+        if not candidates:
+            return {
+                "ok": True,
+                "code": "portrait_no_candidate",
+                "facts": 0,
+                "person_id": person_ref["person_id"],
+            }
         evidence = build_evidence(
             person_ref=person_ref,
             scope=scope,
@@ -77,20 +85,22 @@ class PortraitService:
         if not evidence_result.get("ok") or not evidence_result.get("created"):
             return {"ok": bool(evidence_result.get("ok")), "code": evidence_result.get("code", "portrait_evidence_recorded"), "facts": 0}
         created = 0
-        for candidate in extract_explicit_candidates(ctx.message_text):
+        for candidate in candidates:
             fact = {
                 **candidate,
                 "person_id": person_ref["person_id"],
                 "portrait_tier": "base",
                 "source_scope": scope,
-                "usable_scope": "self_low_global" if cross_scene_whitelisted_fact(
+                "usable_scope": "self_low_global"
+                if cross_scene_whitelisted_fact(
                     dimension=candidate["dimension"],
                     claim_summary=candidate["claim_summary"],
                     sensitivity=candidate["sensitivity"],
                     source_scope=scope,
-                ) else "source_only",
-                "confidence": 0.9,
-                "status": "active",
+                )
+                else "source_only",
+                "confidence": float(candidate.get("extraction_quality_score") or 0.0),
+                "status": clean_text(candidate.get("profile_state"), 40) or "candidate",
                 "evidence_hashes": [evidence["evidence_hash"]],
                 "context_refs": evidence["context_refs"],
                 "operation_id": f"portrait.explicit:{evidence['evidence_hash'][:24]}",

--- a/core/profile_quality.py
+++ b/core/profile_quality.py
@@ -1,0 +1,777 @@
+"""Shared rule-v2 profile extraction and quality gates.
+
+This module deliberately works with plain dictionaries and duck-typed memory
+objects.  The classifier, portrait service, retrieval, and injection paths can
+therefore share the same policy without importing one another.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterator
+from typing import Any
+
+RULE_EXTRACTOR = "rule_v2"
+PROFILE_MEMORY_TYPES = frozenset({"user_profile", "user_preference", "user_habit"})
+PROFILE_STATES = frozenset({"candidate", "active", "rejected", "superseded"})
+
+_TRIM_CHARS = " \t\r\n，,。！？!?；;：:、"
+_QUOTE_PAIRS = (
+    ("“", "”"),
+    ("‘", "’"),
+    ('"', '"'),
+    ("'", "'"),
+    ("「", "」"),
+    ("『", "』"),
+)
+_TAIL_PARTICLES = (
+    "就可以了",
+    "就好了",
+    "就行了",
+    "就好",
+    "就行",
+    "即可",
+    "可以了",
+    "好了",
+    "吧",
+    "呀",
+    "啊",
+    "呢",
+    "哦",
+    "嘛",
+    "啦",
+    "呗",
+    "哟",
+    "喔",
+)
+_LEADING_FILLER_RE = re.compile(
+    r"^(?:(?:嗯+|唔+|呃+|那个|对了|其实|顺便说|话说|好的?|行吧?|拜托)[\s，,、]*)+"
+)
+_REPORT_PREFIX_RE = re.compile(
+    r"(?:老板娘|老板|他|她|他们|她们|同事|别人|有人|朋友|同学|家人|妈妈|爸爸)"
+    r".{0,16}(?:说|讲|告诉|表示|认为|觉得|问|叫|喊|称呼|提到|提及|描述|介绍|转述)"
+)
+_REPORT_MARKERS = (
+    "听说",
+    "据说",
+    "转述",
+    "引用",
+    "原话",
+    "聊天记录",
+    "消息里说",
+)
+_QUESTION_WORD_RE = re.compile(
+    r"(?:什么|啥|多少|哪(?:个|种|些)?|谁|怎么|为何|为什么|干嘛|是否|还是|"
+    r"几(?:月|号|日|点|岁|次|个|种|些|本|杯|碗|年|天|周|位|条|件|份|时|分))"
+)
+_ADDRESS_ACTION_RE = re.compile(r"(?:去|来|跟车|跟着|跟|上班|工作|做|让我)")
+_ADDRESS_REJECT_RE = re.compile(
+    r"(?:不许|不准|不能|别|不要|禁止|怎么还|为何还|为什么还|老是|总是|"
+    r"叫我几声|喊我几声|几声|(?:一|两|三|\d+)声|一次|一下)"
+)
+_TEMPORARY_RE = re.compile(r"(?:今天|现在|刚才|这会儿|最近|这阵子|暂时|临时|目前|当下)")
+_ONE_OFF_CONTEXT_RE = re.compile(
+    r"(?:这次|本次|这一回|这一轮|刚刚|今晚|今早|今晨|这顿|这一顿|这杯|当前)"
+)
+_UNCERTAIN_RE = re.compile(r"(?:大概|可能|也许|好像|似乎|说不定|没准)")
+_PROFILE_ATTEMPT_RE = re.compile(
+    r"(?:叫我|喊我|称呼我|我(?:真的|很|最|超|特别|有点|超级|最近|现在|今天|可能|也许)?"
+    r"(?:喜欢|最爱|超爱|不喜欢|不爱|讨厌)|我的(?:生日|职业|专业|星座|血型)|"
+    r"我(?:从事|担任|习惯|通常|一般|经常|不能吃|不能碰))"
+)
+
+_ADDRESS_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"^(?:请|麻烦|劳驾|拜托)?(?:以后|之后|往后)?(?:你|您)?(?:就)?(?:叫|喊)我(?:为|作|做)?[：:\s]*(?P<value>.+)$",
+        r"^(?:请|麻烦|劳驾|拜托)?(?:你|您)(?:以后|之后|往后)(?:就)?(?:叫|喊)我(?:为|作|做)?[：:\s]*(?P<value>.+)$",
+        r"^(?:请|麻烦|劳驾|拜托)?(?:你|您)?(?:以后|之后|往后)?(?:称呼)我(?:为|作|做)?[：:\s]*(?P<value>.+)$",
+        r"^我(?:希望|想让|希望以后|想请)(?:你|您)?(?:以后|之后|往后)?(?:叫|喊|称呼)我(?:为|作|做)?[：:\s]*(?P<value>.+)$",
+        r"^我叫[：:\s]*(?P<value>.+)$",
+    )
+)
+
+_LIKE_RE = re.compile(
+    r"^(?:我|咱|俺)(?:真的好|真的|很|最|超|特别|有点|超级)?"
+    r"(?:喜欢|最爱|超爱|特别喜欢|真的好爱|很爱|爱)(?P<value>.+)$",
+    re.IGNORECASE,
+)
+_DISLIKE_RE = re.compile(
+    r"^(?:我|咱|俺)(?:真的|很|最|超|特别|有点)?"
+    r"(?:不太喜欢|不喜欢|不爱|讨厌)(?P<value>.+)$",
+    re.IGNORECASE,
+)
+_ALLERGY_RE = re.compile(
+    r"^(?:我|咱|俺)(?:对|对于)(?P<value>.+?)(?:过敏|不能吃|不能碰|受不了)$"
+)
+_CANNOT_EAT_RE = re.compile(r"^(?:我|咱|俺)(?:不能吃|不能碰)(?P<value>.+)$")
+_BIRTHDAY_RE = re.compile(
+    r"^(?:我|咱|俺)(?:的)?生日(?:是|在|为|：|:)?\s*(?P<value>.+)$"
+)
+_OCCUPATION_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"^(?:我|咱|俺)(?:的)?职业(?:是|为|：|:)\s*(?P<value>.+)$",
+        r"^(?:我|咱|俺)(?:从事|担任|当)(?:一名|一个)?\s*(?P<value>.+)$",
+        r"^(?:我|咱|俺)是(?:做|干)(?P<value>.+)$",
+        r"^(?:我|咱|俺)是(?:一名|一个)\s*(?P<value>.+)$",
+    )
+)
+_EDUCATION_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"^(?:我|咱|俺)(?:的)?专业(?:是|为|：|:)\s*(?P<value>.+)$",
+        r"^(?:我|咱|俺)(?:是|在)(?:学|读)(?:的是?)?\s*(?P<value>.+)$",
+        r"^(?:我|咱|俺)是(?P<value>.+?)专业(?:的)?$",
+    )
+)
+_ZODIAC_RE = re.compile(r"^(?:我|咱|俺)(?:的)?星座(?:是|为|：|:)?\s*(?P<value>.+)$")
+_BLOOD_TYPE_RE = re.compile(
+    r"^(?:我|咱|俺)(?:的)?血型(?:是|为|：|:)?\s*(?P<value>.+)$", re.IGNORECASE
+)
+_HABIT_RE = re.compile(r"^(?:我|咱|俺)(?:一般|通常|习惯|每次|总是|经常)(?P<value>.+)$")
+_BOUNDARY_RE = re.compile(r"^(?:我|咱|俺)(?:不喜欢别人|讨厌别人|不希望)(?P<value>.+)$")
+_AVOID_RE = re.compile(r"^(?:请)?(?:别问我|不要问我|不想聊)(?P<value>.*)$")
+
+
+def _source_text(value: Any, limit: int = 1800) -> str:
+    if value is None:
+        return ""
+    source = str(value).replace("\r\n", "\n").replace("\r", "\n").replace("\u3000", " ")
+    source = re.sub(r"[\t\f\v ]+", " ", source)
+    source = re.sub(r" *\n *", "\n", source)
+    return source[:limit].strip()
+
+
+def _clean_text(value: Any, limit: int = 240) -> str:
+    text = "" if value is None else str(value)
+    text = re.sub(r"\s+", " ", text.replace("\u3000", " ")).strip()
+    return text[:limit]
+
+
+def _strip_matching_quotes(value: str) -> str:
+    text = value.strip()
+    changed = True
+    while changed and len(text) >= 2:
+        changed = False
+        for opening, closing in _QUOTE_PAIRS:
+            if text.startswith(opening) and text.endswith(closing):
+                text = text[len(opening) : len(text) - len(closing)].strip()
+                changed = True
+                break
+    return text
+
+
+def _clean_value(
+    value: Any,
+    *,
+    limit: int = 80,
+    strip_terminal_de: bool = False,
+    stop_at_colon: bool = False,
+    tail_particles: tuple[str, ...] = (),
+) -> str:
+    text = _clean_text(value, limit + 32).strip(_TRIM_CHARS)
+    if stop_at_colon:
+        text = re.split(r"[：:]", text, maxsplit=1)[0].rstrip()
+    text = _strip_matching_quotes(text)
+    changed = bool(tail_particles)
+    while changed and text:
+        changed = False
+        for particle in tail_particles:
+            if text.endswith(particle) and len(text) > len(particle):
+                text = text[: -len(particle)].rstrip()
+                changed = True
+                break
+    if strip_terminal_de and text.endswith("的") and len(text) > 1:
+        text = text[:-1].rstrip()
+    return _strip_matching_quotes(text.strip(_TRIM_CHARS))[:limit]
+
+
+def normalize_profile_value(value: Any) -> str:
+    """Return the canonical comparison value while preserving readable text."""
+    return re.sub(r"\s+", " ", _clean_value(value, limit=80).casefold()).strip()
+
+
+def _reported_prefix(prefix: str) -> bool:
+    compact = re.sub(r"\s+", "", prefix)
+    if not compact:
+        return False
+    return any(marker in compact for marker in _REPORT_MARKERS) or bool(
+        _REPORT_PREFIX_RE.search(compact)
+    )
+
+
+def _carries_report_context(sentence: str) -> bool:
+    compact = re.sub(r"\s+", "", sentence)
+    return _reported_prefix(compact) and compact.endswith(
+        (
+            "：",
+            ":",
+            "说",
+            "表示",
+            "提到",
+            "提及",
+            "描述",
+            "介绍",
+            "转述",
+            "原话",
+            "如下",
+            "内容",
+        )
+    )
+
+
+def _iter_clauses(source: str) -> Iterator[tuple[str, str, bool]]:
+    """Yield (clause, prior sentence prefix, is_question)."""
+    carried_prefix = ""
+    for sentence_match in re.finditer(
+        r"([^。.!！？?；;\n]+)([。.!！？?；;\n]*)", source
+    ):
+        sentence = sentence_match.group(1)
+        terminator = sentence_match.group(2)
+        for clause_match in re.finditer(r"[^，,]+", sentence):
+            raw_clause = clause_match.group(0).strip()
+            if not raw_clause:
+                continue
+            prefix = carried_prefix + sentence[: clause_match.start()]
+            clause = _LEADING_FILLER_RE.sub("", raw_clause).strip()
+            if clause:
+                yield clause, prefix, "?" in terminator or "？" in terminator
+        carried_prefix = sentence if _carries_report_context(sentence) else ""
+
+
+def _is_quoted_clause(clause: str) -> bool:
+    return bool(clause) and clause[0] in "“‘\"'「『"
+
+
+def _is_question(clause: str, sentence_is_question: bool) -> bool:
+    compact = re.sub(r"\s+", "", clause)
+    return (
+        sentence_is_question
+        or compact.endswith(("吗", "么"))
+        or bool(_QUESTION_WORD_RE.search(compact))
+    )
+
+
+def _valid_general_value(value: str, *, maximum: int = 40) -> bool:
+    if not value or len(value) > maximum:
+        return False
+    if _QUESTION_WORD_RE.search(value):
+        return False
+    return not any(mark in value for mark in ("\n", "\r"))
+
+
+def _candidate(
+    *,
+    dimension: str,
+    memory_type: str,
+    label: str,
+    kind: str,
+    value: str,
+    claim_summary: str,
+    score: float,
+    importance: float,
+) -> dict[str, Any]:
+    normalized = normalize_profile_value(value)
+    cardinality = (
+        "single"
+        if dimension
+        in {
+            "preferred_address",
+            "birthday",
+            "occupation",
+            "education",
+            "zodiac",
+            "blood_type",
+        }
+        else "multi"
+    )
+    return {
+        "memory_type": memory_type,
+        "label": label,
+        "kind": kind,
+        "profile_polarity": kind,
+        "dimension": dimension,
+        "profile_dimension": dimension,
+        "value": value,
+        "profile_value": value,
+        "normalized_value": normalized,
+        "profile_cardinality": cardinality,
+        "claim_summary": _clean_text(claim_summary, 180),
+        "extractor": RULE_EXTRACTOR,
+        "extraction_quality": "explicit",
+        "extraction_quality_score": round(max(0.0, min(1.0, score)), 3),
+        "evidence_strength": "direct_statement",
+        "profile_state": "active",
+        "status": "active",
+        "quality_gate_passed": True,
+        "confidence": round(max(0.0, min(1.0, score)), 3),
+        "importance": round(max(0.0, min(1.0, importance)), 3),
+    }
+
+
+def _address_from_clause(clause: str) -> dict[str, Any] | None:
+    compact = re.sub(r"\s+", "", clause)
+    if _ADDRESS_REJECT_RE.search(compact):
+        return None
+    for pattern in _ADDRESS_PATTERNS:
+        match = pattern.fullmatch(clause)
+        if not match:
+            continue
+        value = _clean_value(
+            match.group("value"),
+            limit=24,
+            stop_at_colon=True,
+            tail_particles=_TAIL_PARTICLES,
+        )
+        normalized = normalize_profile_value(value)
+        if not normalized or len(normalized) > 12:
+            return None
+        if _ADDRESS_ACTION_RE.search(normalized) or _ADDRESS_REJECT_RE.search(
+            normalized
+        ):
+            return None
+        return _candidate(
+            dimension="preferred_address",
+            memory_type="user_profile",
+            label="称呼",
+            kind="address",
+            value=value,
+            claim_summary=f"希望被称为 {value}",
+            score=0.97,
+            importance=0.74,
+        )
+    return None
+
+
+def extract_preferred_address(text: Any) -> dict[str, Any] | None:
+    """Extract one unambiguous direct address request or self-declaration."""
+    source = _source_text(text)
+    for clause, prefix, question in _iter_clauses(source):
+        if (
+            _reported_prefix(prefix)
+            or _is_quoted_clause(clause)
+            or _is_question(clause, question)
+        ):
+            continue
+        candidate = _address_from_clause(clause)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _match_value(
+    pattern: re.Pattern[str], clause: str, *, strip_terminal_de: bool = False
+) -> str:
+    match = pattern.fullmatch(clause)
+    if not match:
+        return ""
+    return _clean_value(
+        match.group("value"), limit=80, strip_terminal_de=strip_terminal_de
+    )
+
+
+def _non_address_candidates(clause: str) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    if _UNCERTAIN_RE.search(clause):
+        return results
+    transient_context = bool(
+        _TEMPORARY_RE.search(clause) or _ONE_OFF_CONTEXT_RE.search(clause)
+    )
+
+    value = _match_value(_DISLIKE_RE, clause)
+    if _valid_general_value(value) and not transient_context:
+        results.append(
+            _candidate(
+                dimension="preference",
+                memory_type="user_preference",
+                label="不喜欢",
+                kind="dislike",
+                value=value,
+                claim_summary=f"不喜欢 {value}",
+                score=0.93,
+                importance=0.66,
+            )
+        )
+        return results
+
+    value = _match_value(_LIKE_RE, clause)
+    if _valid_general_value(value) and not transient_context:
+        results.append(
+            _candidate(
+                dimension="preference",
+                memory_type="user_preference",
+                label="喜欢",
+                kind="like",
+                value=value,
+                claim_summary=f"喜欢 {value}",
+                score=0.93,
+                importance=0.66,
+            )
+        )
+        return results
+
+    value = _match_value(_ALLERGY_RE, clause) or _match_value(_CANNOT_EAT_RE, clause)
+    if _valid_general_value(value, maximum=30) and not transient_context:
+        results.append(
+            _candidate(
+                dimension="dietary_restriction",
+                memory_type="user_preference",
+                label="过敏/禁忌",
+                kind="avoid",
+                value=value,
+                claim_summary=f"饮食禁忌：{value}",
+                score=0.96,
+                importance=0.82,
+            )
+        )
+        return results
+
+    value = _match_value(_BIRTHDAY_RE, clause)
+    birthday_like = bool(
+        re.search(r"(?:月|日|号|年|/|\d|一|二|三|四|五|六|七|八|九|十)", value)
+    )
+    if (
+        _valid_general_value(value, maximum=20)
+        and birthday_like
+        and not _TEMPORARY_RE.search(value)
+    ):
+        results.append(
+            _candidate(
+                dimension="birthday",
+                memory_type="user_profile",
+                label="生日",
+                kind="birthday",
+                value=value,
+                claim_summary=f"生日是 {value}",
+                score=0.96,
+                importance=0.76,
+            )
+        )
+        return results
+
+    for pattern in _OCCUPATION_PATTERNS:
+        value = _match_value(pattern, clause, strip_terminal_de=True)
+        if _valid_general_value(value) and not _TEMPORARY_RE.search(clause):
+            results.append(
+                _candidate(
+                    dimension="occupation",
+                    memory_type="user_profile",
+                    label="职业",
+                    kind="occupation",
+                    value=value,
+                    claim_summary=f"职业是 {value}",
+                    score=0.92,
+                    importance=0.7,
+                )
+            )
+            return results
+
+    for pattern in _EDUCATION_PATTERNS:
+        value = _match_value(pattern, clause, strip_terminal_de=True)
+        if _valid_general_value(value) and not _TEMPORARY_RE.search(clause):
+            results.append(
+                _candidate(
+                    dimension="education",
+                    memory_type="user_profile",
+                    label="专业/学业",
+                    kind="education",
+                    value=value,
+                    claim_summary=f"专业/学业是 {value}",
+                    score=0.91,
+                    importance=0.68,
+                )
+            )
+            return results
+
+    value = _match_value(_ZODIAC_RE, clause, strip_terminal_de=True)
+    if value.endswith("座"):
+        value = value[:-1].rstrip()
+    if _valid_general_value(value, maximum=12):
+        results.append(
+            _candidate(
+                dimension="zodiac",
+                memory_type="user_profile",
+                label="星座",
+                kind="zodiac",
+                value=value,
+                claim_summary=f"星座是 {value}",
+                score=0.94,
+                importance=0.64,
+            )
+        )
+        return results
+
+    value = _match_value(_BLOOD_TYPE_RE, clause, strip_terminal_de=True)
+    if _valid_general_value(value, maximum=12):
+        results.append(
+            _candidate(
+                dimension="blood_type",
+                memory_type="user_profile",
+                label="血型",
+                kind="blood_type",
+                value=value,
+                claim_summary=f"血型是 {value}",
+                score=0.94,
+                importance=0.7,
+            )
+        )
+        return results
+
+    value = _match_value(_HABIT_RE, clause)
+    if _valid_general_value(value) and not _TEMPORARY_RE.search(clause):
+        results.append(
+            _candidate(
+                dimension="communication_preference",
+                memory_type="user_habit",
+                label="习惯",
+                kind="habit",
+                value=value,
+                claim_summary=f"沟通习惯：{value}",
+                score=0.88,
+                importance=0.61,
+            )
+        )
+        return results
+
+    value = _match_value(_BOUNDARY_RE, clause)
+    if _valid_general_value(value) and not transient_context:
+        results.append(
+            _candidate(
+                dimension="boundary",
+                memory_type="user_preference",
+                label="边界",
+                kind="avoid",
+                value=value,
+                claim_summary=f"边界：{value}",
+                score=0.94,
+                importance=0.75,
+            )
+        )
+        return results
+
+    avoid_match = _AVOID_RE.fullmatch(clause)
+    if avoid_match:
+        value = _clean_value(avoid_match.group("value"), limit=40)
+        if (not value or _valid_general_value(value)) and not transient_context:
+            summary = f"不希望聊 {value}" if value else "有明确不想聊的内容"
+            results.append(
+                _candidate(
+                    dimension="boundary",
+                    memory_type="user_preference",
+                    label="雷区",
+                    kind="avoid",
+                    value=value or "未指明话题",
+                    claim_summary=summary,
+                    score=0.94,
+                    importance=0.75,
+                )
+            )
+    return results
+
+
+def extract_profile_candidates(text: Any) -> list[dict[str, Any]]:
+    """Extract explicit, self-attributed stable profile candidates.
+
+    Rejected, reported, quoted, temporary, and interrogative statements are not
+    returned.  Their source message remains available to the ordinary timeline.
+    """
+    source = _source_text(text)
+    if not source:
+        return []
+    results: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for clause, prefix, question in _iter_clauses(source):
+        if (
+            _reported_prefix(prefix)
+            or _is_quoted_clause(clause)
+            or _is_question(clause, question)
+        ):
+            continue
+        candidates: list[dict[str, Any]] = []
+        address = _address_from_clause(clause)
+        if address is not None:
+            candidates.append(address)
+        else:
+            candidates.extend(_non_address_candidates(clause))
+        for candidate in candidates:
+            key = (
+                str(candidate["profile_dimension"]),
+                str(candidate["kind"]),
+                str(candidate["normalized_value"]),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            results.append(candidate)
+    return results
+
+
+def profile_rejection_reason(text: Any) -> str:
+    """Classify profile-like text rejected before the write gate.
+
+    This is intentionally diagnostic-only. It never creates a candidate and
+    therefore cannot weaken the extraction policy.
+    """
+    source = _source_text(text)
+    if not source or extract_profile_candidates(source):
+        return ""
+    compact = re.sub(r"\s+", "", source)
+    if not _PROFILE_ATTEMPT_RE.search(compact):
+        return ""
+    address_attempt = bool(re.search(r"(?:叫我|喊我|称呼我)", compact))
+    if address_attempt and _ADDRESS_ACTION_RE.search(compact):
+        return "action_context"
+    if _reported_prefix(compact) or any(
+        marker in compact for marker in _REPORT_MARKERS
+    ):
+        return "third_party_statement"
+    return "profile_quality_rejected"
+
+
+def profile_candidate_metadata(
+    candidate: Any, *, source_memory_id: str = ""
+) -> dict[str, Any]:
+    payload = candidate if isinstance(candidate, dict) else {}
+    return {
+        "extractor": RULE_EXTRACTOR,
+        "profile_dimension": _clean_text(
+            payload.get("profile_dimension") or payload.get("dimension"), 80
+        ),
+        "profile_value": _clean_text(
+            payload.get("profile_value") or payload.get("value"), 80
+        ),
+        "normalized_value": normalize_profile_value(
+            payload.get("normalized_value")
+            or payload.get("profile_value")
+            or payload.get("value")
+        ),
+        "profile_polarity": _clean_text(payload.get("kind"), 40),
+        "profile_cardinality": _clean_text(payload.get("profile_cardinality"), 16)
+        or "multi",
+        "extraction_quality": _clean_text(payload.get("extraction_quality"), 40)
+        or "explicit",
+        "extraction_quality_score": float(
+            payload.get("extraction_quality_score") or 0.0
+        ),
+        "evidence_strength": _clean_text(payload.get("evidence_strength"), 40)
+        or "direct_statement",
+        "profile_state": _clean_text(payload.get("profile_state"), 40) or "candidate",
+        "quality_gate_passed": bool(payload.get("quality_gate_passed")),
+        "source_memory_id": _clean_text(source_memory_id, 120),
+    }
+
+
+def _memory_and_metadata(value: Any) -> tuple[str, dict[str, Any]]:
+    if isinstance(value, dict):
+        nested = value.get("metadata")
+        if isinstance(nested, dict):
+            return _clean_text(value.get("memory_type"), 80), nested
+        return _clean_text(value.get("memory_type"), 80), value
+    metadata = getattr(value, "metadata", None)
+    return _clean_text(getattr(value, "memory_type", ""), 80), metadata if isinstance(
+        metadata, dict
+    ) else {}
+
+
+def profile_quality_decision(
+    memory_or_metadata: Any, *, require_active: bool = True
+) -> tuple[bool, str]:
+    """Validate rule-produced profile metadata while preserving manual records."""
+    memory_type, metadata = _memory_and_metadata(memory_or_metadata)
+    extractor = _clean_text(metadata.get("extractor"), 80).lower()
+    producer_kind = _clean_text(metadata.get("producer_kind"), 80).lower()
+    has_rule_metadata = any(
+        key in metadata
+        for key in (
+            "profile_state",
+            "profile_dimension",
+            "profile_value",
+            "normalized_value",
+            "extraction_quality",
+            "extraction_quality_score",
+            "evidence_strength",
+        )
+    )
+    rule_source = extractor.startswith("rule_") or producer_kind.startswith("rule_")
+    is_rule_profile = rule_source and (
+        memory_type in PROFILE_MEMORY_TYPES or has_rule_metadata
+    )
+    if not is_rule_profile:
+        return True, "profile_quality_compatible"
+
+    state = _clean_text(
+        metadata.get("profile_state") or metadata.get("status"), 40
+    ).lower()
+    if not state:
+        return False, "profile_state_missing"
+    if state == "pending":
+        return False, f"profile_state_{state}"
+    if state in {"rejected", "superseded", "archived"}:
+        return False, f"profile_state_{state}"
+    if state not in PROFILE_STATES:
+        return False, "profile_state_invalid"
+    if require_active and state != "active":
+        return False, f"profile_state_{state}"
+
+    dimension = _clean_text(
+        metadata.get("profile_dimension") or metadata.get("dimension"), 80
+    )
+    value = _clean_text(metadata.get("profile_value") or metadata.get("value"), 80)
+    normalized = normalize_profile_value(metadata.get("normalized_value"))
+    if not dimension:
+        return False, "profile_dimension_missing"
+    if not value:
+        return False, "profile_value_missing"
+    if not normalized:
+        return False, "profile_normalized_value_missing"
+    if normalized != normalize_profile_value(value):
+        return False, "profile_normalized_value_mismatch"
+    try:
+        score = float(metadata.get("extraction_quality_score"))
+    except (TypeError, ValueError):
+        return False, "profile_quality_score_missing"
+    if not math.isfinite(score) or score < 0.75 or score > 1.0:
+        return False, "profile_quality_rejected"
+    quality = _clean_text(metadata.get("extraction_quality"), 40).lower()
+    if quality not in {"explicit", "confirmed", "corroborated", "inferred"}:
+        return False, "profile_extraction_quality_missing"
+    evidence = _clean_text(metadata.get("evidence_strength"), 60).lower()
+    if evidence not in {
+        "direct_statement",
+        "user_confirmed",
+        "multiple_independent_evidence",
+        "independent_evidence",
+    }:
+        return False, "profile_evidence_missing"
+    if quality == "inferred":
+        try:
+            evidence_count = int(
+                metadata.get("independent_evidence_count")
+                or metadata.get("evidence_count")
+                or 0
+            )
+        except (TypeError, ValueError):
+            evidence_count = 0
+        if evidence_count < 2 and evidence not in {
+            "user_confirmed",
+            "multiple_independent_evidence",
+        }:
+            return False, "profile_evidence_insufficient"
+    if not bool(metadata.get("quality_gate_passed", True)):
+        return False, "profile_quality_rejected"
+    return True, "profile_quality_passed"
+
+
+__all__ = [
+    "PROFILE_MEMORY_TYPES",
+    "PROFILE_STATES",
+    "RULE_EXTRACTOR",
+    "extract_preferred_address",
+    "extract_profile_candidates",
+    "normalize_profile_value",
+    "profile_candidate_metadata",
+    "profile_quality_decision",
+    "profile_rejection_reason",
+]

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from .identity import session_target_id
 from .models import MemoryRecord, SearchResult, SessionContext, clean_text
+from .profile_quality import PROFILE_MEMORY_TYPES, profile_quality_decision
+
 from .store import MemoryStore
 from .time_intent import TimeIntent
 from .visibility import VisibilityPolicy
@@ -243,6 +245,23 @@ class RetrievalEngine:
         ranked, blocked = await self._rank_candidates(query, ctx, time_intent=time_intent)
         total = max(1, int(total_limit or 1))
         ranked = await self._maybe_rerank_results(query, ranked, total)
+        allow_profile_fallback = self._query_allows_profile_fallback(query)
+        block_profile_retrieval = self._query_blocks_profile_retrieval(query)
+
+        def selectable_for_slot(item: SearchResult, slot: str) -> bool:
+            if slot != "user_profile":
+                return True
+            memory_type = clean_text(
+                getattr(item.memory, "memory_type", ""), 80
+            ).lower()
+            if memory_type in PROFILE_MEMORY_TYPES and block_profile_retrieval:
+                return False
+            if allow_profile_fallback:
+                return True
+            return (
+                memory_type not in PROFILE_MEMORY_TYPES
+                or self._profile_result_has_relevance(item)
+            )
         enforced_caps = {clean_text(slot, 60) for slot in (capped_slots or set()) if clean_text(slot, 60)}
         slot_order = [
             "open_loop",
@@ -271,6 +290,7 @@ class RetrievalEngine:
                     for candidate in ranked
                     if candidate.memory.id not in selected_ids
                     and self._slot_for_memory(candidate.memory, ctx) == slot
+                    and selectable_for_slot(candidate, slot)
                 ),
                 None,
             )
@@ -292,6 +312,8 @@ class RetrievalEngine:
                     continue
                 if self._slot_for_memory(item.memory, ctx) != slot:
                     continue
+                if not selectable_for_slot(item, slot):
+                    continue
                 item.reason = self._with_slot_reason(item.reason, slot)
                 slot_map[slot].append(item)
                 selected.append(item)
@@ -307,6 +329,8 @@ class RetrievalEngine:
                 if item.memory.id in selected_ids:
                     continue
                 slot = self._slot_for_memory(item.memory, ctx)
+                if not selectable_for_slot(item, slot):
+                    continue
                 slot_limit = max(0, int(slot_limits.get(slot, 0) or 0))
                 if slot_limit <= 0:
                     continue
@@ -1068,10 +1092,22 @@ class RetrievalEngine:
         searchable: list[tuple[MemoryRecord, str]] = []
         prefiltered: dict[str, int] = {}
         time_filtered = 0
+        block_profile_retrieval = self._query_blocks_profile_retrieval(query)
         for memory in candidates:
-            visibility_reason, prefilter_reason = self._search_visibility_reason(memory, ctx, acl_state)
+            memory_type = clean_text(getattr(memory, "memory_type", ""), 80).lower()
+            visibility_reason, prefilter_reason = self._search_visibility_reason(
+                memory, ctx, acl_state
+            )
             if visibility_reason:
-                if time_intent is not None and time_intent.active and not self._memory_overlaps_time_window(memory, time_intent):
+                if memory_type in PROFILE_MEMORY_TYPES and block_profile_retrieval:
+                    reason = "profile_intent_not_requested"
+                    prefiltered[reason] = prefiltered.get(reason, 0) + 1
+                    continue
+                if (
+                    time_intent is not None
+                    and time_intent.active
+                    and not self._memory_overlaps_time_window(memory, time_intent)
+                ):
                     time_filtered += 1
                     continue
                 searchable.append((memory, visibility_reason))
@@ -1736,6 +1772,9 @@ class RetrievalEngine:
         ctx: SessionContext,
         acl_state: dict[str, object],
     ) -> tuple[str, str]:
+        quality_allowed, quality_reason = self._profile_retrieval_decision(memory)
+        if not quality_allowed:
+            return "", quality_reason
         visible, visibility_reason = self.policy.is_visible(memory, ctx)
         acl_deny_reason = self._acl_deny_reason(memory, ctx, acl_state)
         if visible:
@@ -1749,6 +1788,296 @@ class RetrievalEngine:
             return acl_reason, ""
         privacy_reason = self._acl_privacy_guard_reason(memory, ctx, visibility_reason, acl_state)
         return "", privacy_reason or visibility_reason
+
+    @staticmethod
+    def _profile_retrieval_decision(memory: MemoryRecord) -> tuple[bool, str]:
+        """Keep inactive and low-quality profile candidates out of every route."""
+        memory_type = clean_text(getattr(memory, "memory_type", ""), 80).lower()
+        metadata = memory.metadata if isinstance(memory.metadata, dict) else {}
+        profile_state = clean_text(metadata.get("profile_state"), 40).lower()
+        review_status = clean_text(getattr(memory, "review_status", ""), 40).lower()
+        lifecycle = clean_text(getattr(memory, "lifecycle", ""), 40).lower()
+        is_profile = memory_type in PROFILE_MEMORY_TYPES or bool(profile_state)
+        if is_profile and review_status in {"pending", "rejected"}:
+            return False, f"profile_review_{review_status}"
+        if is_profile and lifecycle == "archived":
+            return False, "profile_state_archived"
+        if profile_state in {
+            "candidate",
+            "pending",
+            "rejected",
+            "superseded",
+            "archived",
+        }:
+            return False, f"profile_state_{profile_state}"
+        allowed, reason = profile_quality_decision(memory, require_active=True)
+        if not allowed:
+            return False, reason
+        return True, "profile_quality_compatible"
+
+    def _query_allows_profile_fallback(self, query: str) -> bool:
+        """Reserve a profile slot without lexical evidence only for profile intent."""
+        text = clean_text(query, 1000)
+        compact = re.sub(r"[\s，。！？!?,.、~～…]+", "", text).lower()
+        return bool(
+            compact
+            and not self._looks_like_current_task_query(compact)
+            and self._looks_like_explicit_profile_query(text)
+        )
+
+    def _query_blocks_profile_retrieval(self, query: str) -> bool:
+        """Block portrait retrieval for greetings, current state, and empty queries."""
+        text = clean_text(query, 1000)
+        compact = re.sub(r"[\s，。！？!?,.、~～…]+", "", text).lower()
+        if not compact:
+            return True
+        if self._looks_like_current_state_query(compact):
+            return True
+        if self._query_allows_profile_fallback(text):
+            return False
+        greetings = {
+            "你好",
+            "您好",
+            "嗨",
+            "哈喽",
+            "hello",
+            "hi",
+            "早",
+            "早安",
+            "早上好",
+            "午安",
+            "晚上好",
+            "晚安",
+            "在吗",
+            "在不在",
+            "最近好吗",
+            "你好吗",
+        }
+        greeting_base = re.sub(r"(?:呀|啊|哈|哦|喔|哟|啦|呢|诶|欸)+$", "", compact)
+        if compact in greetings or greeting_base in greetings:
+            return True
+        return not bool(self._terms(text))
+
+    def _profile_result_has_relevance(self, item: SearchResult) -> bool:
+        reason = clean_text(getattr(item, "reason", ""), 1600).lower()
+        if re.search(r"(?:^|;)(?:exact|profile)=1(?:;|$)", reason):
+            return True
+        hits = re.search(r"(?:^|;)hits=(\d+)", reason)
+        if hits and int(hits.group(1)) > 0:
+            return True
+        vector = re.search(r"(?:^|;)vector=([0-9.]+)", reason)
+        if vector:
+            try:
+                return float(vector.group(1)) >= self.embedding_score_threshold
+            except ValueError:
+                return False
+        return False
+
+    @staticmethod
+    def _looks_like_explicit_profile_query(text: str) -> bool:
+        source = clean_text(text, 1000).lower()
+        compact = re.sub(r"\s+", "", source)
+        if not compact:
+            return False
+        chinese_markers = (
+            "我的称呼",
+            "称呼我",
+            "怎么叫我",
+            "如何叫我",
+            "该叫我",
+            "喊我什么",
+            "我叫什么",
+            "我的名字",
+            "我的姓名",
+            "我的昵称",
+            "我的职业",
+            "我做什么工作",
+            "我从事什么工作",
+            "我是做什么的",
+            "我的生日",
+            "我的出生",
+            "我的偏好",
+            "我喜欢什么",
+            "我讨厌什么",
+            "我的爱好",
+            "我的习惯",
+            "我的专业",
+            "我的学业",
+            "我的星座",
+            "我的血型",
+            "我的禁忌",
+            "我的忌口",
+            "我对什么过敏",
+            "我不能吃什么",
+            "我的沟通习惯",
+            "我的边界",
+            "我的雷区",
+            "我不想聊什么",
+            "我的资料",
+            "我的画像",
+        )
+        english_patterns = (
+            r"\bmy\s+(?:name|nickname|birthday|occupation|job|profession|"
+            r"preferences?|favorites?|favourites?|habits?|profile|major|"
+            r"education|zodiac|blood\s+type|allerg(?:y|ies)|boundary)\b",
+            r"\bcall\s+me\b",
+            r"\babout\s+me\b",
+            r"\b(?:myname|mynickname|mybirthday|myoccupation|myjob|"
+            r"myprofession|mypreference|myfavorite|myfavourite|myhabit|"
+            r"myprofile|mymajor|myeducation|myzodiac|mybloodtype|"
+            r"myallergy|myboundary|callme|aboutme)\b",
+        )
+        if any(marker in compact for marker in chinese_markers) or any(
+            re.search(pattern, source) for pattern in english_patterns
+        ):
+            return True
+        occupation_patterns = (
+            r"(?:你(?:还)?记得)?我的(?:工作岗位|职位|职务)(?:是)?(?:什么|啥|哪(?:一)?个)?",
+            r"(?:你(?:还)?记得)?我(?:现在|目前)?是做什么工作的?",
+        )
+        general_profile_patterns = (
+            r"关于我的(?:资料|画像|个人信息|基本信息)",
+            r"(?:关于我|你(?:还)?记得我)(?:你)?(?:记得|知道|了解)(?:什么|哪些)",
+        )
+        return any(
+            re.search(pattern, compact)
+            for pattern in (*occupation_patterns, *general_profile_patterns)
+        )
+
+    @staticmethod
+    def _looks_like_current_task_query(text: str) -> bool:
+        """Identify task/project context that must not be treated as a profile query."""
+        compact = re.sub(r"\s+", "", clean_text(text, 1000)).lower()
+        if not compact:
+            return False
+        explicit_task_markers = (
+            "工作安排",
+            "工作进度",
+            "工作计划",
+            "工作任务",
+            "项目安排",
+            "项目进度",
+            "项目计划",
+            "项目任务",
+            "学业进度",
+            "学习进度",
+            "课程进度",
+            "作业进度",
+            "我们的项目",
+            "我们的工作",
+            "待办",
+            "日程",
+            "排班",
+            "工单",
+        )
+        if any(marker in compact for marker in explicit_task_markers):
+            return True
+        english_context_markers = (
+            "job",
+            "work",
+            "project",
+            "task",
+            "meeting",
+            "schedule",
+            "agenda",
+        )
+        english_state_markers = (
+            "progress",
+            "plan",
+            "status",
+            "assignment",
+            "deadline",
+        )
+        if any(marker in compact for marker in english_context_markers) and any(
+            marker in compact for marker in english_state_markers
+        ):
+            return True
+        temporal_markers = (
+            "今天",
+            "今日",
+            "现在",
+            "当前",
+            "这次",
+            "本周",
+            "这周",
+            "最近",
+        )
+        task_markers = ("工作", "任务", "项目", "计划", "安排", "进度", "日程")
+        return any(marker in compact for marker in temporal_markers) and any(
+            marker in compact for marker in task_markers
+        )
+
+    @staticmethod
+    def _profile_query_matches_memory(query: str, memory: MemoryRecord) -> bool:
+        memory_type = clean_text(getattr(memory, "memory_type", ""), 80).lower()
+        if memory_type not in PROFILE_MEMORY_TYPES:
+            return False
+        source = clean_text(query, 1000).lower()
+        if not RetrievalEngine._looks_like_explicit_profile_query(source):
+            return False
+        compact = re.sub(
+            r"[\s，。！？!?,.、~～…]+", "", source
+        )
+        if not compact:
+            return False
+        if any(
+            marker in compact
+            for marker in ("我的画像", "我的资料", "myprofile", "aboutme")
+        ) or re.search(r"关于我的(?:资料|画像|个人信息|基本信息)", compact):
+            return True
+        metadata = memory.metadata if isinstance(memory.metadata, dict) else {}
+        dimension = clean_text(metadata.get("profile_dimension"), 80).lower()
+        aliases = {
+            "preferred_address": (
+                "我的称呼",
+                "称呼我",
+                "怎么叫我",
+                "如何叫我",
+                "该叫我",
+                "喊我什么",
+                "我叫什么",
+                "我的昵称",
+                "callme",
+                "myname",
+                "mynickname",
+            ),
+            "birthday": ("我的生日", "我的出生", "mybirthday"),
+            "occupation": (
+                "我的职业",
+                "我做什么工作",
+                "我从事什么工作",
+                "我是做什么的",
+                "我的工作岗位",
+                "我的职位",
+                "我的职务",
+                "myoccupation",
+                "myjob",
+                "myprofession",
+            ),
+            "education": ("我的专业", "我的学业", "mymajor", "myeducation"),
+            "zodiac": ("我的星座", "myzodiac"),
+            "blood_type": ("我的血型", "mybloodtype"),
+            "preference": (
+                "我的偏好",
+                "我喜欢什么",
+                "我讨厌什么",
+                "我的爱好",
+                "mypreference",
+                "myfavorite",
+                "myfavourite",
+            ),
+            "dietary_restriction": (
+                "我的禁忌",
+                "我的忌口",
+                "我对什么过敏",
+                "我不能吃什么",
+                "myallergy",
+            ),
+            "communication_preference": ("我的习惯", "我的沟通习惯", "myhabit"),
+            "habit": ("我的习惯", "myhabit"),
+            "boundary": ("我的边界", "我的雷区", "我不想聊什么", "myboundary"),
+        }
+        return any(marker in compact for marker in aliases.get(dimension, ()))
 
     def _prefilter_summary_reason(self, prefiltered: dict[str, int]) -> str:
         total = sum(max(0, int(count or 0)) for count in prefiltered.values())
@@ -1798,6 +2127,7 @@ class RetrievalEngine:
             in {
                 "user_profile",
                 "user_preference",
+                "user_habit",
                 "relationship_claim",
                 "explicit_memory",
                 "manual_memory",
@@ -2052,6 +2382,7 @@ class RetrievalEngine:
         elif len(terms) >= 4:
             min_hits = 2
         return {
+            "query_text": compact,
             "exact_phrases": exact_phrases,
             "min_hits": min_hits,
             "contextual_recall": contextual_recall,
@@ -2289,12 +2620,18 @@ class RetrievalEngine:
         metadata_text_parts = [
             metadata.get("canonical_summary", ""),
             metadata.get("persona_summary", ""),
+            metadata.get("profile_dimension", ""),
+            metadata.get("profile_value", ""),
+            metadata.get("normalized_value", ""),
             " ".join(str(item) for item in metadata.get("key_facts", []) if item)
-            if isinstance(metadata.get("key_facts"), list) else "",
+            if isinstance(metadata.get("key_facts"), list)
+            else "",
             " ".join(str(item) for item in metadata.get("topics", []) if item)
-            if isinstance(metadata.get("topics"), list) else "",
+            if isinstance(metadata.get("topics"), list)
+            else "",
             " ".join(str(item) for item in metadata.get("participants", []) if item)
-            if isinstance(metadata.get("participants"), list) else "",
+            if isinstance(metadata.get("participants"), list)
+            else "",
         ]
         return " ".join(
             [
@@ -2325,9 +2662,19 @@ class RetrievalEngine:
         term_hits = sum(1 for term in terms if term and term in haystack)
         exact_phrases = [str(item) for item in profile.get("exact_phrases", []) if str(item)]
         exact_hit = any(phrase in compact_haystack for phrase in exact_phrases)
+        profile_hit = self._profile_query_matches_memory(
+            str(profile.get("query_text") or " ".join(terms)),
+            memory,
+        )
         min_hits = int(profile.get("min_hits", 1) or 1)
         vector_relevant = vector_score >= self.embedding_score_threshold if self.embedding_enabled else False
-        if terms and not exact_hit and term_hits < min_hits and not vector_relevant:
+        if (
+            terms
+            and not exact_hit
+            and not profile_hit
+            and term_hits < min_hits
+            and not vector_relevant
+        ):
             return 0.0, f"keyword_hit_too_weak hits={term_hits}/{min_hits}"
         graph_guard_reason = self._livingmemory_graph_relevance_guard(memory, term_hits, exact_hit, min_hits)
         if graph_guard_reason and vector_score < min(0.98, self.embedding_score_threshold + 0.12):
@@ -2342,7 +2689,9 @@ class RetrievalEngine:
                     continue
                 idf = term_stats.get(term, 0.0)
                 bm25 += idf * ((freq * 2.2) / (freq + 1.2))
-            lexical = (0.42 if exact_hit else 0.24) + min(0.72, bm25 * 0.18)
+            lexical = (0.42 if exact_hit or profile_hit else 0.24) + min(
+                0.72, bm25 * 0.18
+            )
         else:
             lexical = 0.0
 
@@ -2370,7 +2719,7 @@ class RetrievalEngine:
         if not terms:
             score = scope_bonus + memory.importance * 0.8 + age_bonus + vector_bonus + persona_bonus + dynamics_bonus
         return score, (
-            f"hits={term_hits};exact={int(exact_hit)};bm25={bm25:.2f};"
+            f"hits={term_hits};exact={int(exact_hit)};profile={int(profile_hit)};bm25={bm25:.2f};"
             f"vector={vector_score:.3f};importance={memory.importance:.2f};"
             f"persona={persona_bonus:.2f};dynamics={dynamics_bonus:.2f};recency={age_bonus:.2f}"
         )

--- a/core/service.py
+++ b/core/service.py
@@ -89,6 +89,10 @@ USER_MEMORY_SUMMARY_VERSION = "memory.user_memory_summary.v1"
 _USER_MEMORY_PROFILE_TYPES = frozenset({"user_profile", "user_habit", "manual_memory"})
 _USER_MEMORY_PREFERENCE_TYPES = frozenset({"user_preference"})
 _USER_MEMORY_RELATIONSHIP_TYPES = frozenset({"relationship_claim", "relationship_phase_summary"})
+_RULE_PROFILE_MEMORY_TYPES = frozenset(
+    {"user_profile", "user_preference", "user_habit"}
+)
+
 _USER_MEMORY_CONVERSATION_TYPES = frozenset(
     {"conversation_event", "conversation_summary", "important_event", "memory_decay_summary", "self_action"}
 )
@@ -493,6 +497,96 @@ class MemoryCompanionService:
             rebind["embeddings_scheduled"] = embeddings_scheduled
         return result
 
+    @staticmethod
+    def _prepare_rule_profile_write(record: MemoryRecord) -> tuple[str, str]:
+        """Return (write mode, reason) and normalize rule profile state in place."""
+        metadata = dict(record.metadata) if isinstance(record.metadata, dict) else {}
+        extractor = clean_text(metadata.get("extractor"), 40).lower()
+        if (
+            record.memory_type not in _RULE_PROFILE_MEMORY_TYPES
+            or not extractor.startswith("rule_")
+        ):
+            return "generic", "not_rule_profile"
+
+        rejection_reason = clean_text(
+            metadata.get("rejection_reason")
+            or metadata.get("profile_rejection_reason")
+            or metadata.get("quality_rejection_reason"),
+            120,
+        )
+        if rejection_reason or metadata.get("quality_gate_passed") is False:
+            return "reject", rejection_reason or "profile_quality_rejected"
+
+        dimension = clean_text(metadata.get("profile_dimension"), 80).lower()
+        value = clean_text(metadata.get("profile_value"), 240)
+        normalized = clean_text(metadata.get("normalized_value"), 240)
+        try:
+            quality_score = float(metadata.get("extraction_quality_score"))
+        except (TypeError, ValueError):
+            quality_score = -1.0
+        if (
+            not dimension
+            or not value
+            or not normalized
+            or not 0.0 <= quality_score <= 1.0
+        ):
+            return "reject", "profile_candidate_metadata_missing"
+        if extractor not in MemoryStore.PROFILE_RULE_EXTRACTORS:
+            return "reject", "profile_extractor_unsupported"
+
+        extraction_quality = clean_text(metadata.get("extraction_quality"), 40).lower()
+        evidence_strength = clean_text(metadata.get("evidence_strength"), 40).lower()
+        requested_state = clean_text(
+            metadata.get("profile_state") or metadata.get("profile_status"),
+            32,
+        ).lower()
+        explicit_active = bool(
+            requested_state == "active"
+            and extraction_quality == "explicit"
+            and evidence_strength == "direct_statement"
+            and quality_score >= 0.8
+        )
+        next_state = "active" if explicit_active else "candidate"
+        try:
+            configured_evidence_count = int(
+                metadata.get("required_evidence_count") or 2
+            )
+        except (TypeError, ValueError):
+            configured_evidence_count = 2
+        metadata["extractor"] = extractor
+        metadata["profile_dimension"] = dimension
+        metadata["profile_value"] = value
+        metadata["normalized_value"] = normalized
+        metadata["profile_state"] = next_state
+        metadata["profile_status"] = next_state
+        metadata["quality_gate_passed"] = True
+        metadata["required_evidence_count"] = (
+            1 if explicit_active else max(2, min(10, configured_evidence_count))
+        )
+        record.metadata = metadata
+        record.confidence = quality_score
+        record.lifecycle = "stable_memory" if explicit_active else "raw_event"
+        record.review_status = "auto" if explicit_active else "pending"
+        if not explicit_active:
+            record.importance = min(float(record.importance or 0.3), 0.55)
+        return "profile", next_state
+
+    @staticmethod
+    def _log_profile_write_gate(
+        record: MemoryRecord, *, decision: str, reason: str
+    ) -> None:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        logger.info(
+            "[MemoryCompanion] 画像写入门禁: decision=%s reason=%s type=%s dimension=%s "
+            "subject=%s source=%s",
+            clean_text(decision, 40),
+            clean_text(reason, 120),
+            clean_text(record.memory_type, 80),
+            clean_text(metadata.get("profile_dimension"), 80),
+            clean_text(record.subject.id, 120),
+            clean_text(metadata.get("source_memory_id"), 160),
+        )
+
     async def handle_llm_request(self, event: Any, req: Any) -> None:
         if bool(getattr(event, "private_companion_req036_denied", False)):
             # Companion owns the fixed-reply branch. Do not resolve identity,
@@ -544,8 +638,8 @@ class MemoryCompanionService:
         record = self.classifier.from_user_message(ctx)
         if not record:
             return
-        memory_id = ""
-        if not await self._timeline_already_has_message(ctx, "user_message"):
+        memory_id = await self._existing_timeline_message_id(ctx, "user_message")
+        if not memory_id:
             event_metadata = {
                 "memory_id": memory_id,
                 "sender_name": ctx.user_name,
@@ -556,26 +650,83 @@ class MemoryCompanionService:
             event_metadata.update(self._cross_window_event_metadata(ctx))
             event_metadata.update(self._reply_chain_metadata(reply_chain))
             if ctx.scope == "group":
-                event_metadata.update(await self._conversation_memory_metadata(ctx, source="llm_request"))
-            await self.store.add_timeline_event(
+                event_metadata.update(
+                    await self._conversation_memory_metadata(ctx, source="llm_request")
+                )
+            memory_id = await self.store.add_timeline_event(
                 event_type="user_message",
                 session_id=ctx.session_id,
                 scope=ctx.scope,
                 subject_id=ctx.user_id,
                 object_id=ctx.current_target_id,
-                content=self._timeline_content_with_reply_chain(ctx.message_text, reply_chain),
+                content=self._timeline_content_with_reply_chain(
+                    ctx.message_text, reply_chain
+                ),
                 metadata=event_metadata,
             )
         if self.config.bool("memory_capture.record_relationship_edges", True):
             await self.note_relationships(ctx, source_memory_id=memory_id)
         if self.config.bool("memory_capture.extract_stable_facts", True):
-            for derived in self.classifier.derived_user_memories(ctx, source_memory_id=memory_id):
-                derived.id = self.stable_id("derived", derived.memory_type, ctx.session_id, derived.content)
+            derived_memories = self.classifier.derived_user_memories(
+                ctx,
+                source_memory_id=memory_id,
+            )
+            if not any(
+                clean_text((item.metadata or {}).get("profile_dimension"), 80)
+                for item in derived_memories
+            ):
+                rejection_reason = self.classifier.profile_rejection_reason(
+                    ctx.message_text
+                )
+                if rejection_reason:
+                    logger.info(
+                        "[MemoryCompanion] 画像写入门禁: decision=rejected "
+                        "reason=%s type=profile_candidate dimension= subject=%s source=%s",
+                        rejection_reason,
+                        clean_text(ctx.user_id, 120),
+                        clean_text(memory_id, 160),
+                    )
+            for derived in derived_memories:
+                derived.id = self.stable_id(
+                    "derived", derived.memory_type, ctx.session_id, derived.content
+                )
                 self.importance.calibrate(derived, source="stable_fact_extraction")
-                derived_id = await self.store.insert_memory(derived)
-                self._schedule_memory_embedding(derived_id, derived)
+                write_mode, gate_reason = self._prepare_rule_profile_write(derived)
+                if write_mode == "reject":
+                    self._log_profile_write_gate(
+                        derived,
+                        decision="rejected",
+                        reason=gate_reason,
+                    )
+                    continue
+                if write_mode == "profile":
+                    profile_result = await self.store.upsert_profile_candidate(derived)
+                    if not profile_result.get("ok"):
+                        self._log_profile_write_gate(
+                            derived,
+                            decision="rejected",
+                            reason=clean_text(profile_result.get("code"), 120),
+                        )
+                        continue
+                    derived_id = clean_text(profile_result.get("memory_id"), 120)
+                    gate_reason = clean_text(profile_result.get("profile_status"), 40)
+                    self._log_profile_write_gate(
+                        derived,
+                        decision="written",
+                        reason=gate_reason,
+                    )
+                    if gate_reason == "active":
+                        stored_profile = await self.store.get_memory(derived_id)
+                        self._schedule_memory_embedding(
+                            derived_id, stored_profile or derived
+                        )
+                else:
+                    derived_id = await self.store.insert_memory(derived)
+                    self._schedule_memory_embedding(derived_id, derived)
                 relation_type = str(derived.metadata.get("relation_type") or "")
-                if relation_type and self.config.bool("memory_capture.record_relationship_edges", True):
+                if relation_type and self.config.bool(
+                    "memory_capture.record_relationship_edges", True
+                ):
                     await self.store.upsert_relationship(
                         subject=derived.subject,
                         object=self._bot_entity(ctx),
@@ -775,6 +926,11 @@ class MemoryCompanionService:
         self._schedule_session_summary(ctx, reason="after_bot_response")
 
     async def _timeline_already_has_message(self, ctx: SessionContext, event_type: str) -> bool:
+        return bool(await self._existing_timeline_message_id(ctx, event_type))
+
+    async def _existing_timeline_message_id(
+        self, ctx: SessionContext, event_type: str
+    ) -> str:
         message_id = clean_text(ctx.message_id, 120)
         rows = await self.store.recent_timeline(
             limit=20,
@@ -783,23 +939,32 @@ class MemoryCompanionService:
             entity_id=ctx.current_target_id,
         )
         text = clean_text(ctx.message_text, 1000)
-        subject_id = clean_text(self._bot_subject_id(ctx) if event_type == "bot_response" else ctx.user_id, 120)
+        subject_id = clean_text(
+            self._bot_subject_id(ctx) if event_type == "bot_response" else ctx.user_id,
+            120,
+        )
         for row in rows:
             if clean_text(row.get("event_type"), 80) != event_type:
                 continue
             if subject_id and clean_text(row.get("subject_id"), 120) != subject_id:
                 continue
             metadata = json_loads(row.get("metadata"), {})
-            existing_message_id = clean_text(row.get("message_id") or metadata.get("message_id") or "", 120)
+            existing_message_id = clean_text(
+                row.get("message_id") or metadata.get("message_id") or "", 120
+            )
             if message_id and existing_message_id and message_id == existing_message_id:
-                return True
+                return clean_text(row.get("id"), 160)
             if text and clean_text(row.get("content"), 1000) == text:
-                previous_at = self._parse_utc_datetime(str(row.get("occurred_at") or row.get("created_at") or ""))
+                previous_at = self._parse_utc_datetime(
+                    str(row.get("occurred_at") or row.get("created_at") or "")
+                )
                 if previous_at is not None:
-                    gap_seconds = max(0.0, (datetime.now(timezone.utc) - previous_at).total_seconds())
+                    gap_seconds = max(
+                        0.0, (datetime.now(timezone.utc) - previous_at).total_seconds()
+                    )
                     if gap_seconds <= 3:
-                        return True
-        return False
+                        return clean_text(row.get("id"), 160)
+        return ""
 
     async def _conversation_memory_metadata(self, ctx: SessionContext, *, source: str) -> dict[str, Any]:
         metadata: dict[str, Any] = {
@@ -1809,7 +1974,9 @@ class MemoryCompanionService:
         slot_map: dict[str, list[SearchResult]] = {"self_timeline": [], "user_profile": []}
         results: list[SearchResult] = []
         for index, (slot, record) in enumerate(selected):
-            expression = "tone" if outfit_focus or slot == "user_profile" else "mention"
+            # Fast profiles already perform a narrow, intent-specific selection.
+            # Mark usable facts as mention; tone now intentionally carries no raw text.
+            expression = "mention"
             result = SearchResult(
                 memory=record,
                 score=max(0.1, 1.0 - index * 0.05),
@@ -6046,6 +6213,8 @@ class MemoryCompanionService:
             recent_fact_context=recent_fact_context,
             recent_cross_window_context=recent_cross_window_context,
         )
+        injection_omissions, included_memory_ids = self.injection.diagnostic_snapshot()
+        blocked.extend(injection_omissions)
         conversation_memory_note = self._conversation_memory_injection_note(
             slot_map,
             recent_fact_context=(recent_fact_context if "<recent_fact_context>" in injection else ""),
@@ -6069,12 +6238,14 @@ class MemoryCompanionService:
             note=note if injection else f"{note}:no_injection_body",
             retrieval_info=retrieval_path_info,
         )
-        if write_log and self.config.bool("memory_injection.enable_injection_logs", True):
+        if write_log and self.config.bool(
+            "memory_injection.enable_injection_logs", True
+        ):
             await self.store.add_injection_log(
                 session_id=ctx.session_id,
                 scope=ctx.scope,
                 query=intent.query,
-                selected_memory_ids=[item.memory.id for item in results],
+                selected_memory_ids=included_memory_ids,
                 blocked_reasons=blocked[:30],
                 injection_chars=len(injection),
             )
@@ -6348,6 +6519,8 @@ class MemoryCompanionService:
             recent_fact_context=recent_fact_context,
             recent_cross_window_context=recent_cross_window_context,
         )
+        injection_omissions, included_memory_ids = self.injection.diagnostic_snapshot()
+        blocked.extend(injection_omissions)
         conversation_memory_note = self._conversation_memory_injection_note(
             slot_map,
             recent_fact_context=(recent_fact_context if "<recent_fact_context>" in injection else ""),
@@ -6376,7 +6549,7 @@ class MemoryCompanionService:
                 session_id=ctx.session_id,
                 scope=ctx.scope,
                 query=intent.query,
-                selected_memory_ids=[item.memory.id for item in results],
+                selected_memory_ids=included_memory_ids,
                 blocked_reasons=blocked[:30],
                 injection_chars=len(injection),
             )

--- a/core/store.py
+++ b/core/store.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
+import math
+
 from contextlib import closing, contextmanager
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -14,14 +17,46 @@ from typing import Any
 from .identity import parse_scope_from_session
 from .models import EntityRef, MemoryRecord, clean_text, json_dumps, json_loads, new_id, stable_fingerprint, utc_now
 from .portrait import cross_scene_whitelisted_fact
+from .profile_quality import normalize_profile_value, profile_quality_decision
 
 
 class MemoryStore:
     EMBEDDING_CANDIDATE_CACHE_MAX = 64
 
-    def __init__(self, db_path: Path):
+    PROFILE_MEMORY_TYPES = frozenset({"user_profile", "user_preference", "user_habit"})
+
+    PROFILE_RULE_EXTRACTORS = frozenset({"rule_v1", "rule_v2"})
+
+    PROFILE_RULE_PORTRAIT_VERSIONS = frozenset(
+        {"req036.rule.v1", "req036.rule.v2"}
+    )
+
+    PROFILE_SINGLE_VALUE_DIMENSIONS = frozenset(
+        {
+            "preferred_address",
+            "name",
+            "birthday",
+            "birth_date",
+            "occupation",
+            "profession",
+            "education",
+            "major",
+            "zodiac",
+            "zodiac_or_blood_type",
+            "blood_type",
+        }
+    )
+
+    def __init__(self, db_path: Path, *, read_only: bool = False):
         self.db_path = Path(db_path)
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._read_only = bool(read_only)
+        if self._read_only:
+            if not self.db_path.is_file():
+                raise FileNotFoundError(
+                    f"memory database does not exist: {self.db_path}"
+                )
+        else:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = self._open_connection()
         self._lock = threading.RLock()
         self._closed = False
@@ -38,15 +73,22 @@ class MemoryStore:
         self._database_recovery_successes = 0
 
     def _open_connection(self) -> sqlite3.Connection:
+        database = str(self.db_path)
+        uri = False
+        if self._read_only:
+            database = f"{self.db_path.resolve().as_uri()}?mode=ro"
+            uri = True
         connection = sqlite3.connect(
-            str(self.db_path),
+            database,
             timeout=3.0,
             check_same_thread=False,
+            uri=uri,
         )
         connection.row_factory = sqlite3.Row
         connection.execute("PRAGMA foreign_keys=ON")
         connection.execute("PRAGMA busy_timeout=3000")
-        connection.execute("PRAGMA wal_autocheckpoint=500")
+        if not self._read_only:
+            connection.execute("PRAGMA wal_autocheckpoint=500")
         return connection
 
     @staticmethod
@@ -196,6 +238,21 @@ class MemoryStore:
             self._conn.commit()
 
     def initialize(self) -> None:
+        if self._read_only:
+            with self._lock:
+                memories = self._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memories'"
+                ).fetchone()
+                if memories is None:
+                    raise sqlite3.DatabaseError(
+                        "memory database schema is missing the memories table"
+                    )
+                self._fts_enabled = bool(
+                    self._conn.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_fts'"
+                    ).fetchone()
+                )
+            return
         with self._lock:
             self._conn.execute("PRAGMA journal_mode=WAL")
             self._conn.execute("PRAGMA foreign_keys=ON")
@@ -616,6 +673,18 @@ class MemoryStore:
                     payload_hash TEXT NOT NULL DEFAULT '',
                     snapshot TEXT NOT NULL DEFAULT '{}',
                     state TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL DEFAULT ''
+                );
+
+                CREATE TABLE IF NOT EXISTS profile_repair_operations (
+                    operation_id TEXT PRIMARY KEY,
+                    rule_version TEXT NOT NULL DEFAULT '',
+                    state TEXT NOT NULL DEFAULT '',
+                    backup_path TEXT NOT NULL DEFAULT '',
+                    plan_fingerprint TEXT NOT NULL DEFAULT '',
+                    snapshot TEXT NOT NULL DEFAULT '{}',
+                    result TEXT NOT NULL DEFAULT '{}',
                     created_at TEXT NOT NULL DEFAULT '',
                     updated_at TEXT NOT NULL DEFAULT ''
                 );
@@ -1188,79 +1257,122 @@ class MemoryStore:
             clean_text(item, 80) for item in (fact.get("evidence_hashes") or [])
             if re.fullmatch(r"[0-9a-f]{64}", clean_text(item, 80))
         ][:16]
+        status = clean_text(fact.get("status"), 40) or "active"
+        cardinality = clean_text(fact.get("profile_cardinality"), 20).lower()
+        single_value = (
+            cardinality == "single"
+            or dimension in self.PROFILE_SINGLE_VALUE_DIMENSIONS
+        )
         with self._lock:
-            if self._portrait_suppressed_sync(person_id, dimension, claim_hash, source_scope):
-                return {"ok": False, "code": "portrait_suppressed", "created": False}
-            previous = self._conn.execute(
-                """
-                SELECT * FROM portrait_facts WHERE person_id=? AND dimension=?
-                  AND normalized_claim_hash=? AND portrait_tier=? AND source_scope=?
-                """,
-                (person_id, dimension, claim_hash, tier, source_scope),
-            ).fetchone()
-            previous_hashes = json_loads(previous["evidence_hashes"], []) if previous is not None else []
-            merged_hashes = list(dict.fromkeys([
-                clean_text(item, 80) for item in previous_hashes + evidence_hashes if clean_text(item, 80)
-            ]))[:16]
-            fact_id = clean_text(previous["id"], 120) if previous is not None else f"portrait_{stable_fingerprint(person_id, dimension, claim_hash, tier, source_scope)[:24]}"
-            revision = int(previous["revision"] or 0) + 1 if previous is not None else 1
-            first_at = clean_text(previous["first_evidence_at"], 80) if previous is not None else now
-            sensitivity = clean_text(fact.get("sensitivity"), 24)
-            if sensitivity not in {"low", "sensitive", "high"}:
-                sensitivity = "high"
-            usable_scope = clean_text(fact.get("usable_scope"), 80)
-            if usable_scope == "self_low_global" and cross_scene_whitelisted_fact(
-                dimension=dimension,
-                claim_summary=fact.get("claim_summary"),
-                sensitivity=sensitivity,
-                source_scope=source_scope,
-            ):
-                usable_scope = "self_low_global"
-            else:
-                usable_scope = "source_only"
-            self._conn.execute(
-                """
-                INSERT INTO portrait_facts(
-                    id, person_id, dimension, normalized_claim_hash, claim_summary, portrait_tier,
-                    producer_kind, producer_version, derivation_kind, epistemic_status, source_scope,
-                    usable_scope, confidence, sensitivity, status, evidence_hashes, context_refs,
-                    first_evidence_at, last_evidence_at, expires_at, supersedes_id, revision,
-                    operation_id, created_at, updated_at
-                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-                ON CONFLICT(person_id, dimension, normalized_claim_hash, portrait_tier, source_scope) DO UPDATE SET
-                    claim_summary=excluded.claim_summary,
-                    producer_kind=excluded.producer_kind,
-                    producer_version=excluded.producer_version,
-                    derivation_kind=excluded.derivation_kind,
-                    epistemic_status=excluded.epistemic_status,
-                    usable_scope=excluded.usable_scope,
-                    confidence=max(portrait_facts.confidence, excluded.confidence),
-                    sensitivity=excluded.sensitivity,
-                    status=excluded.status,
-                    evidence_hashes=excluded.evidence_hashes,
-                    context_refs=excluded.context_refs,
-                    last_evidence_at=excluded.last_evidence_at,
-                    expires_at=excluded.expires_at,
-                    supersedes_id=excluded.supersedes_id,
-                    revision=excluded.revision,
-                    operation_id=excluded.operation_id,
-                    updated_at=excluded.updated_at
-                """,
-                (
-                    fact_id, person_id, dimension, claim_hash, clean_text(fact.get("claim_summary"), 180), tier,
-                    clean_text(fact.get("producer_kind"), 80), clean_text(fact.get("producer_version"), 80),
-                    clean_text(fact.get("derivation_kind"), 80), clean_text(fact.get("epistemic_status"), 80),
-                    source_scope, usable_scope, max(0.0, min(1.0, float(fact.get("confidence") or 0.0))),
-                    sensitivity, clean_text(fact.get("status"), 40) or "active", json_dumps(merged_hashes),
-                    json_dumps([clean_text(item, 160) for item in (fact.get("context_refs") or []) if clean_text(item, 160)][:8]),
-                    first_at, now, clean_text(fact.get("expires_at"), 80), clean_text(fact.get("supersedes_id"), 120),
-                    revision, clean_text(fact.get("operation_id"), 120),
-                    clean_text(previous["created_at"], 80) if previous is not None else now, now,
-                ),
-            )
-            portrait_revision = self._bump_portrait_revision_sync(person_id)
-            self._conn.commit()
-        return {"ok": True, "code": "portrait_fact_upserted", "created": previous is None, "fact_id": fact_id, "portrait_revision": portrait_revision}
+            with self._transaction_sync():
+                if self._portrait_suppressed_sync(person_id, dimension, claim_hash, source_scope):
+                    return {"ok": False, "code": "portrait_suppressed", "created": False}
+                previous = self._conn.execute(
+                    """
+                    SELECT * FROM portrait_facts WHERE person_id=? AND dimension=?
+                      AND normalized_claim_hash=? AND portrait_tier=? AND source_scope=?
+                    """,
+                    (person_id, dimension, claim_hash, tier, source_scope),
+                ).fetchone()
+                previous_hashes = json_loads(previous["evidence_hashes"], []) if previous is not None else []
+                merged_hashes = list(dict.fromkeys([
+                    clean_text(item, 80) for item in previous_hashes + evidence_hashes if clean_text(item, 80)
+                ]))[:16]
+                fact_id = clean_text(previous["id"], 120) if previous is not None else f"portrait_{stable_fingerprint(person_id, dimension, claim_hash, tier, source_scope)[:24]}"
+                revision = int(previous["revision"] or 0) + 1 if previous is not None else 1
+                first_at = clean_text(previous["first_evidence_at"], 80) if previous is not None else now
+                sensitivity = clean_text(fact.get("sensitivity"), 24)
+                if sensitivity not in {"low", "sensitive", "high"}:
+                    sensitivity = "high"
+                usable_scope = clean_text(fact.get("usable_scope"), 80)
+                if usable_scope == "self_low_global" and cross_scene_whitelisted_fact(
+                    dimension=dimension,
+                    claim_summary=fact.get("claim_summary"),
+                    sensitivity=sensitivity,
+                    source_scope=source_scope,
+                ):
+                    usable_scope = "self_low_global"
+                else:
+                    usable_scope = "source_only"
+                self._conn.execute(
+                    """
+                    INSERT INTO portrait_facts(
+                        id, person_id, dimension, normalized_claim_hash, claim_summary, portrait_tier,
+                        producer_kind, producer_version, derivation_kind, epistemic_status, source_scope,
+                        usable_scope, confidence, sensitivity, status, evidence_hashes, context_refs,
+                        first_evidence_at, last_evidence_at, expires_at, supersedes_id, revision,
+                        operation_id, created_at, updated_at
+                    ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    ON CONFLICT(person_id, dimension, normalized_claim_hash, portrait_tier, source_scope) DO UPDATE SET
+                        claim_summary=excluded.claim_summary,
+                        producer_kind=excluded.producer_kind,
+                        producer_version=excluded.producer_version,
+                        derivation_kind=excluded.derivation_kind,
+                        epistemic_status=excluded.epistemic_status,
+                        usable_scope=excluded.usable_scope,
+                        confidence=max(portrait_facts.confidence, excluded.confidence),
+                        sensitivity=excluded.sensitivity,
+                        status=excluded.status,
+                        evidence_hashes=excluded.evidence_hashes,
+                        context_refs=excluded.context_refs,
+                        last_evidence_at=excluded.last_evidence_at,
+                        expires_at=excluded.expires_at,
+                        supersedes_id=excluded.supersedes_id,
+                        revision=excluded.revision,
+                        operation_id=excluded.operation_id,
+                        updated_at=excluded.updated_at
+                    """,
+                    (
+                        fact_id, person_id, dimension, claim_hash, clean_text(fact.get("claim_summary"), 180), tier,
+                        clean_text(fact.get("producer_kind"), 80), clean_text(fact.get("producer_version"), 80),
+                        clean_text(fact.get("derivation_kind"), 80), clean_text(fact.get("epistemic_status"), 80),
+                        source_scope, usable_scope, max(0.0, min(1.0, float(fact.get("confidence") or 0.0))),
+                        sensitivity, status, json_dumps(merged_hashes),
+                        json_dumps([clean_text(item, 160) for item in (fact.get("context_refs") or []) if clean_text(item, 160)][:8]),
+                        first_at, now, clean_text(fact.get("expires_at"), 80), clean_text(fact.get("supersedes_id"), 120),
+                        revision, clean_text(fact.get("operation_id"), 120),
+                        clean_text(previous["created_at"], 80) if previous is not None else now, now,
+                    ),
+                )
+                superseded_ids: list[str] = []
+                if status == "active" and single_value:
+                    superseded_rows = self._conn.execute(
+                        """
+                        SELECT id FROM portrait_facts
+                        WHERE person_id=? AND dimension=?
+                          AND source_scope=? AND status='active' AND id!=?
+                        """,
+                        (person_id, dimension, source_scope, fact_id),
+                    ).fetchall()
+                    superseded_ids = [clean_text(row["id"], 120) for row in superseded_rows]
+                    if superseded_ids:
+                        placeholders = ",".join("?" for _ in superseded_ids)
+                        self._conn.execute(
+                            f"""
+                            UPDATE portrait_facts
+                            SET status='superseded', supersedes_id=?, revision=revision+1,
+                                operation_id=?, updated_at=?
+                            WHERE id IN ({placeholders})
+                            """,
+                            [fact_id, clean_text(fact.get("operation_id"), 120), now, *superseded_ids],
+                        )
+                        self._conn.execute(
+                            f"""
+                            UPDATE portrait_learning_queue
+                            SET state='superseded', updated_at=?
+                            WHERE fact_id IN ({placeholders}) AND state='pending'
+                            """,
+                            [now, *superseded_ids],
+                        )
+                portrait_revision = self._bump_portrait_revision_sync(person_id)
+        return {
+            "ok": True,
+            "code": "portrait_fact_upserted",
+            "created": previous is None,
+            "fact_id": fact_id,
+            "portrait_revision": portrait_revision,
+            "superseded": len(superseded_ids),
+        }
 
     async def list_portrait_evidence(self, person_id: str, *, limit: int = 64) -> list[dict[str, Any]]:
         return await asyncio.to_thread(self._list_portrait_evidence_sync, person_id, limit)
@@ -1505,7 +1617,11 @@ class MemoryStore:
             capabilities = json_loads(person["capability_summary"], {})
             if not bool(capabilities.get("portrait_usage_enabled")):
                 return {"ok": False, "code": "portrait_usage_disabled", "items": [], "portrait_revision": int(person["portrait_revision"] or 0)}
-            query = "SELECT * FROM portrait_facts WHERE person_id=? AND status='active'"
+            query = (
+                "SELECT * FROM portrait_facts "
+                "WHERE person_id=? AND status='active' "
+                "AND producer_version!='req036.rule.v1'"
+            )
             params: list[Any] = [person_id]
             if low_only:
                 query += " AND sensitivity='low'"
@@ -2188,6 +2304,2156 @@ class MemoryStore:
         from_where, from_params = self._session_target_where("from_session", scope, value)
         to_where, to_params = self._session_target_where("to_session", scope, value)
         return (f"{from_where} OR {to_where}", [*from_params, *to_params])
+
+    @staticmethod
+    def profile_memory_fingerprint(record: MemoryRecord) -> str:
+        """Fingerprint fields governed by profile repair, excluding access counters."""
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        payload = {
+            "id": record.id,
+            "memory_type": record.memory_type,
+            "subject": {
+                "kind": record.subject.kind,
+                "id": record.subject.id,
+                "name": record.subject.name,
+                "role": record.subject.role,
+            },
+            "object": {
+                "kind": record.object.kind,
+                "id": record.object.id,
+                "name": record.object.name,
+                "role": record.object.role,
+            },
+            "scope": record.scope,
+            "session_id": record.session_id,
+            "platform": record.platform,
+            "message_id": record.message_id,
+            "group_id": record.group_id,
+            "visibility": record.visibility,
+            "sayability": record.sayability,
+            "reality_level": record.reality_level,
+            "lifecycle": record.lifecycle,
+            "content": record.content,
+            "evidence": record.evidence,
+            "confidence": record.confidence,
+            "importance": record.importance,
+            "review_status": record.review_status,
+            "tags": list(record.tags or []),
+            "metadata": metadata,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+            "occurred_at": record.occurred_at,
+            "source_plugin": record.source_plugin,
+            "import_batch_id": record.import_batch_id,
+            "content_fingerprint": record.content_fingerprint,
+            "merged_count": record.merged_count,
+            "supersedes_id": record.supersedes_id,
+        }
+        raw = json.dumps(
+            payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def profile_repair_plan_fingerprint(actions: list[dict[str, Any]]) -> str:
+        """Return a deterministic fingerprint for an ordered repair action plan."""
+        raw = json.dumps(
+            actions, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def profile_repair_group_id(record_id: Any) -> str:
+        record_id = clean_text(record_id, 120)
+        return (
+            "profile_group_"
+            + stable_fingerprint("profile_repair_group", record_id)[:24]
+            if record_id
+            else ""
+        )
+
+    @staticmethod
+    def profile_portrait_fact_fingerprint(fact: Any) -> str:
+        data = dict(fact) if fact is not None else {}
+        fields = (
+            "id",
+            "person_id",
+            "dimension",
+            "normalized_claim_hash",
+            "claim_summary",
+            "portrait_tier",
+            "producer_kind",
+            "producer_version",
+            "derivation_kind",
+            "epistemic_status",
+            "source_scope",
+            "usable_scope",
+            "confidence",
+            "sensitivity",
+            "status",
+            "evidence_hashes",
+            "context_refs",
+            "first_evidence_at",
+            "last_evidence_at",
+            "expires_at",
+            "supersedes_id",
+            "revision",
+            "operation_id",
+            "created_at",
+            "updated_at",
+        )
+        payload = {field: data.get(field) for field in fields}
+        raw = json.dumps(
+            payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def profile_portrait_queue_fingerprint(rows: Any) -> str:
+        normalized = sorted(
+            (dict(row) for row in (rows or [])),
+            key=lambda item: (
+                clean_text(item.get("queue_id"), 120),
+                clean_text(item.get("evidence_hash"), 80),
+            ),
+        )
+        raw = json.dumps(
+            normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _memory_db_snapshot(record: MemoryRecord) -> dict[str, Any]:
+        return dict(record.to_db())
+
+    @staticmethod
+    def _memory_from_db_snapshot(snapshot: dict[str, Any]) -> MemoryRecord:
+        return MemoryRecord.from_row(snapshot)
+
+    def _write_memory_record_sync(self, record: MemoryRecord) -> sqlite3.Row:
+        record.ensure_defaults()
+        data = record.to_db()
+        columns = ", ".join(data.keys())
+        placeholders = ", ".join(f":{key}" for key in data)
+        updates = ", ".join(f"{key}=excluded.{key}" for key in data if key != "id")
+        self._conn.execute(
+            f"INSERT INTO memories ({columns}) VALUES ({placeholders}) "
+            f"ON CONFLICT(id) DO UPDATE SET {updates}",
+            data,
+        )
+        row = self._conn.execute(
+            "SELECT * FROM memories WHERE id=?", (record.id,)
+        ).fetchone()
+        self._upsert_memory_fts_row(row)
+        return row
+
+    @staticmethod
+    def _profile_evidence_refs(record: MemoryRecord) -> list[str]:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        raw_refs: list[Any] = []
+        for key in ("profile_evidence_refs", "source_memory_ids", "evidence_refs"):
+            value = metadata.get(key)
+            if isinstance(value, list):
+                raw_refs.extend(value)
+        source_memory_id = clean_text(metadata.get("source_memory_id"), 160)
+        if source_memory_id:
+            raw_refs.append(source_memory_id)
+        elif not raw_refs and record.message_id:
+            raw_refs.append(record.message_id)
+        refs = [clean_text(value, 160) for value in raw_refs if clean_text(value, 160)]
+        if not refs:
+            refs = [
+                "fallback:"
+                + stable_fingerprint(
+                    record.scope,
+                    record.session_id,
+                    record.subject.id,
+                    record.evidence,
+                )
+            ]
+        return list(dict.fromkeys(refs))[:256]
+
+    @staticmethod
+    def _profile_incoming_evidence_refs(record: MemoryRecord) -> list[str]:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        source_memory_id = clean_text(metadata.get("source_memory_id"), 160)
+        if source_memory_id:
+            return [source_memory_id]
+        message_id = clean_text(record.message_id, 160)
+        if message_id:
+            return [message_id]
+        return [
+            "fallback:"
+            + stable_fingerprint(
+                record.scope,
+                record.session_id,
+                record.subject.id,
+                record.evidence,
+            )
+        ]
+
+    @staticmethod
+    def _profile_evidence_text(records: list[MemoryRecord]) -> str:
+        parts: list[str] = []
+        for record in records:
+            for part in clean_text(record.evidence, 4000).split("\n---\n"):
+                cleaned = clean_text(part, 1200)
+                if cleaned and cleaned not in parts:
+                    parts.append(cleaned)
+        return clean_text("\n---\n".join(parts), 4000)
+
+    @staticmethod
+    def _profile_statement_fingerprints(record: MemoryRecord) -> list[str]:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        raw = metadata.get("profile_statement_fingerprints")
+        values = (
+            [clean_text(item, 80) for item in raw if clean_text(item, 80)]
+            if isinstance(raw, list)
+            else []
+        )
+        if not values and clean_text(record.evidence, 4000):
+            values.append(
+                stable_fingerprint("profile_statement", record.evidence.casefold())
+            )
+        return list(dict.fromkeys(values))[:256]
+
+    @staticmethod
+    def _profile_incoming_statement_fingerprints(
+        record: MemoryRecord,
+    ) -> list[str]:
+        evidence = clean_text(record.evidence, 4000)
+        if not evidence:
+            return []
+        return [stable_fingerprint("profile_statement", evidence.casefold())]
+
+    @staticmethod
+    def _profile_evidence_passes_quality_gate(record: MemoryRecord) -> bool:
+        metadata = dict(record.metadata) if isinstance(record.metadata, dict) else {}
+        metadata["profile_state"] = "active"
+        metadata["profile_status"] = "active"
+        metadata["independent_evidence_count"] = 2
+        allowed, _reason = profile_quality_decision(
+            {"memory_type": record.memory_type, "metadata": metadata},
+            require_active=True,
+        )
+        return allowed
+
+    @staticmethod
+    def _profile_domain(record: MemoryRecord) -> tuple[str, ...]:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        return (
+            clean_text(record.platform, 80).lower(),
+            clean_text(record.subject.kind, 40).lower(),
+            clean_text(record.subject.id, 120),
+            clean_text(record.object.kind, 40).lower(),
+            clean_text(record.object.id, 120),
+            clean_text(record.scope, 40).lower(),
+            clean_text(record.group_id, 120),
+            clean_text(record.visibility, 40).lower(),
+            clean_text(metadata.get("owner_bot_id"), 120),
+        )
+
+    def _profile_domain_rows_sync(self, record: MemoryRecord) -> list[sqlite3.Row]:
+        rows = self._conn.execute(
+            """
+            SELECT * FROM memories
+            WHERE memory_type IN ('user_profile', 'user_preference', 'user_habit')
+              AND platform=? AND subject_kind=? AND subject_id=?
+              AND object_kind=? AND object_id=? AND scope=? AND group_id=? AND visibility=?
+              AND lifecycle!='archived'
+            """,
+            (
+                clean_text(record.platform, 80),
+                clean_text(record.subject.kind, 40),
+                clean_text(record.subject.id, 120),
+                clean_text(record.object.kind, 40),
+                clean_text(record.object.id, 120),
+                clean_text(record.scope, 40),
+                clean_text(record.group_id, 120),
+                clean_text(record.visibility, 40),
+            ),
+        ).fetchall()
+        domain = self._profile_domain(record)
+        return [
+            row
+            for row in rows
+            if self._profile_domain(MemoryRecord.from_row(row)) == domain
+        ]
+
+    def _profile_single_value_domain_conflict_sync(
+        self, record: MemoryRecord
+    ) -> bool:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        extractor = clean_text(metadata.get("extractor"), 40).lower()
+        dimension = clean_text(metadata.get("profile_dimension"), 80).lower()
+        cardinality = (
+            "single"
+            if dimension in self.PROFILE_SINGLE_VALUE_DIMENSIONS
+            else clean_text(metadata.get("profile_cardinality"), 20).lower()
+            or "multi"
+        )
+        if not (
+            record.memory_type in self.PROFILE_MEMORY_TYPES
+            and extractor in self.PROFILE_RULE_EXTRACTORS
+            and dimension
+            and cardinality == "single"
+            and self._profile_state(record) == "active"
+        ):
+            return False
+        for domain_row in self._profile_domain_rows_sync(record):
+            other = MemoryRecord.from_row(domain_row)
+            other_metadata = (
+                other.metadata if isinstance(other.metadata, dict) else {}
+            )
+            if (
+                other.id != record.id
+                and self._profile_state(other) == "active"
+                and clean_text(
+                    other_metadata.get("profile_dimension"), 80
+                ).lower()
+                == dimension
+            ):
+                return True
+        return False
+
+    def _profile_single_value_invariant_signature(
+        self, record: MemoryRecord
+    ) -> tuple[Any, ...]:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        dimension = clean_text(metadata.get("profile_dimension"), 80).lower()
+        cardinality = (
+            "single"
+            if dimension in self.PROFILE_SINGLE_VALUE_DIMENSIONS
+            else clean_text(metadata.get("profile_cardinality"), 20).lower()
+            or "multi"
+        )
+        return (
+            clean_text(record.memory_type, 80),
+            self._profile_domain(record),
+            self._profile_state(record),
+            clean_text(record.lifecycle, 40),
+            clean_text(record.review_status, 40),
+            clean_text(metadata.get("extractor"), 40).lower(),
+            dimension,
+            cardinality,
+            normalize_profile_value(metadata.get("normalized_value")),
+        )
+
+    @staticmethod
+    def _profile_state(record: MemoryRecord) -> str:
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        state = clean_text(
+            metadata.get("profile_state") or metadata.get("profile_status"),
+            32,
+        ).lower()
+        if state in {"candidate", "active", "rejected", "superseded"}:
+            return state
+        if record.lifecycle == "archived":
+            return "superseded" if record.supersedes_id else "rejected"
+        if record.review_status == "pending":
+            return "candidate"
+        return "active"
+
+    async def upsert_profile_candidate(self, record: MemoryRecord) -> dict[str, Any]:
+        return await self._run_recoverable_database_operation(
+            self._upsert_profile_candidate_sync,
+            deepcopy(record),
+        )
+
+    def _upsert_profile_candidate_sync(self, record: MemoryRecord) -> dict[str, Any]:
+        record.ensure_defaults()
+        metadata = dict(record.metadata) if isinstance(record.metadata, dict) else {}
+        extractor = clean_text(metadata.get("extractor"), 40).lower()
+        dimension = clean_text(metadata.get("profile_dimension"), 80).lower()
+        profile_value = clean_text(metadata.get("profile_value"), 240)
+        normalized = normalize_profile_value(metadata.get("normalized_value"))
+        polarity = clean_text(metadata.get("profile_polarity"), 40).lower()
+        if (
+            record.memory_type not in self.PROFILE_MEMORY_TYPES
+            or extractor not in self.PROFILE_RULE_EXTRACTORS
+            or not dimension
+            or not profile_value
+            or not normalized
+            or normalize_profile_value(profile_value) != normalized
+        ):
+            return {"ok": False, "code": "profile_candidate_invalid", "memory_id": ""}
+        try:
+            raw_quality_score = float(metadata.get("extraction_quality_score"))
+        except (TypeError, ValueError):
+            return {"ok": False, "code": "profile_candidate_invalid", "memory_id": ""}
+        if not math.isfinite(raw_quality_score):
+            return {"ok": False, "code": "profile_candidate_invalid", "memory_id": ""}
+        quality_score = max(0.0, min(1.0, raw_quality_score))
+
+        requested_state = clean_text(
+            metadata.get("profile_state") or metadata.get("profile_status"),
+            32,
+        ).lower()
+        explicit_active = bool(
+            requested_state == "active"
+            and clean_text(metadata.get("extraction_quality"), 40).lower() == "explicit"
+            and clean_text(metadata.get("evidence_strength"), 40).lower()
+            == "direct_statement"
+            and metadata.get("quality_gate_passed") is True
+            and quality_score >= 0.8
+        )
+        requested_state = "active" if explicit_active else "candidate"
+        try:
+            required_evidence = max(
+                1 if explicit_active else 2,
+                min(10, int(metadata.get("required_evidence_count") or 2)),
+            )
+        except (TypeError, ValueError):
+            required_evidence = 1 if explicit_active else 2
+        incoming_refs = self._profile_incoming_evidence_refs(record)
+        incoming_statement_fingerprints = (
+            self._profile_incoming_statement_fingerprints(record)
+        )
+        now = utc_now()
+
+        with self._lock:  # noqa: SIM117
+            with self._transaction_sync():
+                domain_rows = self._profile_domain_rows_sync(record)
+                exact_records: list[MemoryRecord] = []
+                for row in domain_rows:
+                    candidate = MemoryRecord.from_row(row)
+                    candidate_metadata = (
+                        candidate.metadata
+                        if isinstance(candidate.metadata, dict)
+                        else {}
+                    )
+                    if (
+                        clean_text(
+                            candidate_metadata.get("profile_dimension"), 80
+                        ).lower()
+                        != dimension
+                    ):
+                        continue
+                    candidate_polarity = clean_text(
+                        candidate_metadata.get("profile_polarity"),
+                        40,
+                    ).lower()
+                    if (
+                        normalize_profile_value(
+                            candidate_metadata.get("normalized_value")
+                        )
+                        == normalized
+                        and candidate_polarity == polarity
+                    ):
+                        exact_records.append(candidate)
+
+                exact_records.sort(
+                    key=lambda item: (
+                        self._profile_state(item) == "active",
+                        int(item.merged_count or 1),
+                        item.updated_at,
+                    ),
+                    reverse=True,
+                )
+                if exact_records:
+                    canonical = exact_records[0]
+                    existing_metadata = (
+                        dict(canonical.metadata)
+                        if isinstance(canonical.metadata, dict)
+                        else {}
+                    )
+                    existing_state = self._profile_state(canonical)
+                else:
+                    canonical = deepcopy(record)
+                    profile_key = stable_fingerprint(
+                        *self._profile_domain(record),
+                        dimension,
+                        polarity,
+                        normalized,
+                    )
+                    canonical.id = f"profile_{profile_key}"
+                    if self._conn.execute(
+                        "SELECT 1 FROM memories WHERE id=?", (canonical.id,)
+                    ).fetchone():
+                        collision_seed = stable_fingerprint(
+                            profile_key,
+                            record.id,
+                            *incoming_refs,
+                            *incoming_statement_fingerprints,
+                        )
+                        sequence = 1
+                        while True:
+                            candidate_id = f"profile_{stable_fingerprint(collision_seed, str(sequence))}"
+                            if self._conn.execute(
+                                "SELECT 1 FROM memories WHERE id=?", (candidate_id,)
+                            ).fetchone() is None:
+                                canonical.id = candidate_id
+                                break
+                            sequence += 1
+                    existing_metadata = {}
+                    existing_state = "candidate"
+
+                all_records = [*exact_records, record]
+                refs: list[str] = []
+                statement_fingerprints: list[str] = []
+                for item in exact_records:
+                    refs.extend(self._profile_evidence_refs(item))
+                    statement_fingerprints.extend(
+                        self._profile_statement_fingerprints(item)
+                    )
+                refs.extend(incoming_refs)
+                statement_fingerprints.extend(incoming_statement_fingerprints)
+                refs = list(dict.fromkeys(refs))[:256]
+                statement_fingerprints = list(dict.fromkeys(statement_fingerprints))[
+                    :256
+                ]
+                qualified_refs: list[str] = []
+                qualified_statement_fingerprints: list[str] = []
+                for item in exact_records:
+                    item_metadata = (
+                        item.metadata if isinstance(item.metadata, dict) else {}
+                    )
+                    stored_refs = item_metadata.get(
+                        "profile_qualified_evidence_refs"
+                    )
+                    stored_statements = item_metadata.get(
+                        "profile_qualified_statement_fingerprints"
+                    )
+                    if isinstance(stored_refs, list) and isinstance(
+                        stored_statements, list
+                    ):
+                        qualified_refs.extend(stored_refs)
+                        qualified_statement_fingerprints.extend(stored_statements)
+                    elif self._profile_evidence_passes_quality_gate(item):
+                        qualified_refs.extend(self._profile_evidence_refs(item))
+                        qualified_statement_fingerprints.extend(
+                            self._profile_statement_fingerprints(item)
+                        )
+                if self._profile_evidence_passes_quality_gate(record):
+                    qualified_refs.extend(incoming_refs)
+                    qualified_statement_fingerprints.extend(
+                        incoming_statement_fingerprints
+                    )
+                qualified_refs = list(dict.fromkeys(qualified_refs))[:256]
+                qualified_statement_fingerprints = list(
+                    dict.fromkeys(qualified_statement_fingerprints)
+                )[:256]
+                independent_evidence_count = min(
+                    len(qualified_refs),
+                    len(qualified_statement_fingerprints),
+                )
+                existing_refs: list[str] = []
+                for item in exact_records:
+                    existing_refs.extend(self._profile_evidence_refs(item))
+                existing_refs = list(dict.fromkeys(existing_refs))
+                evidence_added = any(ref not in existing_refs for ref in incoming_refs)
+
+                merged_metadata = dict(existing_metadata)
+                merged_metadata.update(metadata)
+                merged_metadata["extractor"] = extractor
+                merged_metadata["profile_dimension"] = dimension
+                merged_metadata["profile_polarity"] = polarity
+                merged_metadata["normalized_value"] = clean_text(
+                    metadata.get("normalized_value"), 240
+                )
+                merged_metadata["profile_value"] = profile_value
+                try:
+                    existing_quality_score = float(
+                        existing_metadata.get("extraction_quality_score") or 0.0
+                    )
+                except (TypeError, ValueError):
+                    existing_quality_score = 0.0
+                merged_metadata["extraction_quality_score"] = round(
+                    max(quality_score, existing_quality_score),
+                    4,
+                )
+                merged_metadata["profile_evidence_refs"] = refs
+                merged_metadata["profile_statement_fingerprints"] = (
+                    statement_fingerprints
+                )
+                merged_metadata["profile_qualified_evidence_refs"] = qualified_refs
+                merged_metadata["profile_qualified_statement_fingerprints"] = (
+                    qualified_statement_fingerprints
+                )
+                merged_metadata["evidence_count"] = len(refs)
+                merged_metadata["independent_evidence_count"] = (
+                    independent_evidence_count
+                )
+                merged_metadata["required_evidence_count"] = required_evidence
+                merged_metadata["profile_cardinality"] = (
+                    "single"
+                    if dimension in self.PROFILE_SINGLE_VALUE_DIMENSIONS
+                    else clean_text(metadata.get("profile_cardinality"), 20)
+                    or "multi"
+                )
+
+                activation_metadata = {
+                    **merged_metadata,
+                    "profile_state": "active",
+                    "profile_status": "active",
+                }
+                activation_allowed, _activation_reason = profile_quality_decision(
+                    activation_metadata,
+                    require_active=True,
+                )
+
+                next_state = (
+                    "active"
+                    if (
+                        existing_state == "active"
+                        or activation_allowed
+                        and (
+                            requested_state == "active"
+                            or independent_evidence_count >= required_evidence
+                        )
+                    )
+                    else "candidate"
+                )
+                merged_metadata["profile_state"] = next_state
+                merged_metadata["profile_status"] = next_state
+                merged_metadata["profile_status_updated_at"] = now
+                canonical.metadata = merged_metadata
+                if not exact_records or requested_state == "active":
+                    canonical.content = record.content
+                    canonical.memory_type = record.memory_type
+                    canonical.tags = list(
+                        dict.fromkeys([*(canonical.tags or []), *(record.tags or [])])
+                    )
+                canonical.evidence = self._profile_evidence_text(all_records)
+                canonical.confidence = max(
+                    float(canonical.confidence or 0.0), quality_score
+                )
+                canonical.importance = max(
+                    float(canonical.importance or 0.0), float(record.importance or 0.0)
+                )
+                canonical.merged_count = max(1, len(refs))
+                canonical.lifecycle = (
+                    "stable_memory" if next_state == "active" else "raw_event"
+                )
+                canonical.review_status = (
+                    "auto" if next_state == "active" else "pending"
+                )
+                canonical.updated_at = now
+                canonical.content_fingerprint = ""
+                canonical.ensure_defaults()
+                self._write_memory_record_sync(canonical)
+
+                superseded_ids: list[str] = []
+                duplicate_ids = [item.id for item in exact_records[1:]]
+                cardinality = clean_text(
+                    merged_metadata.get("profile_cardinality"), 20
+                ).lower()
+                if next_state == "active" and cardinality == "single":
+                    for row in domain_rows:
+                        other = MemoryRecord.from_row(row)
+                        other_metadata = (
+                            other.metadata if isinstance(other.metadata, dict) else {}
+                        )
+                        if other.id == canonical.id:
+                            continue
+                        if (
+                            clean_text(
+                                other_metadata.get("profile_dimension"), 80
+                            ).lower()
+                            != dimension
+                        ):
+                            continue
+                        if self._profile_state(other) == "active":
+                            duplicate_ids.append(other.id)
+                for memory_id in list(dict.fromkeys(duplicate_ids)):
+                    row = self._conn.execute(
+                        "SELECT * FROM memories WHERE id=?", (memory_id,)
+                    ).fetchone()
+                    if row is None:
+                        continue
+                    other = MemoryRecord.from_row(row)
+                    other_metadata = (
+                        dict(other.metadata) if isinstance(other.metadata, dict) else {}
+                    )
+                    other_metadata["profile_state"] = "superseded"
+                    other_metadata["profile_status"] = "superseded"
+                    other_metadata["profile_superseded_by"] = canonical.id
+                    other_metadata["profile_status_updated_at"] = now
+                    other.metadata = other_metadata
+                    other.lifecycle = "archived"
+                    other.supersedes_id = canonical.id
+                    other.updated_at = now
+                    self._write_memory_record_sync(other)
+                    self._conn.execute(
+                        "DELETE FROM memory_embeddings WHERE memory_id=?", (other.id,)
+                    )
+                    self._conn.execute(
+                        "UPDATE review_queue SET status='superseded', updated_at=? WHERE memory_id=?",
+                        (now, other.id),
+                    )
+                    superseded_ids.append(other.id)
+
+                if next_state == "candidate":
+                    self._upsert_review_sync(
+                        canonical.id, "profile_candidate_requires_evidence"
+                    )
+                    self._conn.execute(
+                        "DELETE FROM memory_embeddings WHERE memory_id=?",
+                        (canonical.id,),
+                    )
+                else:
+                    self._conn.execute(
+                        "UPDATE review_queue SET status='auto', updated_at=? WHERE memory_id=? AND status='pending'",
+                        (now, canonical.id),
+                    )
+                self._embedding_candidate_cache.clear()
+                self._embedding_candidate_cache_revision = ""
+
+        return {
+            "ok": True,
+            "code": "profile_candidate_upserted",
+            "memory_id": canonical.id,
+            "profile_status": next_state,
+            "evidence_count": len(refs),
+            "independent_evidence_count": independent_evidence_count,
+            "evidence_added": evidence_added,
+            "superseded_ids": superseded_ids,
+        }
+
+    async def list_rule_profile_memories(
+        self,
+        *,
+        user_id: str = "",
+        scope: str = "",
+        memory_types: list[str] | None = None,
+        extractors: list[str] | None = None,
+        include_archived: bool = True,
+        limit: int = 5000,
+        offset: int = 0,
+    ) -> list[MemoryRecord]:
+        return await self._run_recoverable_database_operation(
+            self._list_rule_profile_memories_sync,
+            user_id,
+            scope,
+            list(memory_types or []),
+            list(extractors or []),
+            include_archived,
+            limit,
+            offset,
+        )
+
+    def _list_rule_profile_memories_sync(
+        self,
+        user_id: str,
+        scope: str,
+        memory_types: list[str],
+        extractors: list[str],
+        include_archived: bool,
+        limit: int,
+        offset: int,
+    ) -> list[MemoryRecord]:
+        requested_types = [clean_text(value, 80) for value in memory_types]
+        invalid_types = sorted(
+            {
+                value or "<empty>"
+                for value in requested_types
+                if value not in self.PROFILE_MEMORY_TYPES
+            }
+        )
+        if invalid_types:
+            raise ValueError(
+                "unsupported profile memory type filter: " + ", ".join(invalid_types)
+            )
+        selected_types = list(dict.fromkeys(requested_types)) or sorted(
+            self.PROFILE_MEMORY_TYPES
+        )
+
+        requested_extractors = [clean_text(value, 40).lower() for value in extractors]
+        invalid_extractors = sorted(
+            {
+                value or "<empty>"
+                for value in requested_extractors
+                if value not in self.PROFILE_RULE_EXTRACTORS
+            }
+        )
+        if invalid_extractors:
+            raise ValueError(
+                "unsupported profile extractor filter: " + ", ".join(invalid_extractors)
+            )
+        selected_extractors = list(dict.fromkeys(requested_extractors)) or sorted(
+            self.PROFILE_RULE_EXTRACTORS
+        )
+        type_marks = ",".join("?" for _ in selected_types)
+        extractor_marks = ",".join("?" for _ in selected_extractors)
+        where = [
+            f"memory_type IN ({type_marks})",
+            "json_valid(metadata)",
+            f"LOWER(COALESCE(CAST(json_extract(metadata, '$.extractor') AS TEXT), '')) IN ({extractor_marks})",
+        ]
+        params: list[Any] = [*selected_types, *selected_extractors]
+        if user_id:
+            where.append("subject_id=?")
+            params.append(clean_text(user_id, 120))
+        if scope:
+            where.append("scope=?")
+            params.append(clean_text(scope, 40))
+        if not include_archived:
+            where.append("lifecycle!='archived'")
+        safe_limit = max(1, min(100000, int(limit or 5000)))
+        safe_offset = max(0, int(offset or 0))
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT * FROM memories
+                WHERE {" AND ".join(where)}
+                ORDER BY subject_id, scope, occurred_at, created_at, id
+                LIMIT ? OFFSET ?
+                """,
+                [*params, safe_limit, safe_offset],
+            ).fetchall()
+        return [MemoryRecord.from_row(row) for row in rows]
+
+    async def list_rule_portrait_facts(
+        self,
+        *,
+        person_id: str = "",
+        source_scope: str = "",
+        include_inactive: bool = True,
+        limit: int = 5000,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(
+            self._list_rule_portrait_facts_sync,
+            person_id,
+            source_scope,
+            include_inactive,
+            limit,
+            offset,
+        )
+
+    def _list_rule_portrait_facts_sync(
+        self,
+        person_id: str,
+        source_scope: str,
+        include_inactive: bool,
+        limit: int,
+        offset: int,
+    ) -> list[dict[str, Any]]:
+        versions = sorted(self.PROFILE_RULE_PORTRAIT_VERSIONS)
+        marks = ",".join("?" for _ in versions)
+        where = [
+            "producer_kind='rule_explicit'",
+            f"producer_version IN ({marks})",
+        ]
+        params: list[Any] = [*versions]
+        if person_id:
+            where.append("person_id=?")
+            params.append(clean_text(person_id, 80))
+        if source_scope:
+            where.append("source_scope=?")
+            params.append(clean_text(source_scope, 80))
+        if not include_inactive:
+            where.append("status='active'")
+        safe_limit = max(1, min(100000, int(limit or 5000)))
+        safe_offset = max(0, int(offset or 0))
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT * FROM portrait_facts
+                WHERE {" AND ".join(where)}
+                ORDER BY person_id, source_scope, dimension,
+                         last_evidence_at, created_at, id
+                LIMIT ? OFFSET ?
+                """,
+                [*params, safe_limit, safe_offset],
+            ).fetchall()
+            results: list[dict[str, Any]] = []
+            for row in rows:
+                item = dict(row)
+                queue_rows = self._conn.execute(
+                    """
+                    SELECT * FROM portrait_learning_queue
+                    WHERE fact_id=? ORDER BY queue_id
+                    """,
+                    (row["id"],),
+                ).fetchall()
+                item["queue_fingerprint"] = (
+                    self.profile_portrait_queue_fingerprint(queue_rows)
+                )
+                results.append(item)
+        return results
+
+    @staticmethod
+    def _valid_profile_operation_id(operation_id: Any) -> str:
+        value = clean_text(operation_id, 120)
+        return value if re.fullmatch(r"[A-Za-z0-9_.:-]{1,120}", value) else ""
+
+    def _profile_repair_record_snapshot_sync(
+        self,
+        record: MemoryRecord,
+        *,
+        group_id: str = "",
+        guard_only: bool = False,
+    ) -> dict[str, Any]:
+        review_rows = self._conn.execute(
+            "SELECT * FROM review_queue WHERE memory_id=? ORDER BY created_at, id",
+            (record.id,),
+        ).fetchall()
+        embedding_rows = self._conn.execute(
+            "SELECT * FROM memory_embeddings WHERE memory_id=? ORDER BY provider_id",
+            (record.id,),
+        ).fetchall()
+        return {
+            "record_kind": "memory",
+            "record_id": record.id,
+            "memory_id": record.id,
+            "group_id": clean_text(group_id, 120),
+            "guard_only": bool(guard_only),
+            "before": self._memory_db_snapshot(record),
+            "review_queue": [dict(row) for row in review_rows],
+            "embeddings": [dict(row) for row in embedding_rows],
+            "after_fingerprint": "",
+        }
+
+    def _profile_repair_portrait_snapshot_sync(
+        self,
+        fact: Any,
+        *,
+        group_id: str = "",
+        guard_only: bool = False,
+    ) -> dict[str, Any]:
+        fact_data = dict(fact)
+        fact_id = clean_text(fact_data.get("id"), 120)
+        queue_rows = self._conn.execute(
+            """
+            SELECT * FROM portrait_learning_queue
+            WHERE fact_id=? ORDER BY queue_id
+            """,
+            (fact_id,),
+        ).fetchall()
+        return {
+            "record_kind": "portrait_fact",
+            "record_id": fact_id,
+            "group_id": clean_text(group_id, 120),
+            "guard_only": bool(guard_only),
+            "person_id": clean_text(fact_data.get("person_id"), 80),
+            "before": fact_data,
+            "learning_queue": [dict(row) for row in queue_rows],
+            "after_fingerprint": "",
+            "after_queue_fingerprint": "",
+        }
+
+    def _write_portrait_fact_snapshot_sync(
+        self, snapshot: dict[str, Any]
+    ) -> bool:
+        columns = (
+            "id",
+            "person_id",
+            "dimension",
+            "normalized_claim_hash",
+            "claim_summary",
+            "portrait_tier",
+            "producer_kind",
+            "producer_version",
+            "derivation_kind",
+            "epistemic_status",
+            "source_scope",
+            "usable_scope",
+            "confidence",
+            "sensitivity",
+            "status",
+            "evidence_hashes",
+            "context_refs",
+            "first_evidence_at",
+            "last_evidence_at",
+            "expires_at",
+            "supersedes_id",
+            "revision",
+            "operation_id",
+            "created_at",
+            "updated_at",
+        )
+        if any(column not in snapshot for column in columns):
+            return False
+        names = ", ".join(columns)
+        placeholders = ", ".join("?" for _ in columns)
+        updates = ", ".join(
+            f"{column}=excluded.{column}" for column in columns if column != "id"
+        )
+        self._conn.execute(
+            f"""
+            INSERT INTO portrait_facts ({names}) VALUES ({placeholders})
+            ON CONFLICT(id) DO UPDATE SET {updates}
+            """,
+            [snapshot[column] for column in columns],
+        )
+        return True
+
+    def _restore_portrait_queue_snapshot_sync(
+        self, fact_id: str, rows: list[Any]
+    ) -> bool:
+        columns = (
+            "queue_id",
+            "person_id",
+            "fact_id",
+            "evidence_hash",
+            "state",
+            "created_at",
+            "updated_at",
+        )
+        normalized: list[dict[str, Any]] = []
+        for raw in rows:
+            if not isinstance(raw, dict):
+                return False
+            row = dict(raw)
+            if (
+                any(column not in row for column in columns)
+                or clean_text(row.get("fact_id"), 120) != fact_id
+            ):
+                return False
+            normalized.append(row)
+        self._conn.execute(
+            "DELETE FROM portrait_learning_queue WHERE fact_id=?", (fact_id,)
+        )
+        for row in normalized:
+            self._conn.execute(
+                """
+                INSERT INTO portrait_learning_queue(
+                    queue_id, person_id, fact_id, evidence_hash, state,
+                    created_at, updated_at
+                ) VALUES(?,?,?,?,?,?,?)
+                """,
+                [row[column] for column in columns],
+            )
+        return True
+
+    @staticmethod
+    def _profile_repair_history(
+        metadata: dict[str, Any],
+        *,
+        operation_id: str,
+        action: str,
+        reason: str,
+        now: str,
+    ) -> dict[str, Any]:
+        updated = dict(metadata)
+        history = updated.get("profile_repair_history")
+        history = list(history) if isinstance(history, list) else []
+        history.append(
+            {
+                "operation_id": operation_id,
+                "action": action,
+                "reason": clean_text(reason, 240),
+                "applied_at": now,
+            }
+        )
+        updated["profile_repair_history"] = history[-20:]
+        return updated
+
+    def _profile_repair_merge_sync(
+        self,
+        source: MemoryRecord,
+        canonical: MemoryRecord,
+        *,
+        operation_id: str,
+        reason: str,
+        now: str,
+    ) -> tuple[MemoryRecord, MemoryRecord] | None:
+        source_metadata = source.metadata if isinstance(source.metadata, dict) else {}
+        canonical_metadata = (
+            canonical.metadata if isinstance(canonical.metadata, dict) else {}
+        )
+        if self._profile_domain(source) != self._profile_domain(canonical):
+            return None
+        source_dimension = clean_text(
+            source_metadata.get("profile_dimension"), 80
+        ).lower()
+        canonical_dimension = clean_text(
+            canonical_metadata.get("profile_dimension"), 80
+        ).lower()
+        source_value = clean_text(
+            source_metadata.get("normalized_value"), 240
+        ).casefold()
+        canonical_value = clean_text(
+            canonical_metadata.get("normalized_value"), 240
+        ).casefold()
+        source_polarity = clean_text(
+            source_metadata.get("profile_polarity"), 40
+        ).lower()
+        canonical_polarity = clean_text(
+            canonical_metadata.get("profile_polarity"), 40
+        ).lower()
+        if (
+            not source_dimension
+            or source_dimension != canonical_dimension
+            or source_value != canonical_value
+            or source_polarity != canonical_polarity
+        ):
+            return None
+
+        refs = list(
+            dict.fromkeys(
+                [
+                    *self._profile_evidence_refs(canonical),
+                    *self._profile_evidence_refs(source),
+                ]
+            )
+        )[:256]
+        statement_fingerprints = list(
+            dict.fromkeys(
+                [
+                    *self._profile_statement_fingerprints(canonical),
+                    *self._profile_statement_fingerprints(source),
+                ]
+            )
+        )[:256]
+        next_state = (
+            "active"
+            if "active" in {self._profile_state(source), self._profile_state(canonical)}
+            else "candidate"
+        )
+        merged_metadata = self._profile_repair_history(
+            canonical_metadata,
+            operation_id=operation_id,
+            action="merge_target",
+            reason=reason,
+            now=now,
+        )
+        merged_metadata["profile_evidence_refs"] = refs
+        merged_metadata["profile_statement_fingerprints"] = statement_fingerprints
+        merged_metadata["evidence_count"] = len(refs)
+        merged_metadata["independent_evidence_count"] = min(
+            len(refs),
+            len(statement_fingerprints),
+        )
+        merged_metadata["profile_state"] = next_state
+        merged_metadata["profile_status"] = next_state
+        canonical.metadata = merged_metadata
+        canonical.evidence = self._profile_evidence_text([canonical, source])
+        canonical.confidence = max(canonical.confidence, source.confidence)
+        canonical.importance = max(canonical.importance, source.importance)
+        canonical.merged_count = max(1, len(refs))
+        canonical.lifecycle = "stable_memory" if next_state == "active" else "raw_event"
+        canonical.review_status = "auto" if next_state == "active" else "pending"
+        canonical.updated_at = now
+
+        superseded_metadata = self._profile_repair_history(
+            source_metadata,
+            operation_id=operation_id,
+            action="merge_source",
+            reason=reason,
+            now=now,
+        )
+        superseded_metadata["profile_state"] = "superseded"
+        superseded_metadata["profile_status"] = "superseded"
+        superseded_metadata["profile_superseded_by"] = canonical.id
+        source.metadata = superseded_metadata
+        source.lifecycle = "archived"
+        source.review_status = "auto"
+        source.supersedes_id = canonical.id
+        source.updated_at = now
+        return source, canonical
+
+    async def apply_profile_repairs(
+        self,
+        *,
+        operation_id: str,
+        rule_version: str,
+        actions: list[dict[str, Any]],
+        backup_path: str,
+    ) -> dict[str, Any]:
+        return await self._run_recoverable_database_operation(
+            self._apply_profile_repairs_sync,
+            operation_id,
+            rule_version,
+            deepcopy(actions),
+            backup_path,
+        )
+
+    def _apply_profile_repairs_sync(
+        self,
+        operation_id: str,
+        rule_version: str,
+        actions: list[dict[str, Any]],
+        backup_path: str,
+    ) -> dict[str, Any]:
+        operation_id = self._valid_profile_operation_id(operation_id)
+        rule_version = clean_text(rule_version, 80)
+        backup_path = clean_text(backup_path, 2000)
+        if not operation_id or not rule_version or not backup_path:
+            raise ValueError("profile repair operation metadata is invalid")
+        if len(actions) > 100000:
+            raise ValueError("profile repair action limit exceeded")
+        plan_fingerprint = self.profile_repair_plan_fingerprint(actions)
+        now = utc_now()
+
+        with self._lock:  # noqa: SIM117
+            with self._transaction_sync():
+                prior = self._conn.execute(
+                    "SELECT * FROM profile_repair_operations WHERE operation_id=?",
+                    (operation_id,),
+                ).fetchone()
+                if prior is not None:
+                    if (
+                        clean_text(prior["rule_version"], 80) != rule_version
+                        or clean_text(prior["plan_fingerprint"], 80) != plan_fingerprint
+                    ):
+                        raise ValueError(
+                            "profile repair operation id already used with a different plan"
+                        )
+                    if clean_text(prior["state"], 40) == "rolled_back":
+                        raise ValueError(
+                            "profile repair operation has already been rolled back"
+                        )
+                    result = json_loads(prior["result"], {})
+                    return {
+                        **(result if isinstance(result, dict) else {}),
+                        "ok": True,
+                        "code": "profile_repair_idempotent_replay",
+                        "operation_id": operation_id,
+                    }
+
+                snapshots: dict[str, dict[str, Any]] = {}
+                validated_targets: set[str] = set()
+                validated_portrait_targets: set[str] = set()
+                changed_ids: set[str] = set()
+                affected_portrait_people: set[str] = set()
+                results: list[dict[str, Any]] = []
+                for raw_action in actions:
+                    if not isinstance(raw_action, dict):
+                        continue
+                    record_kind = clean_text(
+                        raw_action.get("record_kind"), 32
+                    ).lower() or "memory"
+                    memory_id = clean_text(
+                        raw_action.get("record_id")
+                        or raw_action.get("memory_id"),
+                        120,
+                    )
+                    action = clean_text(raw_action.get("action"), 24).lower()
+                    reason = clean_text(raw_action.get("reason"), 240)
+                    if record_kind == "portrait_fact":
+                        portrait_key = f"portrait_fact:{memory_id}"
+                        fact_row = self._conn.execute(
+                            "SELECT * FROM portrait_facts WHERE id=?",
+                            (memory_id,),
+                        ).fetchone()
+                        if fact_row is None:
+                            results.append(
+                                {
+                                    "record_kind": record_kind,
+                                    "record_id": memory_id,
+                                    "status": "missing",
+                                }
+                            )
+                            continue
+                        fact = dict(fact_row)
+                        if (
+                            clean_text(fact.get("producer_kind"), 80)
+                            != "rule_explicit"
+                            or clean_text(fact.get("producer_version"), 80)
+                            not in self.PROFILE_RULE_PORTRAIT_VERSIONS
+                        ):
+                            results.append(
+                                {
+                                    "record_kind": record_kind,
+                                    "record_id": memory_id,
+                                    "status": "unsupported",
+                                }
+                            )
+                            continue
+                        expected = clean_text(
+                            raw_action.get("expected_fingerprint"), 80
+                        )
+                        queue_rows = self._conn.execute(
+                            """
+                            SELECT * FROM portrait_learning_queue
+                            WHERE fact_id=? ORDER BY queue_id
+                            """,
+                            (memory_id,),
+                        ).fetchall()
+                        expected_queue = clean_text(
+                            raw_action.get("expected_queue_fingerprint"), 80
+                        )
+                        if (
+                            not expected
+                            or self.profile_portrait_fact_fingerprint(fact)
+                            != expected
+                            or (
+                                expected_queue
+                                and self.profile_portrait_queue_fingerprint(
+                                    queue_rows
+                                )
+                                != expected_queue
+                            )
+                        ):
+                            results.append(
+                                {
+                                    "record_kind": record_kind,
+                                    "record_id": memory_id,
+                                    "status": "skip-stale",
+                                }
+                            )
+                            continue
+                        if action == "keep":
+                            results.append(
+                                {
+                                    "record_kind": record_kind,
+                                    "record_id": memory_id,
+                                    "status": "kept",
+                                }
+                            )
+                            continue
+                        if action not in {"pending", "archive"}:
+                            results.append(
+                                {
+                                    "record_kind": record_kind,
+                                    "record_id": memory_id,
+                                    "status": "invalid-action",
+                                }
+                            )
+                            continue
+                        snapshots.setdefault(
+                            portrait_key,
+                            self._profile_repair_portrait_snapshot_sync(
+                                fact,
+                                group_id=self.profile_repair_group_id(memory_id),
+                            ),
+                        )
+                        target_state = "pending"
+                        canonical_id = ""
+                        queue_state = "pending_review"
+                        if action == "archive":
+                            target_state = clean_text(
+                                raw_action.get("target_state"), 32
+                            ).lower()
+                            if target_state not in {"rejected", "superseded"}:
+                                target_state = "rejected"
+                            queue_state = target_state
+                        if target_state == "superseded":
+                            canonical_id = clean_text(
+                                raw_action.get("canonical_id"), 120
+                            )
+                            group_id = self.profile_repair_group_id(canonical_id)
+                            snapshots[portrait_key]["group_id"] = group_id
+                            canonical_row = self._conn.execute(
+                                "SELECT * FROM portrait_facts WHERE id=?",
+                                (canonical_id,),
+                            ).fetchone()
+                            if canonical_row is None or canonical_id == memory_id:
+                                results.append(
+                                    {
+                                        "record_kind": record_kind,
+                                        "record_id": memory_id,
+                                        "status": "invalid-canonical",
+                                    }
+                                )
+                                continue
+                            canonical = dict(canonical_row)
+                            canonical_queue = self._conn.execute(
+                                """
+                                SELECT * FROM portrait_learning_queue
+                                WHERE fact_id=? ORDER BY queue_id
+                                """,
+                                (canonical_id,),
+                            ).fetchall()
+                            if canonical_id not in validated_portrait_targets:
+                                canonical_expected = clean_text(
+                                    raw_action.get(
+                                        "canonical_expected_fingerprint"
+                                    ),
+                                    80,
+                                )
+                                canonical_queue_expected = clean_text(
+                                    raw_action.get(
+                                        "canonical_expected_queue_fingerprint"
+                                    ),
+                                    80,
+                                )
+                                if (
+                                    not canonical_expected
+                                    or self.profile_portrait_fact_fingerprint(
+                                        canonical
+                                    )
+                                    != canonical_expected
+                                    or (
+                                        canonical_queue_expected
+                                        and self.profile_portrait_queue_fingerprint(
+                                            canonical_queue
+                                        )
+                                        != canonical_queue_expected
+                                    )
+                                ):
+                                    results.append(
+                                        {
+                                            "record_kind": record_kind,
+                                            "record_id": memory_id,
+                                            "status": "skip-stale",
+                                        }
+                                    )
+                                    continue
+                                validated_portrait_targets.add(canonical_id)
+                            if (
+                                clean_text(fact.get("person_id"), 80)
+                                != clean_text(canonical.get("person_id"), 80)
+                                or clean_text(fact.get("dimension"), 80).lower()
+                                != clean_text(
+                                    canonical.get("dimension"), 80
+                                ).lower()
+                                or clean_text(fact.get("source_scope"), 80)
+                                != clean_text(
+                                    canonical.get("source_scope"), 80
+                                )
+                                or clean_text(canonical.get("status"), 40)
+                                != "active"
+                            ):
+                                results.append(
+                                    {
+                                        "record_kind": record_kind,
+                                        "record_id": memory_id,
+                                        "status": "acl-domain-mismatch",
+                                    }
+                                )
+                                continue
+                            canonical_key = f"portrait_fact:{canonical_id}"
+                            snapshots.setdefault(
+                                canonical_key,
+                                self._profile_repair_portrait_snapshot_sync(
+                                    canonical,
+                                    group_id=group_id,
+                                    guard_only=True,
+                                ),
+                            )
+                            snapshots[canonical_key]["group_id"] = group_id
+
+                        self._conn.execute(
+                            """
+                            UPDATE portrait_facts
+                            SET status=?, supersedes_id=?, revision=revision+1,
+                                operation_id=?, updated_at=?
+                            WHERE id=?
+                            """,
+                            (
+                                target_state,
+                                canonical_id,
+                                operation_id,
+                                now,
+                                memory_id,
+                            ),
+                        )
+                        self._conn.execute(
+                            """
+                            UPDATE portrait_learning_queue
+                            SET state=?, updated_at=?
+                            WHERE fact_id=? AND state='pending'
+                            """,
+                            (queue_state, now, memory_id),
+                        )
+                        person_id = clean_text(fact.get("person_id"), 80)
+                        if person_id:
+                            affected_portrait_people.add(person_id)
+                        changed_ids.add(portrait_key)
+                        results.append(
+                            {
+                                "record_kind": record_kind,
+                                "record_id": memory_id,
+                                "status": "applied",
+                                "action": action,
+                                "canonical_id": canonical_id,
+                            }
+                        )
+                        continue
+                    if record_kind != "memory":
+                        results.append(
+                            {
+                                "record_kind": record_kind,
+                                "record_id": memory_id,
+                                "memory_id": memory_id,
+                                "status": "unsupported",
+                            }
+                        )
+                        continue
+                    row = self._conn.execute(
+                        "SELECT * FROM memories WHERE id=?", (memory_id,)
+                    ).fetchone()
+                    if row is None:
+                        results.append({"memory_id": memory_id, "status": "missing"})
+                        continue
+                    current = MemoryRecord.from_row(row)
+                    metadata = (
+                        current.metadata if isinstance(current.metadata, dict) else {}
+                    )
+                    if (
+                        current.memory_type not in self.PROFILE_MEMORY_TYPES
+                        or clean_text(metadata.get("extractor"), 40).lower()
+                        not in self.PROFILE_RULE_EXTRACTORS
+                    ):
+                        results.append(
+                            {"memory_id": memory_id, "status": "unsupported"}
+                        )
+                        continue
+                    expected = clean_text(raw_action.get("expected_fingerprint"), 80)
+                    if (
+                        not expected
+                        or self.profile_memory_fingerprint(current) != expected
+                    ):
+                        results.append({"memory_id": memory_id, "status": "skip-stale"})
+                        continue
+                    if action == "keep":
+                        results.append({"memory_id": memory_id, "status": "kept"})
+                        continue
+                    if action not in {"pending", "archive", "merge"}:
+                        results.append(
+                            {"memory_id": memory_id, "status": "invalid-action"}
+                        )
+                        continue
+                    snapshots.setdefault(
+                        memory_id,
+                        self._profile_repair_record_snapshot_sync(
+                            current,
+                            group_id=self.profile_repair_group_id(memory_id),
+                        ),
+                    )
+
+                    records_to_write: list[MemoryRecord] = []
+                    if action == "merge":
+                        canonical_id = clean_text(raw_action.get("canonical_id"), 120)
+                        group_id = self.profile_repair_group_id(canonical_id)
+                        snapshots[memory_id]["group_id"] = group_id
+                        canonical_row = self._conn.execute(
+                            "SELECT * FROM memories WHERE id=?",
+                            (canonical_id,),
+                        ).fetchone()
+                        if canonical_row is None or canonical_id == memory_id:
+                            results.append(
+                                {"memory_id": memory_id, "status": "invalid-canonical"}
+                            )
+                            continue
+                        canonical = MemoryRecord.from_row(canonical_row)
+                        if canonical_id not in validated_targets:
+                            canonical_expected = clean_text(
+                                raw_action.get("canonical_expected_fingerprint"),
+                                80,
+                            )
+                            if (
+                                not canonical_expected
+                                or self.profile_memory_fingerprint(canonical)
+                                != canonical_expected
+                            ):
+                                results.append(
+                                    {"memory_id": memory_id, "status": "skip-stale"}
+                                )
+                                continue
+                            validated_targets.add(canonical_id)
+                            snapshots.setdefault(
+                                canonical_id,
+                                self._profile_repair_record_snapshot_sync(
+                                    canonical,
+                                    group_id=group_id,
+                                ),
+                            )
+                        snapshots[canonical_id]["group_id"] = group_id
+                        merged = self._profile_repair_merge_sync(
+                            current,
+                            canonical,
+                            operation_id=operation_id,
+                            reason=reason,
+                            now=now,
+                        )
+                        if merged is None:
+                            results.append(
+                                {
+                                    "memory_id": memory_id,
+                                    "status": "acl-domain-mismatch",
+                                }
+                            )
+                            continue
+                        records_to_write.extend(merged)
+                    else:
+                        metadata_patch = raw_action.get("metadata_patch")
+                        if isinstance(metadata_patch, dict):
+                            allowed_patch_keys = {
+                                "profile_dimension",
+                                "profile_value",
+                                "normalized_value",
+                                "profile_polarity",
+                                "profile_cardinality",
+                                "extraction_quality",
+                                "extraction_quality_score",
+                                "evidence_strength",
+                                "quality_gate_passed",
+                            }
+                            metadata = {
+                                **metadata,
+                                **{
+                                    key: value
+                                    for key, value in metadata_patch.items()
+                                    if key in allowed_patch_keys
+                                },
+                            }
+                        next_metadata = self._profile_repair_history(
+                            metadata,
+                            operation_id=operation_id,
+                            action=action,
+                            reason=reason,
+                            now=now,
+                        )
+                        if action == "pending":
+                            next_metadata["profile_state"] = "candidate"
+                            next_metadata["profile_status"] = "candidate"
+                            current.lifecycle = "raw_event"
+                            current.review_status = "pending"
+                        else:
+                            target_state = clean_text(
+                                raw_action.get("target_state"),
+                                32,
+                            ).lower()
+                            if target_state not in {"rejected", "superseded"}:
+                                target_state = "rejected"
+                            if target_state == "superseded":
+                                canonical_id = clean_text(
+                                    raw_action.get("canonical_id"),
+                                    120,
+                                )
+                                group_id = self.profile_repair_group_id(canonical_id)
+                                snapshots[memory_id]["group_id"] = group_id
+                                canonical_row = self._conn.execute(
+                                    "SELECT * FROM memories WHERE id=?",
+                                    (canonical_id,),
+                                ).fetchone()
+                                if canonical_row is None or canonical_id == memory_id:
+                                    results.append(
+                                        {
+                                            "memory_id": memory_id,
+                                            "status": "invalid-canonical",
+                                        }
+                                    )
+                                    continue
+                                canonical = MemoryRecord.from_row(canonical_row)
+                                if canonical_id not in validated_targets:
+                                    canonical_expected = clean_text(
+                                        raw_action.get(
+                                            "canonical_expected_fingerprint"
+                                        ),
+                                        80,
+                                    )
+                                    if (
+                                        not canonical_expected
+                                        or self.profile_memory_fingerprint(canonical)
+                                        != canonical_expected
+                                    ):
+                                        results.append(
+                                            {
+                                                "memory_id": memory_id,
+                                                "status": "skip-stale",
+                                            }
+                                        )
+                                        continue
+                                    validated_targets.add(canonical_id)
+                                snapshots.setdefault(
+                                    canonical_id,
+                                    self._profile_repair_record_snapshot_sync(
+                                        canonical,
+                                        group_id=group_id,
+                                        guard_only=True,
+                                    ),
+                                )
+                                snapshots[canonical_id]["group_id"] = group_id
+                                canonical_metadata = (
+                                    canonical.metadata
+                                    if isinstance(canonical.metadata, dict)
+                                    else {}
+                                )
+                                if (
+                                    self._profile_domain(current)
+                                    != self._profile_domain(canonical)
+                                    or clean_text(
+                                        metadata.get("profile_dimension"),
+                                        80,
+                                    ).lower()
+                                    != clean_text(
+                                        canonical_metadata.get("profile_dimension"),
+                                        80,
+                                    ).lower()
+                                    or self._profile_state(canonical) != "active"
+                                ):
+                                    results.append(
+                                        {
+                                            "memory_id": memory_id,
+                                            "status": "acl-domain-mismatch",
+                                        }
+                                    )
+                                    continue
+                            next_metadata["profile_state"] = target_state
+                            next_metadata["profile_status"] = target_state
+                            next_metadata["profile_archive_reason"] = reason
+                            current.lifecycle = "archived"
+                            current.review_status = "auto"
+                            if target_state == "superseded":
+                                current.supersedes_id = canonical_id
+                                next_metadata["profile_superseded_by"] = (
+                                    current.supersedes_id
+                                )
+                        current.metadata = next_metadata
+                        current.updated_at = now
+                        records_to_write.append(current)
+
+                    for changed in records_to_write:
+                        self._write_memory_record_sync(changed)
+                        self._conn.execute(
+                            "DELETE FROM memory_embeddings WHERE memory_id=?",
+                            (changed.id,),
+                        )
+                        if changed.review_status == "pending":
+                            self._upsert_review_sync(
+                                changed.id,
+                                "profile_repair_pending",
+                            )
+                        else:
+                            self._conn.execute(
+                                "UPDATE review_queue SET status=?, updated_at=? WHERE memory_id=? AND status='pending'",
+                                (
+                                    "superseded" if changed.supersedes_id else "auto",
+                                    now,
+                                    changed.id,
+                                ),
+                            )
+                        changed_ids.add(changed.id)
+                    results.append(
+                        {
+                            "memory_id": memory_id,
+                            "status": "applied",
+                            "action": action,
+                            "canonical_id": clean_text(
+                                raw_action.get("canonical_id"), 120
+                            ),
+                        }
+                    )
+
+                for person_id in sorted(affected_portrait_people):
+                    self._bump_portrait_revision_sync(person_id)
+                for snapshot in snapshots.values():
+                    record_kind = clean_text(
+                        snapshot.get("record_kind"), 32
+                    ).lower() or "memory"
+                    record_id = clean_text(
+                        snapshot.get("record_id")
+                        or snapshot.get("memory_id"),
+                        120,
+                    )
+                    if record_kind == "portrait_fact":
+                        row = self._conn.execute(
+                            "SELECT * FROM portrait_facts WHERE id=?",
+                            (record_id,),
+                        ).fetchone()
+                        if row is not None:
+                            snapshot["after_fingerprint"] = (
+                                self.profile_portrait_fact_fingerprint(row)
+                            )
+                            queue_rows = self._conn.execute(
+                                """
+                                SELECT * FROM portrait_learning_queue
+                                WHERE fact_id=? ORDER BY queue_id
+                                """,
+                                (record_id,),
+                            ).fetchall()
+                            snapshot["after_queue_fingerprint"] = (
+                                self.profile_portrait_queue_fingerprint(
+                                    queue_rows
+                                )
+                            )
+                        continue
+                    row = self._conn.execute(
+                        "SELECT * FROM memories WHERE id=?", (record_id,)
+                    ).fetchone()
+                    if row is not None:
+                        snapshot["after_fingerprint"] = self.profile_memory_fingerprint(
+                            MemoryRecord.from_row(row)
+                        )
+                snapshot_payload = {
+                    "schema_version": "profile.repair.snapshot.v2",
+                    "records": list(snapshots.values()),
+                }
+                stale_count = sum(
+                    1 for item in results if item.get("status") == "skip-stale"
+                )
+                result = {
+                    "ok": True,
+                    "code": "profile_repair_applied",
+                    "operation_id": operation_id,
+                    "rule_version": rule_version,
+                    "plan_fingerprint": plan_fingerprint,
+                    "backup_path": backup_path,
+                    "results": results,
+                    "changed": len(changed_ids),
+                    "stale": stale_count,
+                }
+                state = (
+                    "partial"
+                    if any(
+                        item.get("status")
+                        in {
+                            "skip-stale",
+                            "missing",
+                            "unsupported",
+                            "invalid-action",
+                            "invalid-canonical",
+                            "acl-domain-mismatch",
+                        }
+                        for item in results
+                    )
+                    else "applied"
+                )
+                self._conn.execute(
+                    """
+                    INSERT INTO profile_repair_operations(
+                        operation_id, rule_version, state, backup_path, plan_fingerprint,
+                        snapshot, result, created_at, updated_at
+                    ) VALUES(?,?,?,?,?,?,?,?,?)
+                    """,
+                    (
+                        operation_id,
+                        rule_version,
+                        state,
+                        backup_path,
+                        plan_fingerprint,
+                        json_dumps(snapshot_payload),
+                        json_dumps(result),
+                        now,
+                        now,
+                    ),
+                )
+                self._embedding_candidate_cache.clear()
+                self._embedding_candidate_cache_revision = ""
+        return result
+
+    async def get_profile_repair_operation(
+        self, operation_id: str
+    ) -> dict[str, Any] | None:
+        return await self._run_recoverable_database_operation(
+            self._get_profile_repair_operation_sync,
+            operation_id,
+        )
+
+    def _get_profile_repair_operation_sync(
+        self, operation_id: str
+    ) -> dict[str, Any] | None:
+        operation_id = self._valid_profile_operation_id(operation_id)
+        if not operation_id:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM profile_repair_operations WHERE operation_id=?",
+                (operation_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["snapshot"] = json_loads(result.get("snapshot"), {})
+        result["result"] = json_loads(result.get("result"), {})
+        return result
+
+    async def rollback_profile_repairs(
+        self,
+        *,
+        operation_id: str,
+        rollback_backup_path: str = "",
+    ) -> dict[str, Any]:
+        return await self._run_recoverable_database_operation(
+            self._rollback_profile_repairs_sync,
+            operation_id,
+            rollback_backup_path,
+        )
+
+    def _rollback_profile_repairs_sync(
+        self,
+        operation_id: str,
+        rollback_backup_path: str,
+    ) -> dict[str, Any]:
+        operation_id = self._valid_profile_operation_id(operation_id)
+        if not operation_id:
+            raise ValueError("invalid profile repair operation id")
+        now = utc_now()
+        with self._lock:  # noqa: SIM117
+            with self._transaction_sync():
+                operation = self._conn.execute(
+                    "SELECT * FROM profile_repair_operations WHERE operation_id=?",
+                    (operation_id,),
+                ).fetchone()
+                if operation is None:
+                    raise ValueError("profile repair operation not found")
+                if clean_text(operation["state"], 40) == "rolled_back":
+                    previous = json_loads(operation["result"], {})
+                    return {
+                        **(previous if isinstance(previous, dict) else {}),
+                        "ok": True,
+                        "code": "profile_repair_rollback_idempotent",
+                        "operation_id": operation_id,
+                    }
+                if clean_text(operation["state"], 40) not in {"applied", "partial"}:
+                    raise ValueError("profile repair operation is not rollbackable")
+                snapshot = json_loads(operation["snapshot"], {})
+                records = snapshot.get("records") if isinstance(snapshot, dict) else []
+                records = records if isinstance(records, list) else []
+                results: list[dict[str, Any]] = []
+                groups: dict[str, list[dict[str, Any]]] = {}
+                for index, item in enumerate(records):
+                    if not isinstance(item, dict):
+                        continue
+                    record_kind = clean_text(
+                        item.get("record_kind"), 32
+                    ).lower() or "memory"
+                    record_id = clean_text(
+                        item.get("record_id") or item.get("memory_id"), 120
+                    )
+                    group_id = clean_text(item.get("group_id"), 120)
+                    if not group_id:
+                        group_id = f"legacy:{record_kind}:{record_id}:{index}"
+                    groups.setdefault(group_id, []).append(item)
+
+                restored_portrait_people: set[str] = set()
+                for group_id, group in groups.items():
+                    prepared: list[dict[str, Any]] = []
+                    failures: dict[tuple[str, str], str] = {}
+                    for item in group:
+                        record_kind = clean_text(
+                            item.get("record_kind"), 32
+                        ).lower() or "memory"
+                        record_id = clean_text(
+                            item.get("record_id") or item.get("memory_id"), 120
+                        )
+                        failure_key = (record_kind, record_id)
+                        before = (
+                            item.get("before")
+                            if isinstance(item.get("before"), dict)
+                            else {}
+                        )
+                        if record_kind == "portrait_fact":
+                            row = self._conn.execute(
+                                "SELECT * FROM portrait_facts WHERE id=?",
+                                (record_id,),
+                            ).fetchone()
+                            if row is None:
+                                failures[failure_key] = "missing"
+                                continue
+                            queue_rows = self._conn.execute(
+                                """
+                                SELECT * FROM portrait_learning_queue
+                                WHERE fact_id=? ORDER BY queue_id
+                                """,
+                                (record_id,),
+                            ).fetchall()
+                            if (
+                                self.profile_portrait_fact_fingerprint(row)
+                                != clean_text(
+                                    item.get("after_fingerprint"), 80
+                                )
+                                or self.profile_portrait_queue_fingerprint(
+                                    queue_rows
+                                )
+                                != clean_text(
+                                    item.get("after_queue_fingerprint"), 80
+                                )
+                            ):
+                                failures[failure_key] = "skip-stale"
+                                continue
+                            queue_snapshot = item.get("learning_queue")
+                            if (
+                                clean_text(before.get("id"), 120) != record_id
+                                or not isinstance(queue_snapshot, list)
+                                or any(
+                                    not isinstance(queue_item, dict)
+                                    or clean_text(
+                                        queue_item.get("fact_id"), 120
+                                    )
+                                    != record_id
+                                    for queue_item in queue_snapshot
+                                )
+                            ):
+                                failures[failure_key] = "invalid-snapshot"
+                                continue
+                            prepared.append(
+                                {
+                                    "item": item,
+                                    "record_kind": record_kind,
+                                    "record_id": record_id,
+                                    "restored": before,
+                                }
+                            )
+                            continue
+                        if record_kind != "memory":
+                            failures[failure_key] = "invalid-snapshot"
+                            continue
+                        row = self._conn.execute(
+                            "SELECT * FROM memories WHERE id=?", (record_id,)
+                        ).fetchone()
+                        if row is None:
+                            failures[failure_key] = "missing"
+                            continue
+                        current = MemoryRecord.from_row(row)
+                        if self.profile_memory_fingerprint(current) != clean_text(
+                            item.get("after_fingerprint"), 80
+                        ):
+                            failures[failure_key] = "skip-stale"
+                            continue
+                        try:
+                            restored = self._memory_from_db_snapshot(before)
+                        except (KeyError, TypeError, ValueError):
+                            failures[failure_key] = "invalid-snapshot"
+                            continue
+                        prepared.append(
+                            {
+                                "item": item,
+                                "record_kind": record_kind,
+                                "record_id": record_id,
+                                "restored": restored,
+                            }
+                        )
+
+                    if failures:
+                        for item in group:
+                            record_kind = clean_text(
+                                item.get("record_kind"), 32
+                            ).lower() or "memory"
+                            record_id = clean_text(
+                                item.get("record_id")
+                                or item.get("memory_id"),
+                                120,
+                            )
+                            result_item = {
+                                "record_kind": record_kind,
+                                "record_id": record_id,
+                                "group_id": group_id,
+                                "status": failures.get(
+                                    (record_kind, record_id),
+                                    "skip-group-stale",
+                                ),
+                            }
+                            if record_kind == "memory":
+                                result_item["memory_id"] = record_id
+                            results.append(result_item)
+                        continue
+
+                    for prepared_item in prepared:
+                        item = prepared_item["item"]
+                        record_kind = prepared_item["record_kind"]
+                        record_id = prepared_item["record_id"]
+                        result_item = {
+                            "record_kind": record_kind,
+                            "record_id": record_id,
+                            "group_id": group_id,
+                        }
+                        if record_kind == "memory":
+                            result_item["memory_id"] = record_id
+                        if bool(item.get("guard_only")):
+                            result_item["status"] = "guard-verified"
+                            results.append(result_item)
+                            continue
+                        if record_kind == "portrait_fact":
+                            restored_fact = prepared_item["restored"]
+                            if not self._write_portrait_fact_snapshot_sync(
+                                restored_fact
+                            ) or not self._restore_portrait_queue_snapshot_sync(
+                                record_id, item.get("learning_queue", [])
+                            ):
+                                raise ValueError(
+                                    "invalid portrait repair snapshot"
+                                )
+                            person_id = clean_text(
+                                restored_fact.get("person_id"), 80
+                            )
+                            if person_id:
+                                restored_portrait_people.add(person_id)
+                            result_item["status"] = "rolled-back"
+                            results.append(result_item)
+                            continue
+
+                        restored = prepared_item["restored"]
+                        self._write_memory_record_sync(restored)
+                        self._conn.execute(
+                            "DELETE FROM review_queue WHERE memory_id=?",
+                            (record_id,),
+                        )
+                        for review in item.get("review_queue", []):
+                            if not isinstance(review, dict):
+                                continue
+                            self._conn.execute(
+                                """
+                                INSERT INTO review_queue(id, memory_id, reason, status, created_at, updated_at)
+                                VALUES(?,?,?,?,?,?)
+                                """,
+                                (
+                                    clean_text(review.get("id"), 120),
+                                    record_id,
+                                    clean_text(review.get("reason"), 500),
+                                    clean_text(review.get("status"), 40),
+                                    clean_text(review.get("created_at"), 80),
+                                    clean_text(review.get("updated_at"), 80),
+                                ),
+                            )
+                        self._conn.execute(
+                            "DELETE FROM memory_embeddings WHERE memory_id=?",
+                            (record_id,),
+                        )
+                        for embedding in item.get("embeddings", []):
+                            if not isinstance(embedding, dict):
+                                continue
+                            self._conn.execute(
+                                """
+                                INSERT INTO memory_embeddings(
+                                    memory_id, provider_id, text_hash, dimension, vector, created_at, updated_at
+                                ) VALUES(?,?,?,?,?,?,?)
+                                """,
+                                (
+                                    record_id,
+                                    clean_text(embedding.get("provider_id"), 160),
+                                    clean_text(embedding.get("text_hash"), 80),
+                                    max(0, int(embedding.get("dimension") or 0)),
+                                    clean_text(embedding.get("vector"), 100000),
+                                    clean_text(embedding.get("created_at"), 80),
+                                    clean_text(embedding.get("updated_at"), 80),
+                                ),
+                            )
+                        result_item["status"] = "rolled-back"
+                        results.append(result_item)
+
+                for person_id in sorted(restored_portrait_people):
+                    self._bump_portrait_revision_sync(person_id)
+
+                rolled_back = sum(
+                    1 for item in results if item.get("status") == "rolled-back"
+                )
+                stale = sum(
+                    1
+                    for item in results
+                    if item.get("status")
+                    in {
+                        "skip-stale",
+                        "skip-group-stale",
+                        "missing",
+                        "invalid-snapshot",
+                    }
+                )
+                guards = sum(
+                    1 for item in results if item.get("status") == "guard-verified"
+                )
+                previous_result = json_loads(operation["result"], {})
+                result = (
+                    dict(previous_result) if isinstance(previous_result, dict) else {}
+                )
+                result.update(
+                    {
+                        "ok": True,
+                        "code": "profile_repair_rolled_back",
+                        "operation_id": operation_id,
+                        "rollback_backup_path": clean_text(rollback_backup_path, 2000),
+                        "rollback_results": results,
+                        "rolled_back": rolled_back,
+                        "rollback_stale": stale,
+                    }
+                )
+                state = (
+                    "rolled_back"
+                    if rolled_back + guards == len(results) and stale == 0
+                    else "partial"
+                )
+                self._conn.execute(
+                    "UPDATE profile_repair_operations SET state=?, result=?, updated_at=? WHERE operation_id=?",
+                    (state, json_dumps(result), now, operation_id),
+                )
+                self._embedding_candidate_cache.clear()
+                self._embedding_candidate_cache_revision = ""
+        return result
 
     async def insert_memory(self, record: MemoryRecord, review_reason: str = "") -> str:
         return await self._run_recoverable_database_operation(
@@ -6382,6 +8648,19 @@ class MemoryStore:
                 next_metadata = metadata if isinstance(metadata, dict) else json_loads(row["metadata"], {})
                 if not isinstance(next_metadata, dict):
                     next_metadata = {}
+                prospective = MemoryRecord.from_row(row)
+                prospective.memory_type = next_type
+                prospective.visibility = next_visibility
+                prospective.lifecycle = next_lifecycle
+                prospective.review_status = next_review_status
+                prospective.metadata = dict(next_metadata)
+                current = MemoryRecord.from_row(row)
+                if (
+                    self._profile_single_value_invariant_signature(current)
+                    != self._profile_single_value_invariant_signature(prospective)
+                    and self._profile_single_value_domain_conflict_sync(prospective)
+                ):
+                    return False
                 try:
                     next_importance = max(0.0, min(1.0, float(importance if importance is not None else row["importance"])))
                 except Exception:
@@ -6563,20 +8842,156 @@ class MemoryStore:
         return await asyncio.to_thread(self._update_review_status_sync, memory_id, status)
 
     def _update_review_status_sync(self, memory_id: str, status: str) -> bool:
+        memory_id = clean_text(memory_id, 120)
         now = utc_now()
-        status = "auto" if status in {"approve", "approved", "auto"} else "rejected"
-        lifecycle = "archived" if status == "rejected" else "stable_memory"
-        with self._lock:
-            cur = self._conn.execute(
-                "UPDATE memories SET review_status=?, lifecycle=?, updated_at=? WHERE id=?",
-                (status, lifecycle, now, memory_id),
-            )
-            self._conn.execute(
-                "UPDATE review_queue SET status=?, updated_at=? WHERE memory_id=?",
-                (status, now, memory_id),
-            )
-            self._conn.commit()
-            return cur.rowcount > 0
+        review_status = (
+            "auto"
+            if clean_text(status, 24).lower() in {"approve", "approved", "auto"}
+            else "rejected"
+        )
+        lifecycle = "archived" if review_status == "rejected" else "stable_memory"
+        with self._lock:  # noqa: SIM117
+            with self._transaction_sync():
+                row = self._conn.execute(
+                    "SELECT * FROM memories WHERE id=?", (memory_id,)
+                ).fetchone()
+                if row is None:
+                    return False
+
+                record = MemoryRecord.from_row(row)
+                metadata = (
+                    dict(record.metadata) if isinstance(record.metadata, dict) else {}
+                )
+                extractor = clean_text(metadata.get("extractor"), 40).lower()
+                dimension = clean_text(
+                    metadata.get("profile_dimension"), 80
+                ).lower()
+                is_rule_profile = bool(
+                    record.memory_type in self.PROFILE_MEMORY_TYPES
+                    and extractor in self.PROFILE_RULE_EXTRACTORS
+                )
+                if not is_rule_profile:
+                    self._conn.execute(
+                        "UPDATE memories SET review_status=?, lifecycle=?, updated_at=? WHERE id=?",
+                        (review_status, lifecycle, now, memory_id),
+                    )
+                    self._conn.execute(
+                        "UPDATE review_queue SET status=?, updated_at=? WHERE memory_id=?",
+                        (review_status, now, memory_id),
+                    )
+                    return True
+
+                if review_status == "rejected":
+                    metadata["profile_state"] = "rejected"
+                    metadata["profile_status"] = "rejected"
+                    metadata["profile_archive_reason"] = "manual_rejected"
+                    metadata["profile_status_updated_at"] = now
+                    metadata["quality_gate_passed"] = False
+                    record.metadata = metadata
+                    record.lifecycle = "archived"
+                    record.review_status = "rejected"
+                    record.updated_at = now
+                    self._write_memory_record_sync(record)
+                    self._conn.execute(
+                        "DELETE FROM memory_embeddings WHERE memory_id=?", (record.id,)
+                    )
+                    self._conn.execute(
+                        "UPDATE review_queue SET status='rejected', updated_at=? WHERE memory_id=?",
+                        (now, record.id),
+                    )
+                    self._embedding_candidate_cache.clear()
+                    self._embedding_candidate_cache_revision = ""
+                    return True
+
+                profile_value = clean_text(metadata.get("profile_value"), 240)
+                normalized_value = normalize_profile_value(
+                    metadata.get("normalized_value")
+                )
+                if (
+                    not dimension
+                    or not profile_value
+                    or not normalized_value
+                    or normalize_profile_value(profile_value) != normalized_value
+                ):
+                    return False
+
+                domain_rows = self._profile_domain_rows_sync(record)
+                try:
+                    quality_score = float(
+                        metadata.get("extraction_quality_score") or 0.0
+                    )
+                except (TypeError, ValueError):
+                    quality_score = 0.0
+                if not math.isfinite(quality_score):
+                    quality_score = 0.0
+                metadata["profile_state"] = "active"
+                metadata["profile_status"] = "active"
+                metadata["extraction_quality"] = "confirmed"
+                metadata["extraction_quality_score"] = round(
+                    max(0.95, min(1.0, quality_score)), 4
+                )
+                metadata["evidence_strength"] = "user_confirmed"
+                metadata["quality_gate_passed"] = True
+                metadata["required_evidence_count"] = 1
+                metadata["profile_confirmation_source"] = "manual_review"
+                metadata["profile_status_updated_at"] = now
+                metadata["profile_cardinality"] = (
+                    "single"
+                    if dimension in self.PROFILE_SINGLE_VALUE_DIMENSIONS
+                    else clean_text(metadata.get("profile_cardinality"), 20).lower()
+                    or "multi"
+                )
+                record.metadata = metadata
+                record.confidence = max(float(record.confidence or 0.0), 0.95)
+                record.lifecycle = "stable_memory"
+                record.review_status = "auto"
+                record.updated_at = now
+                self._write_memory_record_sync(record)
+
+                cardinality = metadata["profile_cardinality"]
+                if cardinality == "single":
+                    for domain_row in domain_rows:
+                        other = MemoryRecord.from_row(domain_row)
+                        if other.id == record.id or self._profile_state(other) != "active":
+                            continue
+                        other_metadata = (
+                            dict(other.metadata)
+                            if isinstance(other.metadata, dict)
+                            else {}
+                        )
+                        if (
+                            clean_text(
+                                other_metadata.get("profile_dimension"), 80
+                            ).lower()
+                            != dimension
+                        ):
+                            continue
+                        other_metadata["profile_state"] = "superseded"
+                        other_metadata["profile_status"] = "superseded"
+                        other_metadata["profile_superseded_by"] = record.id
+                        other_metadata["profile_status_updated_at"] = now
+                        other.metadata = other_metadata
+                        other.lifecycle = "archived"
+                        other.review_status = "auto"
+                        other.supersedes_id = record.id
+                        other.updated_at = now
+                        self._write_memory_record_sync(other)
+                        self._conn.execute(
+                            "DELETE FROM memory_embeddings WHERE memory_id=?",
+                            (other.id,),
+                        )
+                        self._conn.execute(
+                            "UPDATE review_queue SET status='superseded', updated_at=? WHERE memory_id=?",
+                            (now, other.id),
+                        )
+
+                self._conn.execute(
+                    "UPDATE review_queue SET status='auto', updated_at=? WHERE memory_id=?",
+                    (now, record.id),
+                )
+                self._embedding_candidate_cache.clear()
+                self._embedding_candidate_cache_revision = ""
+                return True
 
     async def approve_livingmemory_imports(self) -> dict[str, Any]:
         return await asyncio.to_thread(self._approve_livingmemory_imports_sync)
@@ -6685,13 +9100,29 @@ class MemoryStore:
         return await asyncio.to_thread(self._update_memory_visibility_sync, memory_id, visibility)
 
     def _update_memory_visibility_sync(self, memory_id: str, visibility: str) -> bool:
-        with self._lock:
-            cur = self._conn.execute(
-                "UPDATE memories SET visibility=?, updated_at=? WHERE id=?",
-                (clean_text(visibility, 40), utc_now(), clean_text(memory_id, 120)),
-            )
-            self._conn.commit()
-            return cur.rowcount > 0
+        memory_id = clean_text(memory_id, 120)
+        visibility = clean_text(visibility, 40)
+        now = utc_now()
+        with self._lock:  # noqa: SIM117
+            with self._transaction_sync():
+                row = self._conn.execute(
+                    "SELECT * FROM memories WHERE id=?", (memory_id,)
+                ).fetchone()
+                if row is None:
+                    return False
+                record = MemoryRecord.from_row(row)
+                target = deepcopy(record)
+                target.visibility = visibility
+                if self._profile_single_value_domain_conflict_sync(target):
+                    return False
+                cur = self._conn.execute(
+                    "UPDATE memories SET visibility=?, updated_at=? WHERE id=?",
+                    (visibility, now, memory_id),
+                )
+                if cur.rowcount:
+                    self._embedding_candidate_cache.clear()
+                    self._embedding_candidate_cache_revision = ""
+                return cur.rowcount > 0
 
     async def update_memory_lifecycle(self, memory_id: str, lifecycle: str) -> bool:
         return await asyncio.to_thread(self._update_memory_lifecycle_sync, memory_id, lifecycle)

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Operational scripts for the memory companion plugin."""

--- a/scripts/repair_profile_noise.py
+++ b/scripts/repair_profile_noise.py
@@ -1,0 +1,747 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import math
+import re
+import secrets
+import sys
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_models = importlib.import_module("core.models")
+_profile_quality = importlib.import_module("core.profile_quality")
+_store = importlib.import_module("core.store")
+MemoryRecord = _models.MemoryRecord
+clean_text = _models.clean_text
+normalize_profile_value = _profile_quality.normalize_profile_value
+profile_quality_decision = _profile_quality.profile_quality_decision
+profile_rejection_reason = _profile_quality.profile_rejection_reason
+MemoryStore = _store.MemoryStore
+
+APPLY_CONFIRMATION = "APPLY_PROFILE_REPAIR"
+ROLLBACK_CONFIRMATION = "ROLLBACK_PROFILE_REPAIR"
+DEFAULT_RULE_VERSION = "profile_noise_repair_v1"
+
+_SINGLE_VALUE_DIMENSIONS = MemoryStore.PROFILE_SINGLE_VALUE_DIMENSIONS
+_LEGACY_DIMENSIONS = {
+    "称呼": "preferred_address",
+    "生日": "birthday",
+    "职业": "occupation",
+    "专业/学业": "education",
+    "星座/血型": "zodiac_or_blood_type",
+    "习惯": "habit",
+    "喜欢": "preference",
+    "最爱": "preference",
+    "讨厌": "preference",
+    "不喜欢": "preference",
+    "过敏/禁忌": "avoidance",
+    "边界": "boundary",
+    "雷区": "boundary",
+}
+_NOISE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "third_party_statement",
+        re.compile(
+            r"(?:(?:老板娘|老板|同事|别人|有人|他|她)"
+            r"(?:说|提到|提及|描述|介绍|转述|叫|喊|总叫|总喊)|听说|据说)"
+        ),
+    ),
+    (
+        "action_context",
+        re.compile(r"(?:叫我|喊我).{0,8}(?:去|来|跟车|跟着|上班|工作|做|干活)"),
+    ),
+    (
+        "negated_request",
+        re.compile(r"(?:不许|别|不要|不能|怎么还|老是|总是).{0,8}(?:叫我|喊我|称呼我)"),
+    ),
+    (
+        "one_off_request",
+        re.compile(r"(?:叫我|喊我|称呼我).{0,12}(?:几声|一次|这次|今天)"),
+    ),
+    (
+        "temporary_preference",
+        re.compile(
+            r"我\s*(?:很|最|真的)?\s*(?:喜欢|讨厌|不喜欢)\s*"
+            r"(?:今天|今日|这次|这回|本次|此次|刚才|当前|现在)(?:的)?"
+            r"(?:午饭|晚饭|早饭|早餐|互动|对话|聊天|会议|安排|体验|服务|回复|回答)"
+        ),
+    ),
+)
+
+
+def _validated_operation_id(value: Any) -> str:
+    operation_id = MemoryStore._valid_profile_operation_id(value)
+    if not operation_id:
+        raise ValueError("invalid profile repair operation id")
+    return operation_id
+
+
+def _record_state(record: MemoryRecord) -> str:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    state = clean_text(
+        metadata.get("profile_state")
+        or metadata.get("profile_status")
+        or metadata.get("status"),
+        32,
+    ).lower()
+    if state:
+        return state
+    if record.lifecycle == "archived":
+        return "superseded" if record.supersedes_id else "rejected"
+    if record.review_status == "pending":
+        return "candidate"
+    return "active"
+
+
+def _legacy_profile_fields(record: MemoryRecord) -> tuple[str, str, str]:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    dimension = clean_text(metadata.get("profile_dimension"), 80).lower()
+    value = clean_text(metadata.get("profile_value"), 240)
+    normalized = normalize_profile_value(metadata.get("normalized_value"))
+    if dimension and value and normalized:
+        return dimension, value, normalized
+
+    tags = [clean_text(tag, 80) for tag in (record.tags or [])]
+    label = next((tag for tag in tags if tag in _LEGACY_DIMENSIONS), "")
+    if label:
+        dimension = _LEGACY_DIMENSIONS[label]
+        marker = f"{label} "
+        content = clean_text(record.content, 4000)
+        value = clean_text(
+            content.split(marker, 1)[1] if marker in content else "", 240
+        )
+    return dimension, value, normalize_profile_value(value)
+
+
+def _metadata_patch(record: MemoryRecord) -> dict[str, Any]:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    dimension, value, normalized = _legacy_profile_fields(record)
+    patch: dict[str, Any] = {}
+    if dimension and not clean_text(metadata.get("profile_dimension"), 80):
+        patch["profile_dimension"] = dimension
+    if value and not clean_text(metadata.get("profile_value"), 240):
+        patch["profile_value"] = value
+    if normalized and not clean_text(metadata.get("normalized_value"), 240):
+        patch["normalized_value"] = normalized
+    if not clean_text(metadata.get("profile_polarity"), 40):
+        labels = {clean_text(tag, 80) for tag in (record.tags or [])}
+        polarity = ""
+        if labels & {"喜欢", "最爱"}:
+            polarity = "like"
+        elif labels & {"讨厌", "不喜欢"}:
+            polarity = "dislike"
+        elif labels & {"过敏/禁忌", "边界", "雷区"}:
+            polarity = "avoid"
+        elif "称呼" in labels:
+            polarity = "address"
+        elif "习惯" in labels:
+            polarity = "habit"
+        if polarity:
+            patch["profile_polarity"] = polarity
+    if dimension and not clean_text(metadata.get("profile_cardinality"), 20):
+        patch["profile_cardinality"] = (
+            "single" if dimension in _SINGLE_VALUE_DIMENSIONS else "multi"
+        )
+    return patch
+
+
+def _noise_reason(record: MemoryRecord) -> str:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    explicit_reason = clean_text(
+        metadata.get("rejection_reason")
+        or metadata.get("profile_rejection_reason")
+        or metadata.get("quality_rejection_reason"),
+        120,
+    )
+    if explicit_reason:
+        return explicit_reason
+    if metadata.get("quality_gate_passed") is False:
+        return "profile_quality_rejected"
+    source = " ".join(
+        [
+            clean_text(record.evidence, 2000),
+            clean_text(metadata.get("profile_value"), 240),
+            clean_text(record.content, 2000),
+        ]
+    )
+    for candidate_text in (record.evidence, record.content):
+        rejected_reason = profile_rejection_reason(candidate_text)
+        if rejected_reason:
+            return rejected_reason
+    for reason, pattern in _NOISE_PATTERNS:
+        if pattern.search(source):
+            return reason
+    return ""
+
+
+def _domain_key(record: MemoryRecord) -> tuple[str, ...]:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    return (
+        clean_text(record.platform, 80).lower(),
+        clean_text(record.subject.kind, 40).lower(),
+        clean_text(record.subject.id, 120),
+        clean_text(record.object.kind, 40).lower(),
+        clean_text(record.object.id, 120),
+        clean_text(record.scope, 40).lower(),
+        clean_text(record.group_id, 120),
+        clean_text(record.visibility, 40).lower(),
+        clean_text(metadata.get("owner_bot_id"), 120),
+    )
+
+
+def _evidence_refs(record: MemoryRecord) -> list[str]:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    values: list[Any] = []
+    for key in ("profile_evidence_refs", "source_memory_ids", "evidence_refs"):
+        if isinstance(metadata.get(key), list):
+            values.extend(metadata[key])
+    source_memory_id = clean_text(metadata.get("source_memory_id"), 160)
+    if source_memory_id:
+        values.append(source_memory_id)
+    elif not values and record.message_id:
+        values.append(record.message_id)
+    return list(
+        dict.fromkeys(
+            clean_text(value, 160) for value in values if clean_text(value, 160)
+        )
+    )
+
+
+def _quality_score(record: MemoryRecord) -> float:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    try:
+        score = float(metadata.get("extraction_quality_score") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, score)) if math.isfinite(score) else 0.0
+
+
+def _record_rank(record: MemoryRecord) -> tuple[int, float, str, str]:
+    return (
+        1 if _record_state(record) == "active" else 0,
+        _quality_score(record),
+        clean_text(record.occurred_at or record.created_at, 80),
+        record.id,
+    )
+
+
+def _single_value_rank(record: MemoryRecord) -> tuple[int, str, float, str]:
+    return (
+        1 if _record_state(record) == "active" else 0,
+        clean_text(record.occurred_at or record.created_at, 80),
+        _quality_score(record),
+        record.id,
+    )
+
+
+def _entry(record: MemoryRecord, *, action: str, reason: str) -> dict[str, Any]:
+    metadata = record.metadata if isinstance(record.metadata, dict) else {}
+    dimension, value, normalized = _legacy_profile_fields(record)
+    return {
+        "record_kind": "memory",
+        "record_id": record.id,
+        "memory_id": record.id,
+        "fingerprint": MemoryStore.profile_memory_fingerprint(record),
+        "expected_fingerprint": MemoryStore.profile_memory_fingerprint(record),
+        "memory_type": record.memory_type,
+        "user_id": record.subject.id,
+        "scope": record.scope,
+        "extractor": clean_text(metadata.get("extractor"), 40).lower(),
+        "profile_dimension": dimension,
+        "profile_polarity": clean_text(metadata.get("profile_polarity"), 40).lower(),
+        "candidate_value": value,
+        "normalized_value": normalized,
+        "profile_state": _record_state(record),
+        "quality_score": _quality_score(record),
+        "matched_rule": reason,
+        "evidence_refs": _evidence_refs(record),
+        "proposed_action": action,
+        "action": action,
+        "reason": reason,
+        "metadata_patch": _metadata_patch(record),
+        "canonical_id": "",
+        "canonical_expected_fingerprint": "",
+        "group_id": MemoryStore.profile_repair_group_id(record.id),
+        "target_state": "",
+    }
+
+
+def _portrait_noise_reason(fact: dict[str, Any]) -> str:
+    summary = clean_text(fact.get("claim_summary"), 1000)
+    source = f"我{summary.lstrip()}"
+    rejected_reason = profile_rejection_reason(source)
+    if rejected_reason:
+        return rejected_reason
+    for reason, pattern in _NOISE_PATTERNS:
+        if pattern.search(source):
+            return reason
+    return ""
+
+
+def _portrait_rank(fact: dict[str, Any]) -> tuple[str, float, str]:
+    try:
+        confidence = float(fact.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    if not math.isfinite(confidence):
+        confidence = 0.0
+    return (
+        clean_text(
+            fact.get("last_evidence_at")
+            or fact.get("updated_at")
+            or fact.get("created_at"),
+            80,
+        ),
+        max(0.0, min(1.0, confidence)),
+        clean_text(fact.get("id"), 120),
+    )
+
+
+def _portrait_entry(
+    fact: dict[str, Any], *, action: str, reason: str
+) -> dict[str, Any]:
+    fact_id = clean_text(fact.get("id"), 120)
+    fingerprint = MemoryStore.profile_portrait_fact_fingerprint(fact)
+    evidence_refs: list[Any] = []
+    raw_evidence = fact.get("evidence_hashes")
+    if isinstance(raw_evidence, list):
+        evidence_refs = raw_evidence
+    elif isinstance(raw_evidence, str):
+        try:
+            loaded = json.loads(raw_evidence)
+        except (TypeError, ValueError):
+            loaded = []
+        if isinstance(loaded, list):
+            evidence_refs = loaded
+    return {
+        "record_kind": "portrait_fact",
+        "record_id": fact_id,
+        "memory_id": "",
+        "fingerprint": fingerprint,
+        "expected_fingerprint": fingerprint,
+        "expected_queue_fingerprint": clean_text(fact.get("queue_fingerprint"), 80),
+        "memory_type": "portrait_fact",
+        "person_id": clean_text(fact.get("person_id"), 80),
+        "scope": clean_text(fact.get("source_scope"), 80),
+        "extractor": clean_text(fact.get("producer_version"), 80),
+        "profile_dimension": clean_text(fact.get("dimension"), 80).lower(),
+        "profile_polarity": "",
+        "candidate_value": clean_text(fact.get("claim_summary"), 180),
+        "normalized_value": clean_text(fact.get("normalized_claim_hash"), 80),
+        "profile_state": clean_text(fact.get("status"), 40).lower(),
+        "quality_score": _portrait_rank(fact)[1],
+        "matched_rule": reason,
+        "evidence_refs": [
+            clean_text(item, 160) for item in evidence_refs if clean_text(item, 160)
+        ],
+        "proposed_action": action,
+        "action": action,
+        "reason": reason,
+        "metadata_patch": {},
+        "canonical_id": "",
+        "canonical_expected_fingerprint": "",
+        "canonical_expected_queue_fingerprint": "",
+        "group_id": MemoryStore.profile_repair_group_id(fact_id),
+        "target_state": "",
+    }
+
+
+def _build_portrait_repair_entries(
+    facts: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    eligible: list[dict[str, Any]] = []
+    for source in facts:
+        if not isinstance(source, dict):
+            continue
+        fact = dict(source)
+        fact_id = clean_text(fact.get("id"), 120)
+        if not fact_id:
+            continue
+        status = clean_text(fact.get("status"), 40).lower()
+        version = clean_text(fact.get("producer_version"), 80).lower()
+        if status in {"pending", "rejected", "superseded", "archived"}:
+            entries[fact_id] = _portrait_entry(
+                fact, action="keep", reason="already_inactive"
+            )
+            continue
+        noise = _portrait_noise_reason(fact)
+        if noise:
+            entry = _portrait_entry(fact, action="archive", reason=noise)
+            entry["target_state"] = "rejected"
+            entries[fact_id] = entry
+            continue
+        if version == "req036.rule.v1":
+            entries[fact_id] = _portrait_entry(
+                fact,
+                action="pending",
+                reason="legacy_portrait_requires_review",
+            )
+            continue
+        if status != "active":
+            entries[fact_id] = _portrait_entry(
+                fact, action="pending", reason="portrait_state_not_active"
+            )
+            continue
+        eligible.append(fact)
+        entries[fact_id] = _portrait_entry(
+            fact, action="keep", reason="portrait_quality_compatible"
+        )
+
+    single_groups: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for fact in eligible:
+        dimension = clean_text(fact.get("dimension"), 80).lower()
+        if dimension not in _SINGLE_VALUE_DIMENSIONS:
+            continue
+        key = (
+            clean_text(fact.get("person_id"), 80),
+            dimension,
+            clean_text(fact.get("source_scope"), 80),
+        )
+        single_groups.setdefault(key, []).append(fact)
+
+    for group in single_groups.values():
+        ordered = sorted(group, key=_portrait_rank, reverse=True)
+        canonical = ordered[0]
+        canonical_id = clean_text(canonical.get("id"), 120)
+        canonical_fp = MemoryStore.profile_portrait_fact_fingerprint(canonical)
+        group_id = MemoryStore.profile_repair_group_id(canonical_id)
+        for fact in ordered[1:]:
+            entry = _portrait_entry(
+                fact,
+                action="archive",
+                reason="profile_value_superseded",
+            )
+            entry["target_state"] = "superseded"
+            entry["canonical_id"] = canonical_id
+            entry["canonical_expected_fingerprint"] = canonical_fp
+            entry["canonical_expected_queue_fingerprint"] = clean_text(
+                canonical.get("queue_fingerprint"), 80
+            )
+            entry["group_id"] = group_id
+            entries[clean_text(fact.get("id"), 120)] = entry
+
+    return [
+        entries[clean_text(fact.get("id"), 120)]
+        for fact in facts
+        if isinstance(fact, dict) and clean_text(fact.get("id"), 120) in entries
+    ]
+
+
+def build_repair_plan(
+    records: Sequence[MemoryRecord],
+    portrait_facts: Sequence[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    by_id = {record.id: record for record in records}
+    entries: dict[str, dict[str, Any]] = {}
+    eligible: list[MemoryRecord] = []
+    for record in records:
+        if record.lifecycle == "archived" or _record_state(record) in {
+            "rejected",
+            "superseded",
+        }:
+            entries[record.id] = _entry(
+                record, action="keep", reason="already_inactive"
+            )
+            continue
+        noise = _noise_reason(record)
+        if noise:
+            entries[record.id] = _entry(record, action="archive", reason=noise)
+            entries[record.id]["target_state"] = "rejected"
+            continue
+        valid, reason = profile_quality_decision(record, require_active=True)
+        if not valid:
+            entries[record.id] = _entry(record, action="pending", reason=reason)
+            continue
+        eligible.append(record)
+        entries[record.id] = _entry(
+            record, action="keep", reason="profile_quality_passed"
+        )
+
+    exact_groups: dict[tuple[str, ...], list[MemoryRecord]] = {}
+    for record in eligible:
+        dimension, _value, normalized = _legacy_profile_fields(record)
+        if not dimension or not normalized:
+            entries[record.id] = _entry(
+                record,
+                action="pending",
+                reason="profile_group_key_missing",
+            )
+            continue
+        metadata = record.metadata if isinstance(record.metadata, dict) else {}
+        polarity = clean_text(metadata.get("profile_polarity"), 40).lower()
+        exact_groups.setdefault(
+            (*_domain_key(record), dimension, polarity, normalized),
+            [],
+        ).append(record)
+
+    dimension_groups: dict[
+        tuple[str, ...], list[tuple[MemoryRecord, list[MemoryRecord]]]
+    ] = {}
+    for key, group in exact_groups.items():
+        ordered = sorted(group, key=_record_rank, reverse=True)
+        canonical = ordered[0]
+        dimension_key = (*key[:-2],)
+        dimension_groups.setdefault(dimension_key, []).append((canonical, ordered))
+
+    for dimension_key, value_groups in dimension_groups.items():
+        dimension = dimension_key[-1]
+        cardinality = clean_text(
+            (value_groups[0][0].metadata or {}).get("profile_cardinality"),
+            20,
+        ).lower()
+        single = cardinality == "single" or dimension in _SINGLE_VALUE_DIMENSIONS
+        ordered_groups = sorted(
+            value_groups,
+            key=(
+                lambda item: (
+                    max(_single_value_rank(member) for member in item[1])
+                    if single
+                    else _record_rank(item[0])
+                )
+            ),
+            reverse=True,
+        )
+        winning_id = (
+            ordered_groups[0][0].id if single and len(ordered_groups) > 1 else ""
+        )
+        for group_index, (canonical, members) in enumerate(ordered_groups):
+            losing_value = bool(winning_id and group_index > 0)
+            if losing_value:
+                winner = by_id[winning_id]
+                winner_fp = MemoryStore.profile_memory_fingerprint(winner)
+                group_id = MemoryStore.profile_repair_group_id(winning_id)
+                for member in members:
+                    entry = _entry(
+                        member,
+                        action="archive",
+                        reason="profile_value_superseded",
+                    )
+                    entry["target_state"] = "superseded"
+                    entry["canonical_id"] = winning_id
+                    entry["canonical_expected_fingerprint"] = winner_fp
+                    entry["group_id"] = group_id
+                    entries[member.id] = entry
+                continue
+            entries[canonical.id] = _entry(
+                canonical,
+                action="keep",
+                reason="canonical_profile_fact",
+            )
+            canonical_fp = MemoryStore.profile_memory_fingerprint(canonical)
+            group_id = MemoryStore.profile_repair_group_id(canonical.id)
+            for duplicate in members[1:]:
+                entry = _entry(
+                    duplicate,
+                    action="merge",
+                    reason="duplicate_profile_fact",
+                )
+                entry["canonical_id"] = canonical.id
+                entry["canonical_expected_fingerprint"] = canonical_fp
+                entry["group_id"] = group_id
+                entries[duplicate.id] = entry
+
+    ordered_entries = [entries[record.id] for record in records if record.id in entries]
+    ordered_entries.extend(_build_portrait_repair_entries(portrait_facts or []))
+    counts: dict[str, int] = {"keep": 0, "merge": 0, "pending": 0, "archive": 0}
+    for item in ordered_entries:
+        counts[item["proposed_action"]] += 1
+    return {
+        "schema_version": "profile.noise.repair.preview.v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "read_only": True,
+        "record_count": len(ordered_entries),
+        "counts": counts,
+        "plan_fingerprint": MemoryStore.profile_repair_plan_fingerprint(
+            ordered_entries
+        ),
+        "records": ordered_entries,
+    }
+
+
+async def preview(
+    db_path: Path,
+    *,
+    user_id: str = "",
+    scope: str = "",
+    memory_types: list[str] | None = None,
+    extractors: list[str] | None = None,
+    person_id: str = "",
+    limit: int = 5000,
+) -> dict[str, Any]:
+    store = MemoryStore(db_path, read_only=True)
+    try:
+        store.initialize()
+        records = await store.list_rule_profile_memories(
+            user_id=user_id,
+            scope=scope,
+            memory_types=memory_types,
+            extractors=extractors,
+            include_archived=True,
+            limit=limit,
+        )
+        portrait_facts = []
+        if not user_id or person_id:
+            portrait_facts = await store.list_rule_portrait_facts(
+                person_id=person_id,
+                source_scope=scope,
+                include_inactive=True,
+                limit=limit,
+            )
+        return build_repair_plan(records, portrait_facts)
+    finally:
+        store.close()
+
+
+async def apply_plan(
+    db_path: Path,
+    plan: dict[str, Any],
+    *,
+    confirmation: str,
+    operation_id: str = "",
+    rule_version: str = DEFAULT_RULE_VERSION,
+) -> dict[str, Any]:
+    if confirmation != APPLY_CONFIRMATION:
+        raise ValueError(f"apply requires --confirm {APPLY_CONFIRMATION}")
+    operation_id = _validated_operation_id(
+        clean_text(operation_id, 120)
+        or (
+            "profile_repair_"
+            + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+            + "_"
+            + secrets.token_hex(4)
+        )
+    )
+    actions = [
+        item
+        for item in plan.get("records", [])
+        if isinstance(item, dict)
+        and item.get("action") in {"keep", "merge", "pending", "archive"}
+    ]
+    expected_plan_fingerprint = clean_text(plan.get("plan_fingerprint"), 80)
+    actual_plan_fingerprint = MemoryStore.profile_repair_plan_fingerprint(actions)
+    if (
+        expected_plan_fingerprint
+        and expected_plan_fingerprint != actual_plan_fingerprint
+    ):
+        raise ValueError("repair plan fingerprint mismatch")
+    store = MemoryStore(db_path)
+    try:
+        store.initialize()
+        backup = await asyncio.to_thread(store.backup, f".before_{operation_id}")
+        result = await store.apply_profile_repairs(
+            operation_id=operation_id,
+            rule_version=rule_version,
+            actions=actions,
+            backup_path=str(backup),
+        )
+        result["preview_counts"] = plan.get("counts", {})
+        return result
+    finally:
+        store.close()
+
+
+async def rollback(
+    db_path: Path,
+    *,
+    operation_id: str,
+    confirmation: str,
+) -> dict[str, Any]:
+    if confirmation != ROLLBACK_CONFIRMATION:
+        raise ValueError(
+            f"rollback requires --rollback-confirm {ROLLBACK_CONFIRMATION}"
+        )
+    operation_id = _validated_operation_id(operation_id)
+    store = MemoryStore(db_path)
+    try:
+        store.initialize()
+        backup = await asyncio.to_thread(
+            store.backup, f".before_rollback_{operation_id}"
+        )
+        return await store.rollback_profile_repairs(
+            operation_id=operation_id,
+            rollback_backup_path=str(backup),
+        )
+    finally:
+        store.close()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Preview and repair rule-produced profile noise"
+    )
+    parser.add_argument(
+        "--db", required=True, type=Path, help="Path to memory_companion.db"
+    )
+    parser.add_argument("--user", default="", help="Exact subject user id")
+    parser.add_argument("--person", default="", help="Exact portrait person id")
+    parser.add_argument(
+        "--scope", choices=("", "private", "group", "unknown"), default=""
+    )
+    parser.add_argument("--memory-type", action="append", default=[])
+    parser.add_argument("--extractor", action="append", default=[])
+    parser.add_argument("--limit", type=int, default=5000)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--confirm", default="")
+    parser.add_argument("--operation-id", default="")
+    parser.add_argument("--rule-version", default=DEFAULT_RULE_VERSION)
+    parser.add_argument("--rollback", metavar="OPERATION_ID", default="")
+    parser.add_argument("--rollback-confirm", default="")
+    return parser
+
+
+async def _run(args: argparse.Namespace) -> dict[str, Any]:
+    db_path = args.db.resolve()
+    if args.rollback:
+        return await rollback(
+            db_path,
+            operation_id=args.rollback,
+            confirmation=args.rollback_confirm,
+        )
+    plan = await preview(
+        db_path,
+        user_id=args.user,
+        scope=args.scope,
+        memory_types=args.memory_type,
+        extractors=args.extractor,
+        person_id=args.person,
+        limit=args.limit,
+    )
+    if args.apply:
+        return await apply_plan(
+            db_path,
+            plan,
+            confirmation=args.confirm,
+            operation_id=args.operation_id,
+            rule_version=args.rule_version,
+        )
+    return plan
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        result = asyncio.run(_run(args))
+    except (ValueError, FileNotFoundError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False))
+        return 2
+    rendered = json.dumps(result, ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_profile_noise_extraction.py
+++ b/tests/test_profile_noise_extraction.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from core.classifier import MemoryClassifier
+from core.models import SessionContext
+from core.portrait import extract_explicit_candidates
+from core.portrait_service import PortraitService
+from core.profile_quality import (
+    extract_profile_candidates,
+    profile_candidate_metadata,
+    profile_quality_decision,
+    profile_rejection_reason,
+)
+from core.store import MemoryStore
+from unified_profile_contract import build_profile_dto
+
+PERSON_REF = {
+    "person_id": "person_" + "1" * 24,
+    "resolved_identity_key": "chat-origin-v1:" + "2" * 64,
+    "projection_revision": 1,
+    "identity_assurance": "observed",
+    "profile_status": "active",
+}
+
+
+class _Config:
+    @staticmethod
+    def float(_key: str, default: float) -> float:
+        return default
+
+    @staticmethod
+    def int(_key: str, default: int) -> int:
+        return default
+
+
+def context(text: str) -> SessionContext:
+    return SessionContext(
+        session_id="onebot:FriendMessage:u1",
+        scope="private",
+        platform="onebot",
+        user_id="u1",
+        user_name="小王",
+        bot_id="bot-1",
+        message_id="message-1",
+        message_text=text,
+    )
+
+
+class ProfileNoiseExtractionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.classifier = MemoryClassifier()
+
+    def assert_paths(self, text: str, expected: list[tuple[str, str]]) -> None:
+        records = self.classifier.derived_user_memories(
+            context(text), source_memory_id="source-1"
+        )
+        classifier_values = [
+            (
+                record.metadata.get("profile_dimension"),
+                record.metadata.get("profile_value"),
+            )
+            for record in records
+            if record.metadata.get("profile_dimension")
+        ]
+        portrait_values = [
+            (candidate.get("profile_dimension"), candidate.get("profile_value"))
+            for candidate in extract_explicit_candidates(text)
+        ]
+        self.assertEqual(expected, classifier_values)
+        self.assertEqual(expected, portrait_values)
+
+    def test_direct_address_requests_share_one_extractor(self) -> None:
+        for text, value in (
+            ("叫我宝宝", "宝宝"),
+            ("以后你叫我主人", "主人"),
+            ("你以后叫我阿岚", "阿岚"),
+            ("请喊我小王吧", "小王"),
+            ("称呼我为墨飞", "墨飞"),
+        ):
+            with self.subTest(text=text):
+                self.assert_paths(text, [("preferred_address", value)])
+
+    def test_address_noise_is_rejected_by_both_paths(self) -> None:
+        for text in (
+            "老板娘叫我去跟车呢",
+            "他总叫我笨蛋",
+            "叫我去上班",
+            "不许叫我大色狼",
+            "叫我几声宝宝",
+            "怎么还叫我小王",
+        ):
+            with self.subTest(text=text):
+                self.assert_paths(text, [])
+
+    def test_sentence_boundaries_and_particles_are_normalized(self) -> None:
+        self.assert_paths(
+            "好的，我喜欢烤肉。以后叫我宝宝就好！",
+            [("preference", "烤肉"), ("preferred_address", "宝宝")],
+        )
+        self.assert_paths("我喜欢酒吧", [("preference", "酒吧")])
+
+    def test_reported_quoted_and_interrogative_facts_are_rejected(self) -> None:
+        for text in (
+            "她说，我喜欢烤肉",
+            "听说，我的生日是八月一日",
+            "同事说，‘我通常用简短回复’",
+            "她说：\n我喜欢烤肉",
+            "引用如下：\n我的生日是八月一日",
+            "我喜欢什么？",
+            "我的生日你还记得吗？",
+            "我的生日是几月几号",
+            "我通常几点睡",
+            "我喜欢咖啡还是茶",
+            "我喜欢啥",
+            "她提到，我喜欢烤肉",
+            "同事描述，我的生日是八月一日",
+            "据她介绍，叫我宝宝",
+        ):
+            with self.subTest(text=text):
+                self.assert_paths(text, [])
+
+    def test_other_direct_profile_dimensions_remain_available(self) -> None:
+        for text, expected in (
+            ("我的生日是八月一日", [("birthday", "八月一日")]),
+            ("我从事软件开发", [("occupation", "软件开发")]),
+            ("我的专业是计算机", [("education", "计算机")]),
+            ("我通常用简短回复", [("communication_preference", "用简短回复")]),
+        ):
+            with self.subTest(text=text):
+                self.assert_paths(text, expected)
+
+    def test_temporary_state_and_current_action_do_not_become_profiles(self) -> None:
+        for text in (
+            "我今天很累",
+            "我现在很焦虑",
+            "我今天在做测试",
+            "我在做一个项目",
+            "我最近喜欢烤肉",
+            "我可能喜欢烤肉",
+            "我不喜欢今天的工作安排",
+            "我喜欢今天的午饭",
+            "我讨厌这次互动",
+            "我不能吃今天的午饭",
+            "我不能碰这杯咖啡",
+        ):
+            with self.subTest(text=text):
+                self.assert_paths(text, [])
+
+    def test_rejected_profile_attempts_have_observable_gate_reasons(self) -> None:
+        cases = {
+            "叫我去上班": "action_context",
+            "他总叫我笨蛋": "third_party_statement",
+            "不许叫我大色狼": "profile_quality_rejected",
+            "我喜欢什么？": "profile_quality_rejected",
+            "我最近喜欢烤肉": "profile_quality_rejected",
+        }
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(expected, profile_rejection_reason(text))
+        self.assertEqual("", profile_rejection_reason("今天天气不错"))
+        self.assertEqual("", profile_rejection_reason("以后叫我宝宝"))
+
+    def test_rule_v2_metadata_and_scores_are_not_fixed(self) -> None:
+        address = self.classifier.derived_user_memories(
+            context("以后叫我宝宝"), "source-1"
+        )[0]
+        habit = self.classifier.derived_user_memories(
+            context("我通常用简短回复"), "source-2"
+        )[0]
+
+        self.assertEqual("rule_v2", address.metadata["extractor"])
+        self.assertEqual("preferred_address", address.metadata["profile_dimension"])
+        self.assertEqual("宝宝", address.metadata["profile_value"])
+        self.assertEqual("宝宝", address.metadata["normalized_value"])
+        self.assertEqual("explicit", address.metadata["extraction_quality"])
+        self.assertEqual("direct_statement", address.metadata["evidence_strength"])
+        self.assertEqual("active", address.metadata["profile_state"])
+        self.assertEqual("source-1", address.metadata["source_memory_id"])
+        self.assertEqual("stable_memory", address.lifecycle)
+        self.assertEqual("auto", address.review_status)
+        self.assertGreater(address.confidence, habit.confidence)
+        self.assertEqual(
+            (True, "profile_quality_passed"), profile_quality_decision(address)
+        )
+
+    def test_quality_gate_has_stable_state_reasons_and_manual_compatibility(
+        self,
+    ) -> None:
+        candidate = extract_profile_candidates("以后叫我宝宝")[0]
+        metadata = profile_candidate_metadata(candidate, source_memory_id="source-1")
+        self.assertEqual(
+            (True, "profile_quality_passed"), profile_quality_decision(metadata)
+        )
+
+        for state in ("candidate", "rejected", "superseded"):
+            with self.subTest(state=state):
+                changed = {**metadata, "profile_state": state}
+                self.assertEqual(
+                    (False, f"profile_state_{state}"), profile_quality_decision(changed)
+                )
+        self.assertEqual(
+            (True, "profile_quality_passed"),
+            profile_quality_decision(
+                {**metadata, "profile_state": "candidate"}, require_active=False
+            ),
+        )
+        pending = {**metadata, "profile_state": "pending"}
+        self.assertEqual(
+            (False, "profile_state_pending"), profile_quality_decision(pending)
+        )
+        low_quality = {**metadata, "extraction_quality_score": 0.3}
+        self.assertEqual(
+            (False, "profile_quality_rejected"), profile_quality_decision(low_quality)
+        )
+        for score in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(score=score):
+                self.assertEqual(
+                    (False, "profile_quality_rejected"),
+                    profile_quality_decision(
+                        {**metadata, "extraction_quality_score": score}
+                    ),
+                )
+        self.assertEqual(
+            (True, "profile_quality_compatible"),
+            profile_quality_decision(
+                {"memory_type": "user_profile", "metadata": {"tool": "remember"}}
+            ),
+        )
+        self.assertEqual(
+            (True, "profile_quality_compatible"),
+            profile_quality_decision(
+                {
+                    "memory_type": "user_profile",
+                    "metadata": {
+                        "tool": "remember",
+                        "profile_dimension": "preferred_address",
+                        "profile_value": "阿岚",
+                        "normalized_value": "阿岚",
+                        "profile_state": "active",
+                        "extraction_quality_score": 0.1,
+                    },
+                }
+            ),
+        )
+        self.assertEqual(
+            (True, "profile_quality_compatible"),
+            profile_quality_decision(
+                {"memory_type": "explicit_memory", "metadata": {"extractor": "rule_v2"}}
+            ),
+        )
+
+
+class PortraitEvidenceNoiseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_rejected_text_does_not_enter_portrait_evidence(self) -> None:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        store = MemoryStore(Path(temp.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        service = PortraitService(store, _Config())
+        dto = build_profile_dto(
+            person_ref=PERSON_REF,
+            capability_summary={
+                "private_companion_enabled": True,
+                "proactive_private_enabled": False,
+                "portrait_mode": "learn_and_use",
+                "grant_source": "administrator",
+            },
+        )
+        event = types.SimpleNamespace(private_companion_unified_profile_context=dto)
+
+        result = await service.capture_user_message(
+            context("老板娘叫我去跟车呢"), event=event
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual("portrait_no_candidate", result["code"])
+        self.assertEqual(
+            [], await store.list_portrait_evidence(PERSON_REF["person_id"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_profile_noise_retrieval_injection.py
+++ b/tests/test_profile_noise_retrieval_injection.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from core.injection import InjectionComposer
+from core.models import (
+    EntityRef,
+    MemoryRecord,
+    SearchResult,
+    SessionContext,
+)
+from core.retrieval import RetrievalEngine
+from core.visibility import VisibilityPolicy
+
+
+def rule_profile(
+    memory_id: str,
+    value: str = "宝贝",
+    *,
+    state: str = "active",
+    score: float = 0.97,
+) -> MemoryRecord:
+    return MemoryRecord(
+        id=memory_id,
+        memory_type="user_profile",
+        subject=EntityRef(kind="user", id="u1"),
+        object=EntityRef.bot_self("b1"),
+        scope="private",
+        session_id="qq:FriendMessage:u1",
+        platform="qq",
+        visibility="private_pair",
+        sayability="direct",
+        reality_level="real_user_fact",
+        lifecycle="stable_memory",
+        content=f"希望被称为 {value}",
+        evidence=f"以后叫我{value}",
+        confidence=score,
+        importance=0.8,
+        metadata={
+            "extractor": "rule_v2",
+            "profile_dimension": "preferred_address",
+            "profile_value": value,
+            "normalized_value": value,
+            "extraction_quality": "explicit",
+            "extraction_quality_score": score,
+            "evidence_strength": "direct_statement",
+            "profile_state": state,
+            "quality_gate_passed": score >= 0.75,
+        },
+    )
+
+
+def compatible_profile(memory_id: str, source: str) -> MemoryRecord:
+    metadata = {
+        "profile_dimension": "preferred_address",
+        "profile_value": "人工称呼",
+        "normalized_value": "人工称呼",
+        "producer_kind": source,
+    }
+    if source == "tool_confirmed":
+        metadata["tool"] = "memory_companion_remember"
+    return MemoryRecord(
+        id=memory_id,
+        memory_type="user_profile",
+        lifecycle="stable_memory",
+        review_status="auto",
+        visibility="shareable",
+        content=f"{source}确认的画像事实",
+        metadata=metadata,
+        tags=["manual" if source == "manual" else "llm_tool"],
+    )
+
+
+def context(message: str = "聊点别的") -> SessionContext:
+    return SessionContext(
+        session_id="qq:FriendMessage:u1",
+        scope="private",
+        platform="qq",
+        user_id="u1",
+        bot_id="b1",
+        message_text=message,
+    )
+
+
+class _MarkOnlyStore:
+    async def mark_accessed(self, _memory_ids):
+        return None
+
+
+class _RankedEngine(RetrievalEngine):
+    def __init__(self, ranked: list[SearchResult]):
+        super().__init__(
+            _MarkOnlyStore(),
+            VisibilityPolicy(enable_acl_rules=False),
+            retrieval_mode="basic",
+            knowledge_graph_enabled=False,
+        )
+        self.ranked = ranked
+
+    async def _rank_candidates(self, _query, _ctx, *, time_intent=None):
+        return list(self.ranked), []
+
+
+class ProfileRetrievalGuardTests(unittest.IsolatedAsyncioTestCase):
+    def test_profile_quality_and_state_gate_keeps_manual_compatibility(self) -> None:
+        self.assertEqual(
+            (True, "profile_quality_compatible"),
+            RetrievalEngine._profile_retrieval_decision(rule_profile("active")),
+        )
+
+        allowed, reason = RetrievalEngine._profile_retrieval_decision(
+            rule_profile("pending", state="candidate")
+        )
+        self.assertFalse(allowed)
+        self.assertEqual("profile_state_candidate", reason)
+
+        allowed, reason = RetrievalEngine._profile_retrieval_decision(
+            rule_profile("low", score=0.4)
+        )
+        self.assertFalse(allowed)
+        self.assertEqual("profile_quality_rejected", reason)
+
+        manual = MemoryRecord(
+            id="manual", memory_type="manual_memory", lifecycle="stable_memory"
+        )
+        self.assertEqual(
+            (True, "profile_quality_compatible"),
+            RetrievalEngine._profile_retrieval_decision(manual),
+        )
+
+        for source in ("manual", "tool_confirmed"):
+            profile = compatible_profile(source, source)
+            self.assertNotIn("extractor", profile.metadata)
+            self.assertEqual(
+                (True, "profile_quality_compatible"),
+                RetrievalEngine._profile_retrieval_decision(profile),
+            )
+
+    def test_explicit_dimension_query_matches_structured_profile_metadata(self) -> None:
+        engine = _RankedEngine([])
+        query = "你还记得我的称呼吗？"
+        terms = engine._terms(query)
+        profile = engine._query_profile(query, terms)
+
+        score, reason = engine._score(
+            rule_profile("address"),
+            terms,
+            context(query),
+            profile,
+            {},
+        )
+
+        self.assertGreater(score, 0.0)
+        self.assertIn("profile=1", reason)
+        self.assertTrue(engine._query_allows_profile_fallback(query))
+        self.assertFalse(engine._query_allows_profile_fallback("我该怎么称呼你？"))
+        self.assertFalse(
+            engine._query_blocks_profile_retrieval("你好呀，我的称呼是什么？")
+        )
+
+    def test_english_profile_intent_uses_word_boundaries(self) -> None:
+        engine = _RankedEngine([])
+
+        false_cases = (
+            ("tell me about meeting notes", "preferred_address"),
+            ("my jobless claim", "occupation"),
+            ("call methods in Python", "preferred_address"),
+        )
+        for query, dimension in false_cases:
+            profile = rule_profile(f"false-{dimension}")
+            profile.metadata["profile_dimension"] = dimension
+            with self.subTest(query=query, dimension=dimension):
+                self.assertFalse(engine._query_allows_profile_fallback(query))
+                self.assertFalse(engine._profile_query_matches_memory(query, profile))
+                terms = engine._terms(query)
+                _score, reason = engine._score(
+                    profile,
+                    terms,
+                    context(query),
+                    engine._query_profile(query, terms),
+                    {},
+                )
+                self.assertNotIn("profile=1", reason)
+
+        true_cases = (
+            ("what is my name?", "preferred_address"),
+            ("what should you call me?", "preferred_address"),
+            ("what is my job?", "occupation"),
+            ("tell me about me", "preferred_address"),
+        )
+        for query, dimension in true_cases:
+            profile = rule_profile(f"true-{dimension}")
+            profile.metadata["profile_dimension"] = dimension
+            with self.subTest(query=query, dimension=dimension):
+                self.assertTrue(engine._query_allows_profile_fallback(query))
+                self.assertTrue(engine._profile_query_matches_memory(query, profile))
+
+    async def test_ordinary_and_current_state_queries_do_not_get_profile_fallback(
+        self,
+    ) -> None:
+        profile = SearchResult(
+            memory=rule_profile("profile"),
+            score=1.0,
+            reason="hits=0;exact=0;profile=0;vector=0.100",
+        )
+        engine = _RankedEngine([profile])
+        limits = {"user_profile": 2}
+
+        for query in (
+            "你好",
+            "你好呀",
+            "",
+            "今天吃了什么？",
+            "今天我的工作安排是什么？",
+            "我的工作进度怎么样？",
+            "关于我们的项目计划聊聊",
+            "我的学业进度怎么样？",
+            "my job progress",
+            "tell me about meeting progress",
+        ):
+            results, _blocked, slots = await engine.search_by_slots(
+                query,
+                context(query),
+                slot_limits=limits,
+                total_limit=2,
+            )
+            self.assertEqual([], results, query)
+            self.assertNotIn("user_profile", slots, query)
+
+        results, _blocked, slots = await engine.search_by_slots(
+            "你还记得我的称呼吗？",
+            context("你还记得我的称呼吗？"),
+            slot_limits=limits,
+            total_limit=2,
+        )
+        self.assertEqual(["profile"], [item.memory.id for item in results])
+        self.assertEqual(
+            ["profile"], [item.memory.id for item in slots["user_profile"]]
+        )
+
+    async def test_current_task_query_keeps_lexically_relevant_profile(
+        self,
+    ) -> None:
+        profile = SearchResult(
+            memory=rule_profile("schedule-preference"),
+            score=1.0,
+            reason="hits=2;exact=1;profile=0;vector=0.100",
+        )
+        engine = _RankedEngine([profile])
+
+        results, _blocked, slots = await engine.search_by_slots(
+            "今天我的工作安排是什么？",
+            context("今天我的工作安排是什么？"),
+            slot_limits={"user_profile": 1},
+            total_limit=1,
+        )
+
+        self.assertEqual(["schedule-preference"], [item.memory.id for item in results])
+        self.assertEqual(
+            ["schedule-preference"],
+            [item.memory.id for item in slots["user_profile"]],
+        )
+
+    async def test_manual_profile_slot_remains_compatible_without_profile_intent(
+        self,
+    ) -> None:
+        manual = MemoryRecord(
+            id="manual",
+            memory_type="manual_memory",
+            lifecycle="stable_memory",
+            visibility="shareable",
+            content="人工确认的长期事实",
+        )
+        engine = _RankedEngine(
+            [SearchResult(memory=manual, score=1.0, reason="hits=0;exact=0")]
+        )
+
+        results, _blocked, _slots = await engine.search_by_slots(
+            "你好",
+            context("你好"),
+            slot_limits={"user_profile": 1},
+            total_limit=1,
+        )
+
+        self.assertEqual(["manual"], [item.memory.id for item in results])
+
+
+class ProfileInjectionGuardTests(unittest.TestCase):
+    def test_tone_uses_abstract_hint_without_original_profile_text(self) -> None:
+        composer = InjectionComposer()
+        memory = rule_profile("tone", value="绝密昵称原文")
+        result = SearchResult(memory=memory, score=1.0, reason="expression=tone")
+
+        injection = composer.compose(context(), [result], max_chars=2400)
+
+        self.assertIn("语气提示", injection)
+        self.assertIn("禁止复述", injection)
+        self.assertNotIn("绝密昵称原文", injection)
+        self.assertIn(
+            "injection_content_abstracted:tone", composer.last_omission_reasons
+        )
+
+    def test_candidate_expression_never_exposes_profile_source_text(self) -> None:
+        composer = InjectionComposer()
+        memory = rule_profile("candidate", value="候选私密称呼原文")
+        result = SearchResult(
+            memory=memory,
+            score=1.0,
+            reason="expression=candidate",
+        )
+
+        injection = composer.compose(context(), [result], max_chars=2400)
+
+        self.assertEqual("", injection)
+        self.assertIn(
+            "injection_omitted:candidate",
+            composer.last_omission_reasons,
+        )
+
+    def test_uncertain_and_low_quality_profiles_are_omitted_with_reasons(self) -> None:
+        composer = InjectionComposer()
+        uncertain = SearchResult(
+            memory=rule_profile("uncertain", value="不应出现的称呼"),
+            score=1.0,
+            reason="expression=uncertain",
+        )
+        self.assertEqual("", composer.compose(context(), [uncertain], max_chars=2400))
+        self.assertIn("injection_omitted:uncertain", composer.last_omission_reasons)
+
+        low_quality = SearchResult(
+            memory=rule_profile("low", value="错误称呼", score=0.4),
+            score=1.0,
+            reason="expression=mention",
+        )
+        self.assertEqual("", composer.compose(context(), [low_quality], max_chars=2400))
+        self.assertIn(
+            "injection_omitted:profile_quality_rejected", composer.last_omission_reasons
+        )
+
+    def test_qualified_mention_and_manual_memory_keep_fact_content(self) -> None:
+        composer = InjectionComposer()
+        qualified = SearchResult(
+            memory=rule_profile("qualified", value="小王"),
+            score=1.0,
+            reason="expression=mention",
+        )
+        self.assertIn(
+            "希望被称为 小王", composer.compose(context(), [qualified], max_chars=2400)
+        )
+
+        manual = MemoryRecord(
+            id="manual",
+            memory_type="manual_memory",
+            lifecycle="stable_memory",
+            visibility="shareable",
+            content="人工确认事实",
+            confidence=0.9,
+        )
+        injection = composer.compose(
+            context(),
+            [SearchResult(memory=manual, score=1.0, reason="expression=mention")],
+            max_chars=2400,
+        )
+        self.assertIn("人工确认事实", injection)
+
+        for source in ("manual", "tool_confirmed"):
+            compatible = compatible_profile(source, source)
+            injection = composer.compose(
+                context(),
+                [
+                    SearchResult(
+                        memory=compatible,
+                        score=1.0,
+                        reason="expression=mention",
+                    )
+                ],
+                max_chars=2400,
+            )
+            self.assertIn(f"{source}确认的画像事实", injection)
+
+
+class InjectionDiagnosticSnapshotTests(unittest.IsolatedAsyncioTestCase):
+    async def test_snapshot_survives_another_compose_after_await(self) -> None:
+        composer = InjectionComposer()
+        first = SearchResult(
+            memory=rule_profile("first", value="不应出现", score=0.4),
+            score=1.0,
+            reason="expression=mention",
+        )
+        second = SearchResult(
+            memory=rule_profile("second", value="小王"),
+            score=1.0,
+            reason="expression=mention",
+        )
+        first_composed = asyncio.Event()
+        second_composed = asyncio.Event()
+
+        async def first_request():
+            composer.compose(context(), [first], max_chars=2400)
+            snapshot = composer.diagnostic_snapshot()
+            first_composed.set()
+            await second_composed.wait()
+            return snapshot
+
+        async def second_request():
+            await first_composed.wait()
+            composer.compose(context(), [second], max_chars=2400)
+            second_composed.set()
+
+        first_snapshot, _ = await asyncio.gather(first_request(), second_request())
+        omissions, included_ids = first_snapshot
+
+        self.assertEqual(
+            ["injection_omitted:profile_quality_rejected"],
+            [item["reason"] for item in omissions],
+        )
+        self.assertEqual([], included_ids)
+        self.assertEqual([], composer.last_omission_diagnostics)
+        self.assertEqual(["second"], composer.last_included_memory_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_profile_storage_governance.py
+++ b/tests/test_profile_storage_governance.py
@@ -1,0 +1,1388 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from core.commands import MemoryCompanionCommandHandler
+from core.models import EntityRef, MemoryRecord
+from core.profile_quality import profile_quality_decision
+from core.retrieval import RetrievalEngine
+from core.service import MemoryCompanionService
+from core.store import MemoryStore
+from scripts.repair_profile_noise import (
+    APPLY_CONFIRMATION,
+    ROLLBACK_CONFIRMATION,
+    apply_plan,
+    build_repair_plan,
+    preview,
+    rollback,
+)
+
+
+def profile_record(
+    *,
+    record_id: str,
+    value: str,
+    source_id: str,
+    dimension: str = "preferred_address",
+    polarity: str = "address",
+    cardinality: str = "single",
+    state: str = "active",
+    scope: str = "private",
+    group_id: str = "",
+    visibility: str = "",
+    owner_bot_id: str = "bot-1",
+    evidence: str = "",
+) -> MemoryRecord:
+    return MemoryRecord(
+        id=record_id,
+        memory_type="user_profile"
+        if dimension == "preferred_address"
+        else "user_preference",
+        subject=EntityRef(kind="user", id="user-1", name="用户一"),
+        object=EntityRef(kind="user", id="user-1"),
+        scope=scope,
+        session_id=f"qq:{scope}:user-1:{source_id}",
+        platform="qq",
+        message_id=f"message-{source_id}",
+        group_id=group_id,
+        visibility=visibility
+        or ("private_pair" if scope == "private" else "group_public"),
+        sayability="direct",
+        reality_level="real_user_fact",
+        lifecycle="stable_memory" if state == "active" else "raw_event",
+        content=f"用户一明确表达过：{dimension} {value}",
+        evidence=evidence or f"用户直接声明 {value}",
+        confidence=0.95,
+        importance=0.68,
+        review_status="auto" if state == "active" else "pending",
+        tags=["stable_fact", dimension],
+        metadata={
+            "extractor": "rule_v2",
+            "profile_dimension": dimension,
+            "profile_value": value,
+            "normalized_value": value,
+            "profile_polarity": polarity,
+            "profile_cardinality": cardinality,
+            "extraction_quality": "explicit" if state == "active" else "inferred",
+            "extraction_quality_score": 0.95,
+            "evidence_strength": "direct_statement"
+            if state == "active"
+            else "independent_evidence",
+            "profile_state": state,
+            "quality_gate_passed": True,
+            "source_memory_id": source_id,
+            "owner_bot_id": owner_bot_id,
+            "required_evidence_count": 1 if state == "active" else 2,
+        },
+    )
+
+
+class ProfileStorageGovernanceTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> tuple[MemoryStore, Path]:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        path = Path(temp.name) / "memory.db"
+        store = MemoryStore(path)
+        store.initialize()
+        self.addCleanup(store.close)
+        return store, path
+
+    async def add_rule_portrait_fact(
+        self,
+        store: MemoryStore,
+        *,
+        person_id: str,
+        dimension: str,
+        summary: str,
+        version: str = "req036.rule.v1",
+        suffix: str = "a",
+    ) -> str:
+        result = await store.upsert_portrait_fact(
+            {
+                "person_id": person_id,
+                "dimension": dimension,
+                "normalized_claim_hash": suffix * 64,
+                "claim_summary": summary,
+                "portrait_tier": "base",
+                "producer_kind": "rule_explicit",
+                "producer_version": version,
+                "derivation_kind": "explicit_statement",
+                "epistemic_status": "explicit",
+                "source_scope": "private",
+                "usable_scope": "source_only",
+                "confidence": 0.92,
+                "sensitivity": "low",
+                "status": "active",
+                "evidence_hashes": [suffix * 64],
+                "operation_id": f"portrait-source-{suffix}",
+            }
+        )
+        self.assertTrue(result["ok"])
+        fact_id = result["fact_id"]
+        queued = await store.enqueue_portrait_learning(
+            person_id=person_id,
+            fact_id=fact_id,
+            evidence_hash=suffix * 64,
+        )
+        self.assertTrue(queued["ok"])
+        return fact_id
+
+    async def test_candidate_evidence_is_distinct_and_promotes_atomically(self) -> None:
+        store, _path = self.make_store()
+        first = profile_record(
+            record_id="candidate-1",
+            value="无糖拿铁",
+            source_id="timeline-1",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+        )
+        result = await store.upsert_profile_candidate(first)
+        self.assertEqual("candidate", result["profile_status"])
+        self.assertEqual(1, result["evidence_count"])
+
+        replay = await store.upsert_profile_candidate(first)
+        self.assertFalse(replay["evidence_added"])
+        self.assertEqual(1, replay["evidence_count"])
+
+        second = profile_record(
+            record_id="candidate-2",
+            value="无糖拿铁",
+            source_id="timeline-2",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+            evidence="用户补充说每次都点无糖拿铁",
+        )
+        promoted = await store.upsert_profile_candidate(second)
+        self.assertEqual("active", promoted["profile_status"])
+        self.assertEqual(2, promoted["evidence_count"])
+        canonical = await store.get_memory(promoted["memory_id"])
+        self.assertEqual("stable_memory", canonical.lifecycle)
+        self.assertEqual("auto", canonical.review_status)
+        self.assertEqual(2, canonical.metadata["independent_evidence_count"])
+
+    async def test_low_quality_independent_evidence_remains_candidate(self) -> None:
+        store, _path = self.make_store()
+        first = profile_record(
+            record_id="low-quality-1",
+            value="无糖拿铁",
+            source_id="timeline-low-quality-1",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+            evidence="用户说最近会点无糖拿铁",
+        )
+        second = profile_record(
+            record_id="low-quality-2",
+            value="无糖拿铁",
+            source_id="timeline-low-quality-2",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+            evidence="用户另一次说有时选择无糖拿铁",
+        )
+        first.metadata["extraction_quality_score"] = 0.4
+        second.metadata["extraction_quality_score"] = 0.4
+
+        initial = await store.upsert_profile_candidate(first)
+        accumulated = await store.upsert_profile_candidate(second)
+
+        self.assertEqual("candidate", initial["profile_status"])
+        self.assertEqual("candidate", accumulated["profile_status"])
+        self.assertEqual(2, accumulated["evidence_count"])
+        self.assertEqual(0, accumulated["independent_evidence_count"])
+        canonical = await store.get_memory(accumulated["memory_id"])
+        self.assertEqual("candidate", canonical.metadata["profile_state"])
+        self.assertEqual(0.4, canonical.metadata["extraction_quality_score"])
+        self.assertEqual("raw_event", canonical.lifecycle)
+        self.assertEqual("pending", canonical.review_status)
+
+    async def test_low_quality_evidence_cannot_corroborate_high_quality_candidate(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        high_quality = profile_record(
+            record_id="mixed-quality-high",
+            value="无糖拿铁",
+            source_id="timeline-mixed-quality-high",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+            evidence="用户说自己经常点无糖拿铁",
+        )
+        low_quality = profile_record(
+            record_id="mixed-quality-low",
+            value="无糖拿铁",
+            source_id="timeline-mixed-quality-low",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+            evidence="低可信来源猜测用户或许选择无糖拿铁",
+        )
+        high_quality.metadata["extraction_quality_score"] = 0.9
+        low_quality.metadata["extraction_quality_score"] = 0.1
+
+        await store.upsert_profile_candidate(high_quality)
+        accumulated = await store.upsert_profile_candidate(low_quality)
+
+        self.assertEqual("candidate", accumulated["profile_status"])
+        self.assertEqual(2, accumulated["evidence_count"])
+        self.assertEqual(1, accumulated["independent_evidence_count"])
+        canonical = await store.get_memory(accumulated["memory_id"])
+        self.assertEqual("candidate", canonical.metadata["profile_state"])
+        self.assertEqual("raw_event", canonical.lifecycle)
+        self.assertEqual("pending", canonical.review_status)
+
+    async def test_single_upsert_cannot_forge_aggregate_evidence(self) -> None:
+        store, _path = self.make_store()
+        forged = profile_record(
+            record_id="forged-aggregate-evidence",
+            value="无糖拿铁",
+            source_id="timeline-forged-aggregate-evidence",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+            evidence="用户说自己经常点无糖拿铁",
+        )
+        forged.metadata["extraction_quality_score"] = 0.9
+        forged.metadata["profile_evidence_refs"] = ["forged-a", "forged-b"]
+        forged.metadata["profile_statement_fingerprints"] = [
+            "forged-statement-a",
+            "forged-statement-b",
+        ]
+
+        result = await store.upsert_profile_candidate(forged)
+
+        self.assertEqual("candidate", result["profile_status"])
+        self.assertEqual(1, result["evidence_count"])
+        self.assertEqual(1, result["independent_evidence_count"])
+        canonical = await store.get_memory(result["memory_id"])
+        self.assertEqual(
+            ["timeline-forged-aggregate-evidence"],
+            canonical.metadata["profile_evidence_refs"],
+        )
+        self.assertNotIn(
+            "forged-statement-a",
+            canonical.metadata["profile_statement_fingerprints"],
+        )
+
+    async def test_non_finite_profile_quality_score_is_rejected(self) -> None:
+        store, _path = self.make_store()
+        record = profile_record(
+            record_id="non-finite-score",
+            value="宝宝",
+            source_id="timeline-non-finite",
+        )
+        record.metadata["extraction_quality_score"] = float("nan")
+
+        result = await store.upsert_profile_candidate(record)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual("profile_candidate_invalid", result["code"])
+        self.assertIsNone(await store.get_memory(record.id))
+
+    async def test_upsert_rejects_incomplete_or_inconsistent_profile_values(
+        self,
+    ) -> None:
+        cases = {
+            "missing_profile_value": lambda metadata: metadata.pop("profile_value"),
+            "missing_normalized_value": lambda metadata: metadata.pop(
+                "normalized_value"
+            ),
+            "normalized_value_mismatch": lambda metadata: metadata.__setitem__(
+                "normalized_value", "另一个称呼"
+            ),
+        }
+        for label, mutate in cases.items():
+            with self.subTest(label=label):
+                store, _path = self.make_store()
+                record = profile_record(
+                    record_id=f"invalid-{label}",
+                    value="宝宝",
+                    source_id=f"timeline-invalid-{label}",
+                )
+                mutate(record.metadata)
+
+                result = await store.upsert_profile_candidate(record)
+
+                self.assertFalse(result["ok"])
+                self.assertEqual("profile_candidate_invalid", result["code"])
+                self.assertEqual("", result["memory_id"])
+                self.assertEqual(
+                    [], await store.list_rule_profile_memories(include_archived=True)
+                )
+                queue_count = store._conn.execute(
+                    "SELECT COUNT(*) AS count FROM review_queue"
+                ).fetchone()["count"]
+                self.assertEqual(0, queue_count)
+
+    async def test_same_statement_from_distinct_sources_does_not_promote(self) -> None:
+        store, _path = self.make_store()
+        first = profile_record(
+            record_id="candidate-same-1",
+            value="无糖拿铁",
+            source_id="timeline-same-1",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+        )
+        second = profile_record(
+            record_id="candidate-same-2",
+            value="无糖拿铁",
+            source_id="timeline-same-2",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+        )
+
+        await store.upsert_profile_candidate(first)
+        result = await store.upsert_profile_candidate(second)
+
+        self.assertEqual("candidate", result["profile_status"])
+        self.assertEqual(2, result["evidence_count"])
+        self.assertEqual(1, result["independent_evidence_count"])
+        canonical = await store.get_memory(result["memory_id"])
+        self.assertEqual("raw_event", canonical.lifecycle)
+        self.assertEqual("pending", canonical.review_status)
+
+    async def test_distinct_statements_from_one_source_do_not_promote(self) -> None:
+        store, _path = self.make_store()
+        first = profile_record(
+            record_id="candidate-one-source-1",
+            value="无糖拿铁",
+            source_id="timeline-one-source",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+        )
+        second = profile_record(
+            record_id="candidate-one-source-2",
+            value="无糖拿铁",
+            source_id="timeline-one-source",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="candidate",
+            evidence="同一条时间线里的另一种表述",
+        )
+
+        await store.upsert_profile_candidate(first)
+        result = await store.upsert_profile_candidate(second)
+
+        self.assertEqual("candidate", result["profile_status"])
+        self.assertEqual(1, result["evidence_count"])
+        self.assertEqual(1, result["independent_evidence_count"])
+
+    async def test_inferred_candidate_cannot_force_single_evidence_activation(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        inferred = profile_record(
+            record_id="forced-active",
+            value="无糖拿铁",
+            source_id="timeline-forced",
+            dimension="drink_preference",
+            polarity="like",
+            cardinality="multi",
+            state="active",
+        )
+        inferred.metadata.update(
+            {
+                "extraction_quality": "inferred",
+                "evidence_strength": "independent_evidence",
+                "required_evidence_count": 1,
+            }
+        )
+
+        result = await store.upsert_profile_candidate(inferred)
+
+        self.assertEqual("candidate", result["profile_status"])
+        canonical = await store.get_memory(result["memory_id"])
+        self.assertEqual(2, canonical.metadata["required_evidence_count"])
+        self.assertEqual("raw_event", canonical.lifecycle)
+
+    async def test_polarity_and_acl_domain_are_part_of_the_merge_key(self) -> None:
+        store, _path = self.make_store()
+        like = profile_record(
+            record_id="like",
+            value="烤肉",
+            source_id="timeline-like",
+            dimension="food_preference",
+            polarity="like",
+            cardinality="multi",
+        )
+        dislike = profile_record(
+            record_id="dislike",
+            value="烤肉",
+            source_id="timeline-dislike",
+            dimension="food_preference",
+            polarity="dislike",
+            cardinality="multi",
+        )
+        group_like = profile_record(
+            record_id="group-like",
+            value="烤肉",
+            source_id="timeline-group",
+            dimension="food_preference",
+            polarity="like",
+            cardinality="multi",
+            scope="group",
+            group_id="group-1",
+        )
+        ids = {
+            (await store.upsert_profile_candidate(like))["memory_id"],
+            (await store.upsert_profile_candidate(dislike))["memory_id"],
+            (await store.upsert_profile_candidate(group_like))["memory_id"],
+        }
+        self.assertEqual(3, len(ids))
+        rows = await store.list_rule_profile_memories(include_archived=False)
+        self.assertEqual(3, len(rows))
+
+    async def test_new_single_value_supersedes_only_inside_same_acl_domain(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        old = await store.upsert_profile_candidate(
+            profile_record(record_id="old", value="宝宝", source_id="timeline-old")
+        )
+        group = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="group",
+                value="宝宝",
+                source_id="timeline-group",
+                scope="group",
+                group_id="group-1",
+            )
+        )
+        new = await store.upsert_profile_candidate(
+            profile_record(record_id="new", value="主人", source_id="timeline-new")
+        )
+        previous = await store.get_memory(old["memory_id"])
+        group_record = await store.get_memory(group["memory_id"])
+        self.assertEqual("superseded", previous.metadata["profile_state"])
+        self.assertEqual(new["memory_id"], previous.supersedes_id)
+        self.assertEqual("active", group_record.metadata["profile_state"])
+
+    async def test_single_value_dimension_ignores_declared_multi_cardinality(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        previous = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="declared-multi-old",
+                value="宝宝",
+                source_id="timeline-declared-multi-old",
+                cardinality="multi",
+            )
+        )
+        current = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="declared-multi-new",
+                value="主人",
+                source_id="timeline-declared-multi-new",
+                cardinality="multi",
+            )
+        )
+
+        previous_record = await store.get_memory(previous["memory_id"])
+        current_record = await store.get_memory(current["memory_id"])
+        self.assertEqual("superseded", previous_record.metadata["profile_state"])
+        self.assertEqual(current["memory_id"], previous_record.supersedes_id)
+        self.assertEqual("single", current_record.metadata["profile_cardinality"])
+        rows = await store.list_rule_profile_memories(include_archived=True)
+        active = [
+            row
+            for row in rows
+            if row.metadata.get("profile_dimension") == "preferred_address"
+            and row.metadata.get("profile_state") == "active"
+        ]
+        self.assertEqual([current["memory_id"]], [row.id for row in active])
+
+    async def test_single_value_round_trip_preserves_superseded_history(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        first = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="address-a-1",
+                value="宝宝",
+                source_id="timeline-a-1",
+                evidence="evidence-a-1",
+            )
+        )
+        second = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="address-b",
+                value="主人",
+                source_id="timeline-b",
+                evidence="evidence-b",
+            )
+        )
+        third = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="address-a-2",
+                value="宝宝",
+                source_id="timeline-a-2",
+                evidence="evidence-a-2",
+            )
+        )
+
+        self.assertNotEqual(first["memory_id"], third["memory_id"])
+        first_record = await store.get_memory(first["memory_id"])
+        second_record = await store.get_memory(second["memory_id"])
+        third_record = await store.get_memory(third["memory_id"])
+        self.assertEqual("evidence-a-1", first_record.evidence)
+        self.assertEqual("archived", first_record.lifecycle)
+        self.assertEqual("superseded", first_record.metadata["profile_state"])
+        self.assertEqual(second["memory_id"], first_record.supersedes_id)
+        self.assertEqual("archived", second_record.lifecycle)
+        self.assertEqual(third["memory_id"], second_record.supersedes_id)
+        self.assertEqual("evidence-a-2", third_record.evidence)
+
+        rows = await store.list_rule_profile_memories(include_archived=True)
+        active = [
+            row
+            for row in rows
+            if row.metadata.get("profile_dimension") == "preferred_address"
+            and row.metadata.get("profile_state") == "active"
+        ]
+        self.assertEqual([third["memory_id"]], [row.id for row in active])
+        self.assertEqual(3, len(rows))
+
+    async def test_command_promote_confirms_profile_candidate_atomically(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        previous = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="address-old",
+                value="宝宝",
+                source_id="timeline-old",
+            )
+        )
+        candidate = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="address-candidate",
+                value="主人",
+                source_id="timeline-candidate",
+                state="candidate",
+            )
+        )
+        handler = MemoryCompanionCommandHandler(
+            type("ServiceStub", (), {"store": store})(),
+            "test",
+        )
+
+        await handler.promote(candidate["memory_id"])
+
+        confirmed = await store.get_memory(candidate["memory_id"])
+        superseded = await store.get_memory(previous["memory_id"])
+        self.assertEqual("active", confirmed.metadata["profile_state"])
+        self.assertEqual("active", confirmed.metadata["profile_status"])
+        self.assertEqual("confirmed", confirmed.metadata["extraction_quality"])
+        self.assertEqual("user_confirmed", confirmed.metadata["evidence_strength"])
+        self.assertEqual("stable_memory", confirmed.lifecycle)
+        self.assertEqual("auto", confirmed.review_status)
+        self.assertEqual(
+            (True, "profile_quality_passed"),
+            profile_quality_decision(confirmed),
+        )
+        self.assertEqual(
+            (True, "profile_quality_compatible"),
+            RetrievalEngine._profile_retrieval_decision(confirmed),
+        )
+        self.assertEqual("superseded", superseded.metadata["profile_state"])
+        self.assertEqual(candidate["memory_id"], superseded.supersedes_id)
+
+        rows = await store.list_rule_profile_memories(include_archived=True)
+        active = [
+            row
+            for row in rows
+            if row.metadata.get("profile_dimension") == "preferred_address"
+            and row.metadata.get("profile_state") == "active"
+        ]
+        self.assertEqual([candidate["memory_id"]], [row.id for row in active])
+
+    async def test_manual_approval_cannot_override_single_dimension_with_multi(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        previous = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="manual-multi-old",
+                value="宝宝",
+                source_id="timeline-manual-multi-old",
+            )
+        )
+        candidate = profile_record(
+            record_id="manual-multi-candidate",
+            value="主人",
+            source_id="timeline-manual-multi-candidate",
+            cardinality="multi",
+            state="candidate",
+        )
+        await store.insert_memory(candidate, "profile_candidate_requires_review")
+
+        changed = await store.update_review_status(candidate.id, "auto")
+
+        self.assertTrue(changed)
+        previous_record = await store.get_memory(previous["memory_id"])
+        approved = await store.get_memory(candidate.id)
+        self.assertEqual("superseded", previous_record.metadata["profile_state"])
+        self.assertEqual(candidate.id, previous_record.supersedes_id)
+        self.assertEqual("active", approved.metadata["profile_state"])
+        self.assertEqual("single", approved.metadata["profile_cardinality"])
+        self.assertEqual("stable_memory", approved.lifecycle)
+        rows = await store.list_rule_profile_memories(include_archived=True)
+        active = [
+            row
+            for row in rows
+            if row.metadata.get("profile_dimension") == "preferred_address"
+            and row.metadata.get("profile_state") == "active"
+        ]
+        self.assertEqual([candidate.id], [row.id for row in active])
+
+    async def test_manual_approval_rejects_rule_profile_without_dimension(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        candidate = profile_record(
+            record_id="manual-missing-dimension",
+            value="主人",
+            source_id="timeline-manual-missing-dimension",
+            state="candidate",
+        )
+        candidate.metadata.pop("profile_dimension")
+        await store.insert_memory(candidate, "profile_candidate_requires_review")
+
+        changed = await store.update_review_status(candidate.id, "auto")
+
+        self.assertFalse(changed)
+        unchanged = await store.get_memory(candidate.id)
+        self.assertEqual("candidate", unchanged.metadata["profile_state"])
+        self.assertEqual("raw_event", unchanged.lifecycle)
+        self.assertEqual("pending", unchanged.review_status)
+
+    async def test_manual_approval_rejects_incomplete_profile_without_superseding(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        current = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="address-current",
+                value="宝宝",
+                source_id="timeline-current",
+            )
+        )
+        incomplete = profile_record(
+            record_id="address-incomplete",
+            value="主人",
+            source_id="timeline-incomplete",
+            state="candidate",
+        )
+        incomplete.metadata.pop("normalized_value")
+        await store.insert_memory(incomplete, "profile_candidate_requires_review")
+
+        changed = await store.update_review_status(incomplete.id, "auto")
+
+        self.assertFalse(changed)
+        current_record = await store.get_memory(current["memory_id"])
+        incomplete_record = await store.get_memory(incomplete.id)
+        self.assertEqual("active", current_record.metadata["profile_state"])
+        self.assertEqual("candidate", incomplete_record.metadata["profile_state"])
+        self.assertEqual("pending", incomplete_record.review_status)
+
+    async def test_manual_approval_requires_consistent_profile_values(self) -> None:
+        cases = {
+            "missing_value": lambda metadata: metadata.pop("profile_value"),
+            "missing_normalized": lambda metadata: metadata.pop("normalized_value"),
+            "mismatched": lambda metadata: metadata.__setitem__(
+                "normalized_value", "另一个称呼"
+            ),
+        }
+        for label, mutate in cases.items():
+            with self.subTest(label=label):
+                store, _path = self.make_store()
+                current = await store.upsert_profile_candidate(
+                    profile_record(
+                        record_id=f"current-{label}",
+                        value="宝宝",
+                        source_id=f"current-{label}",
+                    )
+                )
+                candidate = profile_record(
+                    record_id=f"candidate-{label}",
+                    value="主人",
+                    source_id=f"candidate-{label}",
+                    state="candidate",
+                )
+                mutate(candidate.metadata)
+                await store.insert_memory(
+                    candidate, "profile_candidate_requires_review"
+                )
+
+                changed = await store.update_review_status(candidate.id, "auto")
+
+                self.assertFalse(changed)
+                self.assertEqual(
+                    "active",
+                    (await store.get_memory(current["memory_id"])).metadata[
+                        "profile_state"
+                    ],
+                )
+                rejected = await store.get_memory(candidate.id)
+                self.assertEqual("candidate", rejected.metadata["profile_state"])
+                self.assertEqual("raw_event", rejected.lifecycle)
+                self.assertEqual("pending", rejected.review_status)
+
+    async def test_command_promote_does_not_bypass_profile_validation(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        candidate = profile_record(
+            record_id="command-invalid-candidate",
+            value="主人",
+            source_id="command-invalid-candidate",
+            state="candidate",
+        )
+        candidate.metadata.pop("normalized_value")
+        await store.insert_memory(candidate, "profile_candidate_requires_review")
+        handler = MemoryCompanionCommandHandler(
+            type("ServiceStub", (), {"store": store})(), "test"
+        )
+
+        response = await handler.promote(candidate.id)
+
+        current = await store.get_memory(candidate.id)
+        self.assertEqual("没有找到这条记忆。", response)
+        self.assertEqual("candidate", current.metadata["profile_state"])
+        self.assertEqual("raw_event", current.lifecycle)
+        self.assertEqual("pending", current.review_status)
+
+    async def test_visibility_move_preserves_single_value_domain_invariant(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        private = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="private-address",
+                value="宝宝",
+                source_id="timeline-private",
+            )
+        )
+        shareable = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="shareable-address",
+                value="主人",
+                source_id="timeline-shareable",
+                visibility="shareable",
+            )
+        )
+
+        self.assertFalse(
+            await store.update_memory_visibility(
+                shareable["memory_id"],
+                "private_pair",
+            )
+        )
+
+        rows = await store.list_rule_profile_memories(include_archived=True)
+        active = [
+            row
+            for row in rows
+            if row.metadata.get("profile_dimension") == "preferred_address"
+            and row.metadata.get("profile_state") == "active"
+            and row.visibility == "private_pair"
+        ]
+        self.assertEqual([private["memory_id"]], [row.id for row in active])
+        private_record = await store.get_memory(private["memory_id"])
+        shareable_record = await store.get_memory(shareable["memory_id"])
+        self.assertEqual("active", private_record.metadata["profile_state"])
+        self.assertEqual("private_pair", private_record.visibility)
+        self.assertEqual("active", shareable_record.metadata["profile_state"])
+        self.assertEqual("shareable", shareable_record.visibility)
+        self.assertEqual("", private_record.supersedes_id)
+        self.assertEqual("", shareable_record.supersedes_id)
+
+    async def test_payload_update_cannot_bypass_visibility_domain_guard(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        private = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="payload-private-address",
+                value="宝宝",
+                source_id="payload-private",
+            )
+        )
+        shareable = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="payload-shareable-address",
+                value="主人",
+                source_id="payload-shareable",
+                visibility="shareable",
+            )
+        )
+
+        changed = await store.update_memory_payload(
+            shareable["memory_id"], visibility="private_pair"
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(
+            "private_pair", (await store.get_memory(private["memory_id"])).visibility
+        )
+        self.assertEqual(
+            "shareable",
+            (await store.get_memory(shareable["memory_id"])).visibility,
+        )
+
+    async def test_reject_profile_candidate_archives_and_removes_embedding(
+        self,
+    ) -> None:
+        store, _path = self.make_store()
+        candidate = await store.upsert_profile_candidate(
+            profile_record(
+                record_id="address-rejected",
+                value="主人",
+                source_id="timeline-rejected",
+                state="candidate",
+            )
+        )
+        await store.upsert_memory_embedding(
+            memory_id=candidate["memory_id"],
+            provider_id="test-provider",
+            text_hash="test-hash",
+            vector=[0.1, 0.2],
+        )
+
+        changed = await store.update_review_status(candidate["memory_id"], "rejected")
+
+        self.assertTrue(changed)
+        rejected = await store.get_memory(candidate["memory_id"])
+        self.assertEqual("rejected", rejected.metadata["profile_state"])
+        self.assertEqual("rejected", rejected.metadata["profile_status"])
+        self.assertFalse(rejected.metadata["quality_gate_passed"])
+        self.assertEqual("archived", rejected.lifecycle)
+        self.assertEqual("rejected", rejected.review_status)
+        embedding = store._conn.execute(
+            "SELECT 1 FROM memory_embeddings WHERE memory_id=?",
+            (candidate["memory_id"],),
+        ).fetchone()
+        review = store._conn.execute(
+            "SELECT status FROM review_queue WHERE memory_id=?",
+            (candidate["memory_id"],),
+        ).fetchone()
+        self.assertIsNone(embedding)
+        self.assertEqual("rejected", review["status"])
+
+    async def test_repair_apply_is_cas_and_rollback_restores_snapshots(self) -> None:
+        store, path = self.make_store()
+        first = profile_record(
+            record_id="duplicate-a", value="宝宝", source_id="timeline-a"
+        )
+        second = profile_record(
+            record_id="duplicate-b", value="宝宝", source_id="timeline-b"
+        )
+        await store.insert_memory(first)
+        await store.insert_memory(second)
+        plan = build_repair_plan([first, second])
+        self.assertEqual(1, plan["counts"]["merge"])
+        backup = store.backup(".test_profile_repair")
+        result = await store.apply_profile_repairs(
+            operation_id="profile_repair_test",
+            rule_version="test-v1",
+            actions=plan["records"],
+            backup_path=str(backup),
+        )
+        self.assertEqual(2, result["changed"])
+        merged = next(item for item in plan["records"] if item["action"] == "merge")
+        source = await store.get_memory(merged["memory_id"])
+        self.assertEqual("archived", source.lifecycle)
+
+        replay = await store.apply_profile_repairs(
+            operation_id="profile_repair_test",
+            rule_version="test-v1",
+            actions=plan["records"],
+            backup_path=str(backup),
+        )
+        self.assertEqual("profile_repair_idempotent_replay", replay["code"])
+
+        conflicting_plan = [dict(item) for item in plan["records"]]
+        conflicting_plan[0]["action"] = "pending"
+        with self.assertRaisesRegex(ValueError, "different plan"):
+            await store.apply_profile_repairs(
+                operation_id="profile_repair_test",
+                rule_version="test-v1",
+                actions=conflicting_plan,
+                backup_path=str(backup),
+            )
+
+        rolled_back = await store.rollback_profile_repairs(
+            operation_id="profile_repair_test",
+            rollback_backup_path=str(path.with_suffix(".rollback.db")),
+        )
+        self.assertEqual(2, rolled_back["rolled_back"])
+        self.assertEqual("stable_memory", (await store.get_memory(first.id)).lifecycle)
+        self.assertEqual("stable_memory", (await store.get_memory(second.id)).lifecycle)
+
+        with self.assertRaisesRegex(ValueError, "already been rolled back"):
+            await store.apply_profile_repairs(
+                operation_id="profile_repair_test",
+                rule_version="test-v1",
+                actions=plan["records"],
+                backup_path=str(backup),
+            )
+
+    async def test_repair_skips_stale_record_without_overwrite(self) -> None:
+        store, _path = self.make_store()
+        record = profile_record(
+            record_id="stale", value="宝宝", source_id="timeline-stale"
+        )
+        await store.insert_memory(record)
+        plan = build_repair_plan([record])
+        action = plan["records"][0]
+        action["action"] = "archive"
+        action["proposed_action"] = "archive"
+        await store.update_memory_payload(record.id, content="用户刚刚修正的新内容")
+        backup = store.backup(".stale")
+        result = await store.apply_profile_repairs(
+            operation_id="profile_repair_stale",
+            rule_version="test-v1",
+            actions=[action],
+            backup_path=str(backup),
+        )
+        self.assertEqual(1, result["stale"])
+        current = await store.get_memory(record.id)
+        self.assertEqual("用户刚刚修正的新内容", current.content)
+        self.assertEqual("stable_memory", current.lifecycle)
+
+    async def test_rollback_skips_entire_merge_when_canonical_is_stale(self) -> None:
+        store, path = self.make_store()
+        first = profile_record(
+            record_id="rollback-source",
+            value="宝宝",
+            source_id="timeline-rollback-source",
+        )
+        second = profile_record(
+            record_id="rollback-canonical",
+            value="宝宝",
+            source_id="timeline-rollback-canonical",
+        )
+        await store.insert_memory(first)
+        await store.insert_memory(second)
+        plan = build_repair_plan([first, second])
+        merge = next(item for item in plan["records"] if item["action"] == "merge")
+        backup = store.backup(".rollback-dependent-stale")
+        await store.apply_profile_repairs(
+            operation_id="profile_repair_rollback_dependent_stale",
+            rule_version="test-v1",
+            actions=plan["records"],
+            backup_path=str(backup),
+        )
+        await store.update_memory_payload(
+            merge["canonical_id"],
+            content="用户在修复后更新了 canonical",
+        )
+
+        result = await store.rollback_profile_repairs(
+            operation_id="profile_repair_rollback_dependent_stale",
+            rollback_backup_path=str(path.with_suffix(".rollback.db")),
+        )
+
+        source = await store.get_memory(merge["memory_id"])
+        canonical = await store.get_memory(merge["canonical_id"])
+        self.assertEqual("archived", source.lifecycle)
+        self.assertEqual("active", canonical.metadata["profile_state"])
+        self.assertGreaterEqual(result["rollback_stale"], 1)
+
+    async def test_supersede_skips_when_canonical_record_is_stale(self) -> None:
+        store, _path = self.make_store()
+        older = profile_record(
+            record_id="supersede-old",
+            value="宝宝",
+            source_id="timeline-supersede-old",
+        )
+        newer = profile_record(
+            record_id="supersede-new",
+            value="主人",
+            source_id="timeline-supersede-new",
+        )
+        older.occurred_at = "2026-01-01T00:00:00+00:00"
+        newer.occurred_at = "2026-02-01T00:00:00+00:00"
+        await store.insert_memory(older)
+        await store.insert_memory(newer)
+        plan = build_repair_plan([older, newer])
+        action = next(
+            item for item in plan["records"] if item["target_state"] == "superseded"
+        )
+        await store.update_memory_payload(
+            action["canonical_id"],
+            content="用户刚刚修正的 canonical 内容",
+        )
+        backup = store.backup(".canonical-stale")
+
+        result = await store.apply_profile_repairs(
+            operation_id="profile_repair_canonical_stale",
+            rule_version="test-v1",
+            actions=[action],
+            backup_path=str(backup),
+        )
+
+        self.assertEqual(1, result["stale"])
+        source = await store.get_memory(action["memory_id"])
+        self.assertEqual("stable_memory", source.lifecycle)
+        self.assertEqual("", source.supersedes_id)
+
+    async def test_preview_is_read_only_and_apply_requires_confirmation(self) -> None:
+        store, path = self.make_store()
+        await store.insert_memory(
+            profile_record(
+                record_id="preview", value="宝宝", source_id="timeline-preview"
+            )
+        )
+        store.close()
+        before = path.read_bytes()
+        plan = await preview(path)
+        after = path.read_bytes()
+        self.assertTrue(plan["read_only"])
+        self.assertEqual(before, after)
+        self.assertEqual([], list(path.parent.glob("*.backup.*")))
+
+        with self.assertRaisesRegex(ValueError, APPLY_CONFIRMATION):
+            await apply_plan(path, plan, confirmation="")
+        self.assertEqual([], list(path.parent.glob("*.backup.*")))
+
+        with self.assertRaisesRegex(ValueError, "invalid profile repair operation id"):
+            await apply_plan(
+                path,
+                plan,
+                confirmation=APPLY_CONFIRMATION,
+                operation_id="../invalid",
+            )
+        self.assertEqual([], list(path.parent.glob("*.before_.*")))
+
+        with self.assertRaisesRegex(ValueError, "memory type filter"):
+            await preview(path, memory_types=["observation"])
+        with self.assertRaisesRegex(ValueError, "extractor filter"):
+            await preview(path, extractors=["manual"])
+
+    async def test_portrait_v1_preview_apply_and_rollback_govern_queue(self) -> None:
+        store, path = self.make_store()
+        person_id = "person_repair_v1"
+        pending_id = await self.add_rule_portrait_fact(
+            store,
+            person_id=person_id,
+            dimension="preferred_address",
+            summary="希望被称为 宝宝",
+            suffix="a",
+        )
+        rejected_id = await self.add_rule_portrait_fact(
+            store,
+            person_id=person_id,
+            dimension="preference",
+            summary="喜欢 今天的午饭",
+            suffix="b",
+        )
+
+        plan = await preview(path, person_id=person_id)
+        portrait = {
+            item["record_id"]: item
+            for item in plan["records"]
+            if item["record_kind"] == "portrait_fact"
+        }
+        self.assertEqual("pending", portrait[pending_id]["action"])
+        self.assertEqual("archive", portrait[rejected_id]["action"])
+        self.assertEqual("rejected", portrait[rejected_id]["target_state"])
+        before = store._conn.execute(
+            "SELECT id, status FROM portrait_facts ORDER BY id"
+        ).fetchall()
+        self.assertEqual(["active", "active"], [row["status"] for row in before])
+
+        applied = await apply_plan(
+            path,
+            plan,
+            confirmation=APPLY_CONFIRMATION,
+            operation_id="portrait_repair_apply",
+        )
+        self.assertEqual(2, applied["changed"])
+        states = {
+            row["id"]: row["status"]
+            for row in store._conn.execute(
+                "SELECT id, status FROM portrait_facts"
+            ).fetchall()
+        }
+        queue_states = {
+            row["fact_id"]: row["state"]
+            for row in store._conn.execute(
+                "SELECT fact_id, state FROM portrait_learning_queue"
+            ).fetchall()
+        }
+        self.assertEqual("pending", states[pending_id])
+        self.assertEqual("rejected", states[rejected_id])
+        self.assertEqual("pending_review", queue_states[pending_id])
+        self.assertEqual("rejected", queue_states[rejected_id])
+
+        rolled_back = await rollback(
+            path,
+            operation_id="portrait_repair_apply",
+            confirmation=ROLLBACK_CONFIRMATION,
+        )
+        self.assertEqual(2, rolled_back["rolled_back"])
+        self.assertEqual(
+            ["active", "active"],
+            [
+                row["status"]
+                for row in store._conn.execute(
+                    "SELECT status FROM portrait_facts ORDER BY id"
+                ).fetchall()
+            ],
+        )
+        self.assertEqual(
+            ["pending", "pending"],
+            [
+                row["state"]
+                for row in store._conn.execute(
+                    "SELECT state FROM portrait_learning_queue ORDER BY fact_id"
+                ).fetchall()
+            ],
+        )
+
+    async def test_portrait_rollback_skips_fact_when_queue_is_stale(self) -> None:
+        store, path = self.make_store()
+        fact_id = await self.add_rule_portrait_fact(
+            store,
+            person_id="person_queue_stale",
+            dimension="preferred_address",
+            summary="希望被称为 宝宝",
+            suffix="c",
+        )
+        plan = await preview(path, person_id="person_queue_stale")
+        await apply_plan(
+            path,
+            plan,
+            confirmation=APPLY_CONFIRMATION,
+            operation_id="portrait_repair_queue_stale",
+        )
+        store._conn.execute(
+            "UPDATE portrait_learning_queue SET state='manual_change' WHERE fact_id=?",
+            (fact_id,),
+        )
+        store._conn.commit()
+
+        result = await rollback(
+            path,
+            operation_id="portrait_repair_queue_stale",
+            confirmation=ROLLBACK_CONFIRMATION,
+        )
+
+        fact = store._conn.execute(
+            "SELECT status FROM portrait_facts WHERE id=?", (fact_id,)
+        ).fetchone()
+        queue = store._conn.execute(
+            "SELECT state FROM portrait_learning_queue WHERE fact_id=?",
+            (fact_id,),
+        ).fetchone()
+        self.assertEqual("pending", fact["status"])
+        self.assertEqual("manual_change", queue["state"])
+        self.assertGreaterEqual(result["rollback_stale"], 1)
+
+    async def test_portrait_preview_archives_one_off_profile_summaries(self) -> None:
+        store, path = self.make_store()
+        person_id = "person_one_off_portrait"
+        fact_ids = []
+        for suffix, summary in (
+            ("d", "喜欢 今晚的晚饭"),
+            ("e", "喜欢 刚刚的回复"),
+        ):
+            fact_ids.append(
+                await self.add_rule_portrait_fact(
+                    store,
+                    person_id=person_id,
+                    dimension="preference",
+                    summary=summary,
+                    suffix=suffix,
+                )
+            )
+
+        plan = await preview(path, person_id=person_id)
+        records = {
+            item["record_id"]: item
+            for item in plan["records"]
+            if item["record_kind"] == "portrait_fact"
+        }
+
+        for fact_id in fact_ids:
+            with self.subTest(fact_id=fact_id):
+                self.assertEqual("archive", records[fact_id]["action"])
+                self.assertEqual("rejected", records[fact_id]["target_state"])
+
+    def test_repair_plan_never_reactivates_inactive_records(self) -> None:
+        rejected = profile_record(
+            record_id="already-rejected",
+            value="错误称呼",
+            source_id="timeline-rejected",
+        )
+        rejected.metadata["profile_state"] = "rejected"
+        rejected.lifecycle = "archived"
+        rejected.review_status = "auto"
+
+        plan = build_repair_plan([rejected])
+
+        self.assertEqual("keep", plan["records"][0]["action"])
+        self.assertEqual("already_inactive", plan["records"][0]["reason"])
+
+    def test_repair_plan_keeps_valid_boundary_mentions_of_other_people(self) -> None:
+        boundary = profile_record(
+            record_id="valid-boundary",
+            value="别人问我的工资",
+            source_id="timeline-boundary",
+            dimension="boundary",
+            polarity="avoid",
+            cardinality="multi",
+            evidence="我不喜欢别人问我的工资",
+        )
+
+        plan = build_repair_plan([boundary])
+
+        self.assertEqual("keep", plan["records"][0]["action"])
+        self.assertNotEqual(
+            "third_party_statement",
+            plan["records"][0]["reason"],
+        )
+
+    def test_repair_plan_archives_temporary_rule_v2_preferences(self) -> None:
+        for suffix, statement, value in (
+            ("lunch", "我喜欢今天的午饭", "今天的午饭"),
+            ("dinner", "我喜欢今晚的晚饭", "今晚的晚饭"),
+            ("reply", "我喜欢刚刚的回复", "刚刚的回复"),
+        ):
+            with self.subTest(statement=statement):
+                temporary = profile_record(
+                    record_id=f"temporary-preference-{suffix}",
+                    value=value,
+                    source_id=f"timeline-temporary-{suffix}",
+                    dimension="food_preference",
+                    polarity="like",
+                    cardinality="multi",
+                )
+                temporary.evidence = ""
+                temporary.content = statement
+
+                plan = build_repair_plan([temporary])
+
+                self.assertEqual("archive", plan["records"][0]["action"])
+                self.assertEqual("rejected", plan["records"][0]["target_state"])
+
+    def test_repair_plan_prefers_newer_single_value_correction_over_score(self) -> None:
+        older = profile_record(
+            record_id="older-high-score",
+            value="宝宝",
+            source_id="timeline-older-high-score",
+        )
+        newer = profile_record(
+            record_id="newer-correction",
+            value="主人",
+            source_id="timeline-newer-correction",
+        )
+        older.occurred_at = "2026-01-01T00:00:00+00:00"
+        newer.occurred_at = "2026-02-01T00:00:00+00:00"
+        older.metadata["extraction_quality_score"] = 0.99
+        newer.metadata["extraction_quality_score"] = 0.95
+
+        plan = build_repair_plan([older, newer])
+
+        archived = next(
+            item for item in plan["records"] if item["target_state"] == "superseded"
+        )
+        self.assertEqual(older.id, archived["memory_id"])
+        self.assertEqual(newer.id, archived["canonical_id"])
+
+    async def test_script_apply_and_rollback_are_backed_up_and_cas_guarded(
+        self,
+    ) -> None:
+        store, path = self.make_store()
+        first = profile_record(
+            record_id="script-a", value="宝宝", source_id="timeline-a"
+        )
+        second = profile_record(
+            record_id="script-b", value="宝宝", source_id="timeline-b"
+        )
+        await store.insert_memory(first)
+        await store.insert_memory(second)
+        store.close()
+
+        plan = await preview(path)
+        self.assertEqual(
+            MemoryStore.profile_repair_plan_fingerprint(plan["records"]),
+            plan["plan_fingerprint"],
+        )
+        tampered = {**plan, "records": [dict(item) for item in plan["records"]]}
+        tampered["records"][0]["action"] = "pending"
+        with self.assertRaisesRegex(ValueError, "fingerprint mismatch"):
+            await apply_plan(
+                path,
+                tampered,
+                confirmation=APPLY_CONFIRMATION,
+                operation_id="script_tampered",
+            )
+        self.assertEqual([], list(path.parent.glob("*.before_script_tampered*")))
+
+        applied = await apply_plan(
+            path,
+            plan,
+            confirmation=APPLY_CONFIRMATION,
+            operation_id="script_roundtrip",
+        )
+        self.assertEqual(2, applied["changed"])
+        self.assertTrue(Path(applied["backup_path"]).is_file())
+
+        rolled_back = await rollback(
+            path,
+            operation_id="script_roundtrip",
+            confirmation=ROLLBACK_CONFIRMATION,
+        )
+        self.assertEqual(2, rolled_back["rolled_back"])
+        self.assertTrue(Path(rolled_back["rollback_backup_path"]).is_file())
+
+        restored = MemoryStore(path)
+        restored.initialize()
+        self.addCleanup(restored.close)
+        self.assertEqual(
+            "stable_memory", (await restored.get_memory(first.id)).lifecycle
+        )
+        self.assertEqual(
+            "stable_memory", (await restored.get_memory(second.id)).lifecycle
+        )
+
+    def test_service_gate_requires_complete_rule_metadata(self) -> None:
+        valid = profile_record(
+            record_id="valid", value="宝宝", source_id="timeline-valid"
+        )
+        mode, state = MemoryCompanionService._prepare_rule_profile_write(valid)
+        self.assertEqual(("profile", "active"), (mode, state))
+
+        invalid = profile_record(
+            record_id="invalid", value="宝宝", source_id="timeline-invalid"
+        )
+        invalid.metadata.pop("normalized_value")
+        mode, reason = MemoryCompanionService._prepare_rule_profile_write(invalid)
+        self.assertEqual("reject", mode)
+        self.assertEqual("profile_candidate_metadata_missing", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_req036_portrait.py
+++ b/tests/test_req036_portrait.py
@@ -104,6 +104,115 @@ class Req036PortraitTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(summary["ok"])
         self.assertTrue(any("烤肉" in item["summary"] for item in summary["items"]))
 
+    async def test_new_single_value_portrait_fact_supersedes_previous_value(
+        self,
+    ) -> None:
+        store = self.make_store()
+        service = PortraitService(store, _Config())
+        event = types.SimpleNamespace(
+            private_companion_unified_profile_context=self.dto()
+        )
+        for message_id, text in (
+            ("address-old", "以后叫我宝宝"),
+            ("address-new", "以后叫我主人"),
+        ):
+            result = await service.capture_user_message(
+                SessionContext(
+                    session_id="onebot:FriendMessage:10001",
+                    scope="private",
+                    platform="onebot",
+                    user_id="10001",
+                    message_id=message_id,
+                    message_text=text,
+                ),
+                event=event,
+            )
+            self.assertTrue(result["ok"])
+
+        summary = await service.read_summary(self.request())
+        addresses = [
+            item["summary"]
+            for item in summary["items"]
+            if item["dimension"] == "preferred_address"
+        ]
+        self.assertEqual(["希望被称为 主人"], addresses)
+        rows = store._conn.execute(
+            "SELECT status, supersedes_id FROM portrait_facts "
+            "WHERE person_id=? AND dimension='preferred_address' "
+            "ORDER BY created_at",
+            (PERSON_REF["person_id"],),
+        ).fetchall()
+        self.assertEqual(["superseded", "active"], [row["status"] for row in rows])
+        self.assertTrue(rows[0]["supersedes_id"])
+
+    async def test_single_value_portrait_supersedes_across_tiers_and_queue(
+        self,
+    ) -> None:
+        store = self.make_store()
+        first = await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_REF["person_id"],
+                "dimension": "preferred_address",
+                "profile_cardinality": "single",
+                "normalized_claim_hash": "a" * 64,
+                "claim_summary": "希望被称为 宝宝",
+                "portrait_tier": "base",
+                "producer_kind": "rule_explicit",
+                "producer_version": "req036.rule.v2",
+                "derivation_kind": "explicit_statement",
+                "epistemic_status": "explicit",
+                "source_scope": "private",
+                "usable_scope": "self_low_global",
+                "confidence": 0.95,
+                "sensitivity": "low",
+                "status": "active",
+                "evidence_hashes": ["c" * 64],
+                "operation_id": "cross-tier-base",
+            }
+        )
+        await store.enqueue_portrait_learning(
+            person_id=PERSON_REF["person_id"],
+            fact_id=first["fact_id"],
+            evidence_hash="c" * 64,
+        )
+        second = await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_REF["person_id"],
+                "dimension": "preferred_address",
+                "profile_cardinality": "single",
+                "normalized_claim_hash": "b" * 64,
+                "claim_summary": "希望被称为 主人",
+                "portrait_tier": "intelligent",
+                "producer_kind": "daily_evidence_batch",
+                "producer_version": "req036.batch.v1",
+                "derivation_kind": "independent_evidence_aggregate",
+                "epistemic_status": "inferred",
+                "source_scope": "private",
+                "usable_scope": "self_low_global",
+                "confidence": 0.96,
+                "sensitivity": "low",
+                "status": "active",
+                "evidence_hashes": ["d" * 64],
+                "operation_id": "cross-tier-intelligent",
+            }
+        )
+
+        old = store._conn.execute(
+            "SELECT status, supersedes_id FROM portrait_facts WHERE id=?",
+            (first["fact_id"],),
+        ).fetchone()
+        new = store._conn.execute(
+            "SELECT status FROM portrait_facts WHERE id=?", (second["fact_id"],)
+        ).fetchone()
+        queue = store._conn.execute(
+            "SELECT state FROM portrait_learning_queue WHERE fact_id=?",
+            (first["fact_id"],),
+        ).fetchone()
+        self.assertEqual("superseded", old["status"])
+        self.assertEqual(second["fact_id"], old["supersedes_id"])
+        self.assertEqual("active", new["status"])
+        self.assertEqual("superseded", queue["state"])
+
     async def test_mechanical_repeats_do_not_satisfy_independent_evidence_threshold(self) -> None:
         store = self.make_store()
         service = PortraitService(store, _Config())
@@ -227,6 +336,49 @@ class Req036PortraitTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([], private["items"])
         self.assertEqual(1, len(group_a["items"]))
         self.assertEqual([], group_b["items"])
+
+    async def test_legacy_rule_v1_fact_is_not_returned_before_governance(
+        self,
+    ) -> None:
+        store = self.make_store()
+        await store.upsert_portrait_person_projection(
+            PERSON_REF,
+            build_capability_summary(
+                {
+                    "private_companion_enabled": True,
+                    "proactive_private_enabled": False,
+                    "portrait_mode": "use_existing",
+                }
+            ),
+        )
+        inserted = await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_REF["person_id"],
+                "dimension": "preferred_address",
+                "profile_cardinality": "single",
+                "normalized_claim_hash": "d" * 64,
+                "claim_summary": "希望被称为 错误旧称呼",
+                "portrait_tier": "base",
+                "producer_kind": "rule_explicit",
+                "producer_version": "req036.rule.v1",
+                "derivation_kind": "explicit_statement",
+                "epistemic_status": "explicit",
+                "source_scope": "private",
+                "usable_scope": "self_low_global",
+                "confidence": 0.99,
+                "sensitivity": "low",
+                "status": "active",
+                "evidence_hashes": ["e" * 64],
+                "operation_id": "legacy-v1-fact",
+            }
+        )
+        self.assertTrue(inserted["ok"])
+
+        summary = await store.portrait_summary(
+            PERSON_REF["person_id"], scope="private"
+        )
+
+        self.assertEqual([], summary["items"])
 
     async def test_cross_scene_allowlist_keeps_schedule_like_habits_in_source_scope(self) -> None:
         store = self.make_store()


### PR DESCRIPTION
## 变更说明

- 新增统一的 `rule_v2` 用户画像抽取与质量判定模块，收紧称呼、偏好、职业、生日、专业、习惯等规则的句界和第一人称约束。
- 引入 `candidate / active / rejected / superseded` 状态流转、独立证据聚合和单值画像替换，阻止低质量证据、伪造聚合引用及人工审批旁路。
- 在检索与提示词注入阶段增加画像质量、意图和表达策略防线，避免普通查询或临时任务错误召回画像，并保留普通 ACL 记忆兼容性。
- 新增存量治理工具 `scripts/repair_profile_noise.py`，默认只读预览；apply/rollback 需要显式确认，支持备份、事务、CAS、整组回滚以及 memory/portrait fact 治理。
- 补充画像抽取、存储状态机、P2 治理、检索注入和 portrait 单值替换回归测试。

## 安全性

- 未写入、归档或删除任何现有实例数据。
- 治理脚本默认 dry-run，实际执行前必须显式确认并创建备份。
- apply 和 rollback 均校验指纹；同组任一成员 stale 时整组跳过。

## 验证

- `python -m pytest -q`：`425 passed, 134 subtests passed`
- 画像专项与 ACL：`96 passed, 101 subtests passed`
- Ruff、格式检查、`py_compile`、`git diff --check`：通过