### PR TITLE
feat: 落地历史画像回填与只读渲染

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -190,6 +190,36 @@
         "type": "int",
         "default": 6000,
         "hint": "上下文仅作当场解释，不写入画像表，也不跨场景拼接。"
+      },
+      "backfill_max_records": {
+        "description": "历史画像回填最大记录数",
+        "type": "int",
+        "default": 5000,
+        "hint": "单次历史回填最多读取的源记录数；达到上限会保留 checkpoint，等待下一次继续。"
+      },
+      "backfill_page_size": {
+        "description": "历史画像回填分页大小",
+        "type": "int",
+        "default": 100,
+        "hint": "历史回填每页读取的源记录数。"
+      },
+      "backfill_max_runtime_seconds": {
+        "description": "历史画像回填单次运行时限",
+        "type": "int",
+        "default": 30,
+        "hint": "单次 start 最长运行秒数；到时暂停并保存 checkpoint，不会丢弃已提交结果。"
+      },
+      "backfill_max_characters": {
+        "description": "历史画像回填单次字符上限",
+        "type": "int",
+        "default": 200000,
+        "hint": "单次 preview/start 最多送入规则提取器的历史字符数；达到上限会保留 checkpoint。"
+      },
+      "backfill_max_dimensions": {
+        "description": "历史画像回填画像维度上限",
+        "type": "int",
+        "default": 32,
+        "hint": "单次历史回填最多接受的稳定画像维度数，超出维度会保留为跳过计数。"
       }
     }
   },

--- a/core/portrait_renderer.py
+++ b/core/portrait_renderer.py
@@ -1,0 +1,286 @@
+"""Read-only, provenance-aware rendering of approved portrait facts.
+
+``PortraitService.read_summary`` remains the policy boundary.  This module
+only formats the already filtered result; it never writes facts, evidence,
+queue entries, capabilities, or suppression markers.  The renderer accepts
+only facts carrying opaque fact/evidence references so every natural-language
+sentence can be audited without copying historical message text.
+"""
+from __future__ import annotations
+
+import math
+import re
+from collections import defaultdict
+from typing import Any, Awaitable, Callable, Mapping
+
+
+PORTRAIT_RENDER_SCHEMA = "portrait.render.v1"
+LOW_SENSITIVITY = "low"
+
+# Keep this allowlist deliberately small.  New dimensions must be reviewed
+# before becoming visible in an administrator/agent portrait projection.
+DIMENSION_CATEGORIES: dict[str, tuple[str, str]] = {
+    "preferred_address": ("stable_facts", "称呼偏好"),
+    "birthday": ("stable_facts", "生日"),
+    "occupation": ("stable_facts", "职业"),
+    "education": ("stable_facts", "专业/学业"),
+    "zodiac": ("stable_facts", "星座"),
+    "blood_type": ("stable_facts", "血型"),
+    "preference": ("preferences", "偏好"),
+    "interest": ("interests", "兴趣"),
+    "communication_preference": ("communication_style", "沟通习惯"),
+    "interaction_preference": ("interaction_preferences", "互动偏好"),
+    "habit": ("habits", "习惯"),
+    "dietary_restriction": ("boundaries", "饮食边界"),
+    "boundary": ("boundaries", "沟通边界"),
+}
+
+CATEGORY_ORDER = (
+    "stable_facts",
+    "habits",
+    "preferences",
+    "interests",
+    "communication_style",
+    "interaction_preferences",
+    "boundaries",
+)
+_CATEGORY_INDEX = {name: index for index, name in enumerate(CATEGORY_ORDER)}
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _text(value: Any, limit: int = 240) -> str:
+    if value is None or isinstance(value, bool):
+        return ""
+    text = str(value).replace("\x00", " ")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit]
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _fact_id(value: Any) -> str:
+    # Store-generated IDs are opaque references; do not expose arbitrary
+    # caller-provided long strings in an audit projection.
+    return _text(value, 120)
+
+
+def _evidence_refs(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    refs: list[str] = []
+    for item in value[:16]:
+        ref = _text(item, 80).lower()
+        if _HASH_RE.fullmatch(ref) and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _punctuate(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return ""
+    return value if value.endswith(("。", "！", "？", ".", "!", "?")) else f"{value}。"
+
+
+def _sentence_for_fact(fact: Mapping[str, Any], label: str) -> str:
+    summary = _text(fact.get("summary"), 180)
+    if not summary:
+        return ""
+    epistemic = _text(fact.get("epistemic_status"), 40).lower()
+    if epistemic == "inferred":
+        # Keep inferred facts visibly tentative even if a producer happened to
+        # omit a hedge from ``claim_summary``.
+        return _punctuate(f"从多条独立证据看，{label}：{summary}")
+    return _punctuate(f"{label}：{summary}")
+
+
+def _safe_fact(item: Any) -> tuple[dict[str, Any] | None, str]:
+    if not isinstance(item, Mapping):
+        return None, "malformed"
+    dimension = _text(item.get("dimension"), 80).lower()
+    category_label = DIMENSION_CATEGORIES.get(dimension)
+    if category_label is None:
+        return None, "unsupported_dimension"
+    if _text(item.get("sensitivity"), 24).lower() != LOW_SENSITIVITY:
+        return None, "sensitivity"
+    if _text(item.get("status"), 40) not in {"", "active"}:
+        return None, "inactive"
+    epistemic = _text(item.get("epistemic_status"), 40).lower()
+    if epistemic not in {"explicit", "inferred"}:
+        return None, "epistemic_status"
+    # Interests are intentionally more restrictive than ordinary low-risk
+    # preferences: an inferred interest is not a supported portrait claim.
+    if dimension == "interest" and epistemic != "explicit":
+        return None, "interest_requires_explicit"
+    summary = _text(item.get("summary"), 180)
+    provenance = item.get("provenance")
+    if not isinstance(provenance, Mapping):
+        return None, "provenance_missing"
+    fact_id = _fact_id(provenance.get("fact_id"))
+    evidence_refs = _evidence_refs(provenance.get("evidence_refs"))
+    if not fact_id:
+        return None, "fact_reference_missing"
+    if not evidence_refs:
+        return None, "evidence_reference_missing"
+    if not summary:
+        return None, "summary_missing"
+    category, label = category_label
+    try:
+        confidence = float(item.get("confidence") or 0.0)
+    except (TypeError, ValueError, OverflowError):
+        return None, "confidence_invalid"
+    if not math.isfinite(confidence) or confidence < 0.0 or confidence > 1.0:
+        return None, "confidence_invalid"
+    fact = {
+        "fact_id": fact_id,
+        "dimension": dimension,
+        "category": category,
+        "summary": summary,
+        "portrait_tier": _text(item.get("portrait_tier"), 24),
+        "epistemic_status": epistemic,
+        "confidence": confidence,
+        "sensitivity": LOW_SENSITIVITY,
+        "usable_scope": _text(item.get("usable_scope"), 80),
+        "updated_at": _text(item.get("updated_at"), 80),
+        "provenance": {
+            "fact_id": fact_id,
+            "evidence_refs": evidence_refs,
+            "source_scope": _text(provenance.get("source_scope"), 80),
+            "first_evidence_at": _text(provenance.get("first_evidence_at"), 80),
+            "last_evidence_at": _text(provenance.get("last_evidence_at"), 80),
+        },
+    }
+    fact["sentence"] = _sentence_for_fact(fact, label)
+    if not fact["sentence"]:
+        return None, "summary_missing"
+    return fact, ""
+
+
+def render_portrait_items(
+    items: Any,
+    *,
+    portrait_revision: int = 0,
+    last_synced_at: Any = "",
+    person_id: Any = "",
+    code: str = "profile_exact",
+    ok: bool = True,
+) -> dict[str, Any]:
+    """Render an already governed summary without performing any I/O.
+
+    The input is expected to be the ``items`` list returned by
+    ``MemoryStore.portrait_summary(..., include_provenance=True)``.  Rows that
+    do not carry a traceable reference are omitted rather than rendered as
+    un-auditable prose.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    omitted: dict[str, int] = defaultdict(int)
+    seen: set[tuple[str, str, str]] = set()
+    for item in items if isinstance(items, list) else []:
+        fact, reason = _safe_fact(item)
+        if fact is None:
+            omitted[reason or "invalid"] += 1
+            continue
+        key = (fact["fact_id"], fact["dimension"], fact["summary"])
+        if key in seen:
+            omitted["duplicate"] += 1
+            continue
+        seen.add(key)
+        grouped[fact["dimension"]].append(fact)
+
+    for dimension, facts in grouped.items():
+        facts.sort(
+            key=lambda value: (
+                -float(value.get("confidence") or 0.0),
+                _text(value.get("updated_at"), 80),
+                _text(value.get("fact_id"), 120),
+            )
+        )
+    dimensions = {
+        dimension: grouped[dimension]
+        for dimension in sorted(
+            grouped,
+            key=lambda value: (
+                _CATEGORY_INDEX.get(DIMENSION_CATEGORIES[value][0], 999),
+                value,
+            ),
+        )
+    }
+    facts = [fact for dimension in dimensions.values() for fact in dimension]
+    sentences = [
+        {
+            "text": fact["sentence"],
+            "fact_id": fact["fact_id"],
+            "dimension": fact["dimension"],
+            "evidence_refs": list(fact["provenance"]["evidence_refs"]),
+        }
+        for fact in facts
+    ]
+    for fact in facts:
+        fact.pop("sentence", None)
+    natural_language = " ".join(item["text"] for item in sentences)
+    return {
+        "ok": bool(ok),
+        "read_only": True,
+        "code": _text(code, 80) or "profile_exact",
+        "schema_version": PORTRAIT_RENDER_SCHEMA,
+        "person_id": _text(person_id, 80),
+        "portrait_revision": _nonnegative_int(portrait_revision),
+        "last_synced_at": _text(last_synced_at, 80),
+        "dimensions": dimensions,
+        "structured": dimensions,
+        "facts": facts,
+        "sentences": sentences,
+        "natural_language": natural_language,
+        "text": natural_language,
+        "governance": {
+            "approved_only": True,
+            "active_only": True,
+            "max_sensitivity": LOW_SENSITIVITY,
+            "provenance_required": True,
+        },
+        "omitted": {
+            "count": sum(omitted.values()),
+            "reasons": dict(sorted(omitted.items())),
+        },
+    }
+
+
+class PortraitRenderer:
+    """Read-only adapter over ``PortraitService.read_summary``."""
+
+    def __init__(self, portrait_service: Any):
+        self.portrait_service = portrait_service
+
+    async def render(self, request: dict[str, Any], *, limit: int = 16) -> dict[str, Any]:
+        """Authorize and render one subject without changing store state."""
+        reader: Callable[..., Awaitable[dict[str, Any]]] = self.portrait_service.read_summary
+        result = await reader(
+            request,
+            limit=max(1, min(32, int(limit))),
+            include_provenance=True,
+        )
+        if not isinstance(result, dict):
+            return render_portrait_items([], ok=False, code="bridge_degraded")
+        target = request.get("target_person_id") if isinstance(request, dict) else ""
+        return render_portrait_items(
+            result.get("items"),
+            portrait_revision=result.get("portrait_revision", 0),
+            last_synced_at=result.get("last_synced_at", ""),
+            person_id=target if bool(result.get("ok")) else "",
+            code=_text(result.get("code"), 80) or "bridge_degraded",
+            ok=bool(result.get("ok")),
+        )
+
+
+__all__ = [
+    "CATEGORY_ORDER",
+    "DIMENSION_CATEGORIES",
+    "PORTRAIT_RENDER_SCHEMA",
+    "PortraitRenderer",
+    "render_portrait_items",
+]

--- a/core/portrait_service.py
+++ b/core/portrait_service.py
@@ -1,24 +1,33 @@
 """Memory-owned REQ-036 portrait capture, governance, and read boundary."""
 from __future__ import annotations
 
+import hashlib
+import json
+import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
 try:
     from ..unified_profile_contract import build_person_ref, validate_profile_dto
 except ImportError:  # Existing standalone core.* test/import compatibility.
-    from unified_profile_contract import build_person_ref, validate_profile_dto  # type: ignore[no-redef]
+    from unified_profile_contract import (  # type: ignore[no-redef]
+        build_person_ref,
+        validate_profile_dto,
+    )
 from .models import SessionContext, clean_text
 from .portrait import (
     build_evidence,
     cross_scene_whitelisted_fact,
     extract_explicit_candidates,
     portrait_access_decision,
+    statement_fingerprint,
 )
 from .portrait_namespace import portrait_namespace_decision
+from .portrait_renderer import render_portrait_items
 
 
-class PortraitService:
+class _PortraitServiceCore:
     def __init__(self, store: Any, config: Any) -> None:
         self.store = store
         self.config = config
@@ -156,7 +165,13 @@ class PortraitService:
                 )
         return {"ok": True, "code": "portrait_evidence_recorded", "facts": created, "person_id": person_ref["person_id"]}
 
-    async def read_summary(self, request: dict[str, Any], *, limit: int = 8) -> dict[str, Any]:
+    async def read_summary(
+        self,
+        request: dict[str, Any],
+        *,
+        limit: int = 8,
+        include_provenance: bool = False,
+    ) -> dict[str, Any]:
         decision = portrait_access_decision(request)
         if not decision["candidates_allowed"]:
             return {"ok": False, "code": decision["code"], "items": [], "decision": decision}
@@ -192,8 +207,17 @@ class PortraitService:
             low_only=True,
             usage_min_confidence=self.config.float("portrait.usage_min_confidence", 0.75),
             inferred_freshness_days=self.config.int("portrait.inferred_freshness_days", 90),
+            include_provenance=include_provenance,
         )
         return {**result, "decision": decision}
+
+    async def render_readonly_portrait(
+        self, request: dict[str, Any], *, limit: int = 16
+    ) -> dict[str, Any]:
+        """Render a traceable structured/text portrait over the read boundary."""
+        from .portrait_renderer import PortraitRenderer
+
+        return await PortraitRenderer(self).render(request, limit=limit)
 
     @staticmethod
     def _scope_for_context(ctx: SessionContext) -> str:
@@ -261,3 +285,870 @@ class PortraitService:
 
     async def rollback_legacy_migration(self, *, operation_id: str) -> dict[str, Any]:
         return await self.store.rollback_portrait_migration(operation_id=clean_text(operation_id, 120))
+
+
+@dataclass(frozen=True, slots=True)
+class PortraitBackfillRequest:
+    """Explicit, single-person historical portrait operation request."""
+
+    target_person_id: str
+    target_identity: str
+    source_scopes: tuple[str, ...] = ("private",)
+    from_time: str = ""
+    to_time: str = ""
+    operation_id: str = ""
+    dry_run: bool = False
+
+    @staticmethod
+    def _normalize_utc_time(value: Any) -> str:
+        """Normalize valid request bounds for lexicographic UTC SQL comparisons."""
+        raw = clean_text(value, 80)
+        if not raw:
+            return ""
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except (TypeError, ValueError, OverflowError):
+            # Keep the original invalid value so ``validate`` reports the
+            # request error instead of silently treating it as unbounded.
+            return raw
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat()
+
+    def __post_init__(self) -> None:
+        scopes = sorted(
+            {
+                clean_text(scope, 80)
+                for scope in self.source_scopes
+                if clean_text(scope, 80)
+            }
+        )
+        object.__setattr__(self, "source_scopes", tuple(scopes[:16]))
+        object.__setattr__(self, "from_time", self._normalize_utc_time(self.from_time))
+        object.__setattr__(self, "to_time", self._normalize_utc_time(self.to_time))
+
+    @classmethod
+    def from_value(cls, value: Any) -> PortraitBackfillRequest:
+        if isinstance(value, cls):
+            return value
+        source = value if isinstance(value, dict) else {}
+        raw_scopes = source.get("source_scopes", ("private",))
+        if isinstance(raw_scopes, str):
+            raw_scopes = [raw_scopes]
+        scopes: list[str] = []
+        if isinstance(raw_scopes, (list, tuple, set)):
+            for item in raw_scopes:
+                scope = clean_text(item, 80)
+                if scope and scope not in scopes:
+                    scopes.append(scope)
+        if not scopes:
+            scopes = ["private"]
+        # Scope sets are semantically unordered.  Canonicalizing them keeps
+        # retries with the same scope set idempotent even when the caller's
+        # input order differs.
+        scopes = sorted(scopes)
+
+        return cls(
+            target_person_id=clean_text(source.get("target_person_id"), 80),
+            target_identity=clean_text(source.get("target_identity"), 160),
+            source_scopes=tuple(scopes[:16]),
+            from_time=source.get("from_time"),
+            to_time=source.get("to_time"),
+            operation_id=clean_text(source.get("operation_id"), 120),
+            dry_run=source.get("dry_run") is True,
+        )
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not self.target_person_id:
+            errors.append("missing_target_person_id")
+        if not self.target_identity:
+            errors.append("missing_target_identity")
+        if not self.operation_id:
+            errors.append("missing_operation_id")
+        if not self.source_scopes:
+            errors.append("missing_source_scopes")
+        for scope in self.source_scopes:
+            if scope != "private" and not scope.startswith("private@") and not scope.startswith("group:"):
+                errors.append("scope_not_allowed")
+            if scope.startswith("private@") and not scope.split("@", 1)[1].strip():
+                errors.append("scope_not_allowed")
+            if scope.startswith("group:"):
+                parts = scope.split(":", 2)
+                if len(parts) < 3 or not parts[1].strip() or not parts[2].strip():
+                    errors.append("scope_not_allowed")
+        if any(scope == "group" for scope in self.source_scopes):
+            errors.append("scope_not_allowed")
+        if self.from_time:
+            try:
+                datetime.fromisoformat(self.from_time.replace("Z", "+00:00"))
+            except (TypeError, ValueError, OverflowError):
+                errors.append("from_time_invalid")
+        if self.to_time:
+            try:
+                datetime.fromisoformat(self.to_time.replace("Z", "+00:00"))
+            except (TypeError, ValueError, OverflowError):
+                errors.append("to_time_invalid")
+        if self.from_time and self.to_time:
+            try:
+                start = datetime.fromisoformat(self.from_time.replace("Z", "+00:00"))
+                end = datetime.fromisoformat(self.to_time.replace("Z", "+00:00"))
+                if start > end:
+                    errors.append("time_range_invalid")
+            except (TypeError, ValueError, OverflowError):
+                pass
+        return list(dict.fromkeys(errors))
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "target_person_id": self.target_person_id,
+            "target_identity": self.target_identity,
+            "source_scopes": list(self.source_scopes),
+            "from_time": self.from_time,
+            "to_time": self.to_time,
+            "operation_id": self.operation_id,
+            "dry_run": bool(self.dry_run),
+        }
+
+
+class _PortraitBackfillMixin:
+    """Implementation kept separate so existing capture/read paths stay stable."""
+
+    @staticmethod
+    def _backfill_truthy(value: Any) -> bool:
+        if value is True:
+            return True
+        return clean_text(value, 24).lower() in {"1", "true", "yes", "y", "on"}
+
+    @classmethod
+    def _backfill_identity_values(cls, row: dict[str, Any]) -> set[str]:
+        metadata = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
+        values = {clean_text(row.get("subject_id"), 160)}
+        for key in (
+            "source_identity_key", "origin_identity_key", "authenticated_identity",
+            "author_identity_key", "identity_key", "sender_identity_key",
+            "subject_identity_key", "authenticated_subject", "author_id", "sender_id",
+        ):
+            value = metadata.get(key)
+            if isinstance(value, dict):
+                value = value.get("key") or value.get("identity_key") or value.get("id")
+            text = clean_text(value, 160)
+            if text:
+                values.add(text)
+        identity = metadata.get("identity")
+        if isinstance(identity, dict):
+            for key in ("key", "identity_key", "authenticated", "author"):
+                text = clean_text(identity.get(key), 160)
+                if text:
+                    values.add(text)
+        for container_key in ("authenticated", "author", "sender"):
+            container = metadata.get(container_key)
+            if isinstance(container, dict):
+                for key in ("key", "id", "identity_key", "authenticated_identity", "author_id", "sender_id"):
+                    text = clean_text(container.get(key), 160)
+                    if text:
+                        values.add(text)
+        return {value for value in values if value}
+
+    @classmethod
+    def _backfill_skip_reason(cls, row: dict[str, Any], target_identity: str) -> str:
+        metadata = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
+        event_type = clean_text(row.get("event_type"), 80).lower()
+        subject_kind = clean_text(row.get("subject_kind"), 40).lower()
+        subject_role = clean_text(row.get("subject_role"), 40).lower()
+        if (
+            event_type.startswith(("bot", "assistant", "system"))
+            or subject_kind in {"bot", "assistant", "system"}
+            or subject_role in {"bot", "bot_self", "assistant", "system"}
+            or cls._backfill_truthy(metadata.get("bot_generated"))
+            or cls._backfill_truthy(metadata.get("is_bot"))
+        ):
+            return "bot_subject"
+        for key in (
+            "quoted", "is_quoted", "quote", "quoted_message", "reply", "replied", "is_reply", "reply_to",
+            "forwarded", "is_forwarded", "forward", "forwarded_content", "synthetic", "unresolved",
+            "identity_ambiguous", "third_party", "third_party_author", "context_only", "concatenated_context",
+        ):
+            value = metadata.get(key)
+            if (isinstance(value, (dict, list, tuple, set)) and bool(value)) or cls._backfill_truthy(value):
+                return "excluded_context"
+        role = clean_text(metadata.get("author_role") or metadata.get("sender_role"), 40).lower()
+        if role in {"bot", "assistant", "system", "third_party", "unknown"} or clean_text(metadata.get("sender_kind"), 40).lower() in {"bot", "assistant", "system"}:
+            return "third_party"
+        # If an authenticated identity field is present, it is authoritative;
+        # a matching subject_id alone cannot override a contradictory sender
+        # identity carried by an imported record.
+        explicit_identity_values: set[str] = set()
+        for key in (
+            "source_identity_key", "origin_identity_key", "authenticated_identity",
+            "author_identity_key", "identity_key", "sender_identity_key",
+            "subject_identity_key", "authenticated_subject", "author_id", "sender_id",
+        ):
+            value = metadata.get(key)
+            if isinstance(value, dict):
+                value = value.get("key") or value.get("identity_key") or value.get("id")
+            text = clean_text(value, 160)
+            if text:
+                explicit_identity_values.add(text)
+        for container_key in ("identity", "authenticated", "author", "sender"):
+            container = metadata.get(container_key)
+            if isinstance(container, dict):
+                for key in ("key", "id", "identity_key", "authenticated_identity", "author_id", "sender_id"):
+                    text = clean_text(container.get(key), 160)
+                    if text:
+                        explicit_identity_values.add(text)
+        if explicit_identity_values and (
+            target_identity not in explicit_identity_values
+            or any(value != target_identity for value in explicit_identity_values)
+        ):
+            return "identity_mismatch"
+        if target_identity not in cls._backfill_identity_values(row):
+            return "identity_mismatch"
+        return ""
+
+    @staticmethod
+    def _backfill_source_key(row: dict[str, Any]) -> str:
+        """Build a stable source key even when an imported record lacks a message ID."""
+        source_kind = clean_text(row.get("source_kind"), 16) or "unknown"
+        scope = clean_text(row.get("scope"), 80)
+        message_id = clean_text(row.get("message_id"), 160)
+        if message_id:
+            return f"message:{source_kind}:{scope}:{message_id}"
+        source_id = clean_text(row.get("source_id"), 160)
+        content_hash = statement_fingerprint(row.get("content"))
+        if content_hash:
+            occurred_at = clean_text(row.get("occurred_at"), 80)
+            return f"content:{source_kind}:{scope}:{occurred_at}:{content_hash}"
+        return f"source:{source_kind}:{scope}:{source_id}" if source_id else ""
+
+    async def _backfill_validate(self, req: PortraitBackfillRequest) -> tuple[dict[str, Any], dict[str, Any]]:
+        errors = req.validate()
+        if errors:
+            return {"ok": False, "code": "invalid_request", "errors": errors}, {}
+        person = await self.store.portrait_backfill_person(req.target_person_id, req.target_identity)
+        if not person.get("ok"):
+            return {"ok": False, "code": person.get("code", "identity_mismatch"), "errors": []}, {}
+        for scope in req.source_scopes:
+            capability = await self.store.portrait_backfill_scope_capability(req.target_person_id, scope)
+            if scope.startswith("group:") and not bool(capability.get("configured")):
+                return {"ok": False, "code": "scope_not_allowed", "scope": scope, "errors": []}, person
+            if not bool(capability.get("portrait_learning_enabled")):
+                return {"ok": False, "code": "scope_not_allowed", "scope": scope, "errors": []}, person
+        return {"ok": True, "code": "profile_exact"}, person
+
+    async def _backfill_scan(
+        self,
+        req: PortraitBackfillRequest,
+        *,
+        person: dict[str, Any],
+        offset: int = 0,
+        max_records: int = 5000,
+        page_size: int = 100,
+    ) -> dict[str, Any]:
+        counts: dict[str, Any] = {
+            "scanned": 0, "eligible_sources": 0, "candidate_count": 0,
+            "proposed_fact_count": 0, "skipped": {}, "dimensions": {},
+            "characters_read": 0, "next_offset": max(0, int(offset)), "exhausted": False,
+        }
+        started_at = time.monotonic()
+        runtime_limit = max(1, min(3600, self.config.int("portrait.backfill_max_runtime_seconds", 30)))
+        character_limit = max(1, min(10_000_000, self.config.int("portrait.backfill_max_characters", 200_000)))
+        dimension_limit = max(1, min(128, self.config.int("portrait.backfill_max_dimensions", 32)))
+        seen_sources: set[str] = set()
+        while counts["scanned"] < max(1, int(max_records)):
+            page = await self.store.list_portrait_history_sources(
+                source_scopes=list(req.source_scopes), from_time=req.from_time, to_time=req.to_time,
+                offset=counts["next_offset"], limit=min(page_size, max_records - counts["scanned"]),
+            )
+            if not page:
+                counts["exhausted"] = True
+                break
+            counts["next_offset"] += len(page)
+            for row in page:
+                counts["scanned"] += 1
+                source_id = clean_text(row.get("source_id"), 160)
+                source_key = self._backfill_source_key(row)
+                if source_key and source_key in seen_sources:
+                    counts["skipped"]["duplicate_source"] = counts["skipped"].get("duplicate_source", 0) + 1
+                    continue
+                if source_key:
+                    seen_sources.add(source_key)
+                content = clean_text(row.get("content"), 4000)
+                if counts["characters_read"] + len(content) > character_limit:
+                    counts["skipped"]["character_limit"] = counts["skipped"].get("character_limit", 0) + 1
+                    counts["paused_reason"] = "character_limit"
+                    return counts
+                counts["characters_read"] += len(content)
+                if clean_text(row.get("scope"), 80) not in req.source_scopes:
+                    reason = "scope_not_allowed"
+                else:
+                    reason = self._backfill_skip_reason(row, req.target_identity)
+                if reason:
+                    counts["skipped"][reason] = counts["skipped"].get(reason, 0) + 1
+                    continue
+                counts["eligible_sources"] += 1
+                candidates = extract_explicit_candidates(row.get("content"))
+                for candidate in candidates:
+                    # Keep the existing explicit extractor and governance gate
+                    # authoritative; no semantic/LLM extraction is introduced.
+                    if candidate.get("quality_gate_passed") is False:
+                        counts["skipped"]["quality_gate"] = counts["skipped"].get("quality_gate", 0) + 1
+                        continue
+                    if clean_text(candidate.get("sensitivity"), 24) == "high":
+                        counts["skipped"]["sensitivity_gate"] = counts["skipped"].get("sensitivity_gate", 0) + 1
+                        continue
+                    counts["candidate_count"] += 1
+                    dimension = clean_text(candidate.get("dimension"), 80)
+                    if dimension not in counts["dimensions"] and len(counts["dimensions"]) >= dimension_limit:
+                        counts["skipped"]["dimension_limit"] = counts["skipped"].get("dimension_limit", 0) + 1
+                        continue
+                    counts["dimensions"][dimension] = counts["dimensions"].get(dimension, 0) + 1
+                    counts["proposed_fact_count"] += 1
+                if time.monotonic() - started_at >= runtime_limit:
+                    counts["skipped"]["runtime_limit"] = counts["skipped"].get("runtime_limit", 0) + 1
+                    return counts
+            if counts["scanned"] >= max_records or len(page) < page_size:
+                # A short page is the only bounded exhaustion signal available
+                # from the store's offset API.
+                counts["exhausted"] = True
+                break
+        return counts
+
+    @staticmethod
+    def _backfill_public_counts(snapshot: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "scanned": int(snapshot.get("scanned", 0) or 0),
+            "eligible_sources": int(snapshot.get("eligible_sources", 0) or 0),
+            "candidate_count": int(snapshot.get("candidate_count", 0) or 0),
+            "accepted_fact_count": int(snapshot.get("accepted_fact_count", 0) or 0),
+            "inferred_fact_count": int(snapshot.get("inferred_fact_count", 0) or 0),
+            "characters_read": int(snapshot.get("characters_read", 0) or 0),
+            "skipped": dict(snapshot.get("skipped", {})) if isinstance(snapshot.get("skipped"), dict) else {},
+            "dimensions": dict(snapshot.get("dimensions", {})) if isinstance(snapshot.get("dimensions"), dict) else {},
+            "paused_reason": clean_text(snapshot.get("paused_reason"), 80),
+        }
+
+    async def _backfill_process(self, req: PortraitBackfillRequest, person: dict[str, Any], snapshot: dict[str, Any]) -> dict[str, Any]:
+        max_records = max(1, min(50000, self.config.int("portrait.backfill_max_records", 5000)))
+        page_size = max(1, min(500, self.config.int("portrait.backfill_page_size", 100)))
+        runtime_limit = max(1, min(3600, self.config.int("portrait.backfill_max_runtime_seconds", 30)))
+        character_limit = max(1, min(10_000_000, self.config.int("portrait.backfill_max_characters", 200_000)))
+        dimension_limit = max(1, min(128, self.config.int("portrait.backfill_max_dimensions", 32)))
+        invocation_characters = 0
+        started_at = time.monotonic()
+        offset = max(0, int(snapshot.get("next_offset", 0) or 0))
+        # ``paused_reason`` describes the current invocation only.  Keeping a
+        # previous budget marker here would make every resumed run pause again
+        # even when the new invocation has fresh limits.
+        snapshot.pop("paused_reason", None)
+        target_ref = {
+            "person_id": req.target_person_id,
+            "resolved_identity_key": req.target_identity,
+            "projection_revision": int(person.get("projection_revision") or 1),
+            "identity_assurance": clean_text(person.get("identity_assurance"), 40),
+            "profile_status": clean_text(person.get("profile_status"), 40),
+        }
+        snapshot.setdefault("created_fact_ids", [])
+        snapshot.setdefault("created_fact_snapshots", {})
+        snapshot.setdefault("touched_fact_ids", [])
+        snapshot.setdefault("touched_fact_snapshots", {})
+        snapshot.setdefault("created_evidence_hashes", [])
+        snapshot.setdefault("created_queue_ids", [])
+        snapshot.setdefault("skipped", {})
+        snapshot.setdefault("dimensions", {})
+        while snapshot.get("scanned", 0) < max_records and not bool(snapshot.get("exhausted")):
+            if time.monotonic() - started_at >= runtime_limit:
+                snapshot["paused_reason"] = "runtime_limit"
+                break
+            state = await self.store.portrait_backfill_operation(req.operation_id)
+            if state and state.get("state") in {"cancelled", "rolled_back", "complete", "failed"}:
+                snapshot["cancelled"] = True
+                return snapshot
+            for scope in req.source_scopes:
+                capability = await self.store.portrait_backfill_scope_capability(
+                    req.target_person_id, scope
+                )
+                if not bool(capability.get("portrait_learning_enabled")):
+                    snapshot["paused_reason"] = "capability_disabled"
+                    break
+            if snapshot.get("paused_reason") == "capability_disabled":
+                await self.store.update_portrait_backfill_operation(
+                    req.operation_id, snapshot, state="paused"
+                )
+                return snapshot
+            page = await self.store.list_portrait_history_sources(
+                source_scopes=list(req.source_scopes), from_time=req.from_time, to_time=req.to_time,
+                offset=offset, limit=min(page_size, max_records - int(snapshot.get("scanned", 0) or 0)),
+            )
+            if not page:
+                snapshot["exhausted"] = True
+                break
+            page_offset = offset
+            for row_index, row in enumerate(page):
+                row_next_offset = page_offset + row_index + 1
+                snapshot["scanned"] = int(snapshot.get("scanned", 0) or 0) + 1
+                source_id = clean_text(row.get("source_id"), 160)
+                source_key = self._backfill_source_key(row)
+                if source_key and source_key in set(snapshot.get("processed_source_ids", [])):
+                    snapshot["skipped"]["duplicate_source"] = snapshot["skipped"].get("duplicate_source", 0) + 1
+                    snapshot["next_offset"] = row_next_offset
+                    continue
+                if source_key:
+                    snapshot.setdefault("processed_source_ids", []).append(source_key)
+                content = clean_text(row.get("content"), 4000)
+                if invocation_characters + len(content) > character_limit:
+                    snapshot["skipped"]["character_limit"] = snapshot["skipped"].get("character_limit", 0) + 1
+                    if invocation_characters == 0:
+                        # A single oversized source cannot ever fit this
+                        # bounded invocation; skip it explicitly so resume
+                        # cannot spin forever on the same row.
+                        if source_key:
+                            processed = snapshot.get("processed_source_ids", [])
+                            if isinstance(processed, list) and source_key in processed:
+                                processed.remove(source_key)
+                        snapshot["scanned"] = max(0, int(snapshot.get("scanned", 0) or 0) - 1)
+                        snapshot["next_offset"] = row_next_offset
+                        continue
+                    if source_key:
+                        processed = snapshot.get("processed_source_ids", [])
+                        if isinstance(processed, list) and source_key in processed:
+                            processed.remove(source_key)
+                    snapshot["scanned"] = max(0, int(snapshot.get("scanned", 0) or 0) - 1)
+                    snapshot["next_offset"] = page_offset + row_index
+                    snapshot["paused_reason"] = "character_limit"
+                    break
+                invocation_characters += len(content)
+                snapshot["characters_read"] = int(snapshot.get("characters_read", 0) or 0) + len(content)
+                reason = self._backfill_skip_reason(row, req.target_identity)
+                if clean_text(row.get("scope"), 80) not in req.source_scopes:
+                    reason = "scope_not_allowed"
+                if reason:
+                    snapshot["skipped"][reason] = snapshot["skipped"].get(reason, 0) + 1
+                    snapshot["next_offset"] = row_next_offset
+                    continue
+                snapshot["eligible_sources"] = int(snapshot.get("eligible_sources", 0) or 0) + 1
+                message_id = clean_text(row.get("message_id"), 160) or source_id
+                candidates = extract_explicit_candidates(row.get("content"))
+                if not candidates:
+                    snapshot["skipped"]["no_candidate"] = snapshot["skipped"].get("no_candidate", 0) + 1
+                    snapshot["next_offset"] = row_next_offset
+                    continue
+                evidence = build_evidence(
+                    person_ref=target_ref,
+                    scope=clean_text(row.get("scope"), 80),
+                    session_id=clean_text(row.get("session_id"), 200),
+                    message_id=message_id,
+                    source_identity_key=req.target_identity,
+                    text=row.get("content"),
+                    context_refs=[source_id] if source_id else [],
+                )
+                evidence["operation_id"] = req.operation_id
+                evidence_result = await self.store.add_portrait_evidence(evidence)
+                if not evidence_result.get("ok"):
+                    if evidence_result.get("code") == "operation_not_active":
+                        snapshot["cancelled"] = True
+                        return snapshot
+                    if evidence_result.get("code") == "portrait_learning_disabled":
+                        snapshot["paused_reason"] = "capability_disabled"
+                        return snapshot
+                    snapshot["skipped"]["evidence_error"] = snapshot["skipped"].get("evidence_error", 0) + 1
+                    snapshot["next_offset"] = row_next_offset
+                    continue
+                if not evidence_result.get("created"):
+                    snapshot["skipped"]["duplicate_evidence"] = snapshot["skipped"].get("duplicate_evidence", 0) + 1
+                elif evidence["evidence_hash"] not in snapshot["created_evidence_hashes"]:
+                    snapshot["created_evidence_hashes"].append(evidence["evidence_hash"])
+                for candidate in candidates:
+                    if candidate.get("quality_gate_passed") is False:
+                        snapshot["skipped"]["quality_gate"] = snapshot["skipped"].get("quality_gate", 0) + 1
+                        continue
+                    if clean_text(candidate.get("sensitivity"), 24) == "high":
+                        snapshot["skipped"]["sensitivity_gate"] = snapshot["skipped"].get("sensitivity_gate", 0) + 1
+                        continue
+                    snapshot["candidate_count"] = int(snapshot.get("candidate_count", 0) or 0) + 1
+                    dimension = clean_text(candidate.get("dimension"), 80)
+                    if dimension not in snapshot["dimensions"] and len(snapshot["dimensions"]) >= dimension_limit:
+                        snapshot["skipped"]["dimension_limit"] = snapshot["skipped"].get("dimension_limit", 0) + 1
+                        continue
+                    snapshot["dimensions"][dimension] = snapshot["dimensions"].get(dimension, 0) + 1
+                    source_scope = clean_text(row.get("scope"), 80)
+                    existing = await self.store.get_portrait_backfill_fact(
+                        person_id=req.target_person_id, dimension=dimension,
+                        normalized_claim_hash=clean_text(candidate.get("normalized_claim_hash"), 80),
+                        source_scope=source_scope, portrait_tier="base",
+                    )
+                    if existing is not None:
+                        # A historical operation may extend its own candidate,
+                        # but must never mutate an external official fact.
+                        if clean_text(existing.get("operation_id"), 120) != req.operation_id:
+                            snapshot["skipped"]["external_fact_protected"] = snapshot["skipped"].get("external_fact_protected", 0) + 1
+                            snapshot["next_offset"] = row_next_offset
+                            continue
+                        append = await self.store.append_portrait_fact_evidence(
+                            person_id=req.target_person_id,
+                            fact_id=clean_text(existing.get("id"), 120),
+                            evidence_hash=evidence["evidence_hash"],
+                            context_refs=evidence["context_refs"],
+                            operation_id=req.operation_id,
+                        )
+                        if append.get("ok"):
+                            fact_key = clean_text(existing.get("id"), 120)
+                            is_created_by_operation = fact_key in snapshot.get("created_fact_ids", [])
+                            if not is_created_by_operation and fact_key not in snapshot["touched_fact_ids"]:
+                                snapshot["touched_fact_ids"].append(fact_key)
+                            previous = append.get("previous")
+                            if isinstance(previous, dict) and append.get("created") and not is_created_by_operation:
+                                snapshot["touched_fact_snapshots"].setdefault(fact_key, previous)
+                                entry = snapshot["touched_fact_snapshots"][fact_key]
+                                if isinstance(entry, dict):
+                                    entry.setdefault("added_evidence_hashes", []).append(evidence["evidence_hash"])
+                            created_snapshot = snapshot["created_fact_snapshots"].get(clean_text(existing.get("id"), 120))
+                            if append.get("created") and isinstance(created_snapshot, dict):
+                                created_snapshot.setdefault("evidence_hashes", []).append(evidence["evidence_hash"])
+                                created_snapshot["evidence_hashes"] = list(dict.fromkeys(created_snapshot["evidence_hashes"]))[:16]
+                                created_snapshot["revision"] = int(created_snapshot.get("revision") or 1) + 1
+                            result_key = "existing_fact_evidence_appended" if append.get("created") else "existing_fact_evidence_duplicate"
+                            snapshot["skipped"][result_key] = snapshot["skipped"].get(result_key, 0) + 1
+                        else:
+                            if append.get("code") == "operation_not_active":
+                                snapshot["cancelled"] = True
+                                return snapshot
+                            if append.get("code") == "portrait_learning_disabled":
+                                snapshot["paused_reason"] = "capability_disabled"
+                                return snapshot
+                            snapshot["skipped"][clean_text(append.get("code"), 80) or "existing_fact_rejected"] = snapshot["skipped"].get(clean_text(append.get("code"), 80) or "existing_fact_rejected", 0) + 1
+                        snapshot["next_offset"] = row_next_offset
+                        continue
+                    fact = {
+                        **candidate,
+                        "person_id": req.target_person_id,
+                        "portrait_tier": "base",
+                        "source_scope": source_scope,
+                        "usable_scope": "self_low_global"
+                        if cross_scene_whitelisted_fact(
+                            dimension=dimension,
+                            claim_summary=candidate.get("claim_summary"),
+                            sensitivity=candidate.get("sensitivity"),
+                            source_scope=source_scope,
+                        ) else "source_only",
+                        "confidence": float(candidate.get("extraction_quality_score") or 0.0),
+                        "status": clean_text(candidate.get("profile_state"), 40) or "candidate",
+                        "evidence_hashes": [evidence["evidence_hash"]],
+                        "context_refs": evidence["context_refs"],
+                        "operation_id": req.operation_id,
+                    }
+                    result = await self.store.upsert_portrait_fact(fact)
+                    if not result.get("ok"):
+                        if result.get("code") == "operation_not_active":
+                            snapshot["cancelled"] = True
+                            return snapshot
+                        if result.get("code") == "portrait_learning_disabled":
+                            snapshot["paused_reason"] = "capability_disabled"
+                            return snapshot
+                        code = clean_text(result.get("code"), 80) or "fact_rejected"
+                        snapshot["skipped"][code] = snapshot["skipped"].get(code, 0) + 1
+                        snapshot["next_offset"] = row_next_offset
+                        continue
+                    queued = {"created": False}
+                    if result.get("created"):
+                        snapshot["created_fact_ids"].append(result["fact_id"])
+                        snapshot["touched_fact_ids"].append(result["fact_id"])
+                        snapshot["created_fact_snapshots"][result["fact_id"]] = {
+                            "revision": int(result.get("revision") or 1),
+                            "evidence_hashes": [evidence["evidence_hash"]],
+                            "operation_id": req.operation_id,
+                        }
+                        snapshot["accepted_fact_count"] = int(snapshot.get("accepted_fact_count", 0) or 0) + 1
+                        queued = await self.store.enqueue_portrait_learning(
+                            person_id=req.target_person_id,
+                            fact_id=result["fact_id"],
+                            evidence_hash=evidence["evidence_hash"],
+                            operation_id=req.operation_id,
+                        )
+                        if not queued.get("ok") and queued.get("code") == "operation_not_active":
+                            snapshot["cancelled"] = True
+                            return snapshot
+                        if not queued.get("ok") and queued.get("code") == "portrait_learning_disabled":
+                            snapshot["paused_reason"] = "capability_disabled"
+                            return snapshot
+                    if queued.get("created"):
+                        snapshot["created_queue_ids"].append(queued.get("queue_id"))
+                snapshot["next_offset"] = row_next_offset
+                if time.monotonic() - started_at >= runtime_limit:
+                    snapshot["paused_reason"] = "runtime_limit"
+                    break
+            offset = int(snapshot.get("next_offset", page_offset) or page_offset)
+            if snapshot.get("paused_reason") in {"runtime_limit", "character_limit"}:
+                await self.store.update_portrait_backfill_operation(req.operation_id, snapshot, state="paused")
+                return snapshot
+            if snapshot.get("scanned", 0) >= max_records or len(page) < page_size:
+                snapshot["exhausted"] = True
+            await self.store.update_portrait_backfill_operation(req.operation_id, snapshot, state="running")
+        return snapshot
+
+    async def _backfill_aggregate(self, req: PortraitBackfillRequest, snapshot: dict[str, Any]) -> dict[str, Any]:
+        runner = getattr(self.store, "run_portrait_backfill_aggregation", None)
+        if not callable(runner):
+            return {"ok": True, "accepted": 0, "insufficient": int(snapshot.get("accepted_fact_count", 0) or 0)}
+        result = await runner(
+            operation_id=req.operation_id,
+            person_id=req.target_person_id,
+            min_independent_evidence=max(1, min(16, self.config.int("portrait.min_independent_evidence", 3))),
+            fact_ids=list(dict.fromkeys(clean_text(item, 120) for item in snapshot.get("touched_fact_ids", []) if clean_text(item, 120))),
+            queue_ids=list(dict.fromkeys(clean_text(item, 120) for item in snapshot.get("created_queue_ids", []) if clean_text(item, 120))),
+        )
+        if not result.get("ok"):
+            if result.get("code") == "operation_not_active":
+                snapshot["cancelled"] = True
+            return result
+        snapshot["inferred_fact_count"] = int(result.get("created", 0) or 0)
+        snapshot["insufficient_evidence_count"] = int(result.get("insufficient", 0) or 0)
+        aggregate_snapshots = result.get("created_fact_snapshots")
+        if isinstance(aggregate_snapshots, dict):
+            for fact_id, metadata in aggregate_snapshots.items():
+                fact_key = clean_text(fact_id, 120)
+                if fact_key and isinstance(metadata, dict):
+                    snapshot.setdefault("created_fact_snapshots", {})[fact_key] = metadata
+        for fact_id in result.get("created_fact_ids", []) if isinstance(result.get("created_fact_ids"), list) else []:
+            if fact_id not in snapshot["created_fact_ids"]:
+                snapshot["created_fact_ids"].append(fact_id)
+        return result
+
+    async def preview_history_backfill(self, request: Any) -> dict[str, Any]:
+        req = PortraitBackfillRequest.from_value(request)
+        validation, person = await self._backfill_validate(req)
+        if not validation.get("ok"):
+            return {**validation, "operation_id": req.operation_id, "dry_run": True}
+        max_records = max(1, min(50000, self.config.int("portrait.backfill_max_records", 5000)))
+        page_size = max(1, min(500, self.config.int("portrait.backfill_page_size", 100)))
+        counts = await self._backfill_scan(req, person=person, max_records=max_records, page_size=page_size)
+        return {
+            "ok": True, "code": "dry_run_ready", "operation_id": req.operation_id, "dry_run": True,
+            "target_person_id": req.target_person_id, "source_scopes": list(req.source_scopes),
+            "from_time": req.from_time, "to_time": req.to_time,
+            "counts": counts, "audit": self._backfill_public_counts(counts),
+        }
+
+    async def start_history_backfill(self, request: Any, *, actor: str = "administrator") -> dict[str, Any]:
+        req = PortraitBackfillRequest.from_value(request)
+        if req.dry_run:
+            return await self.preview_history_backfill(req)
+        validation, person = await self._backfill_validate(req)
+        if not validation.get("ok"):
+            return {**validation, "operation_id": req.operation_id, "dry_run": False}
+        actor_value = clean_text(actor, 120) or "administrator"
+        payload_hash = hashlib.sha256(
+            json.dumps(
+                {**req.payload(), "actor": actor_value},
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        initial = {
+            "actor": actor_value,
+            "target_person_id": req.target_person_id, "target_identity_hash": hashlib.sha256(req.target_identity.encode("utf-8")).hexdigest(),
+            "source_scopes": list(req.source_scopes), "from_time": req.from_time, "to_time": req.to_time,
+            "next_offset": 0, "exhausted": False, "scanned": 0, "eligible_sources": 0, "candidate_count": 0,
+            "accepted_fact_count": 0, "inferred_fact_count": 0, "characters_read": 0, "skipped": {}, "dimensions": {},
+            "created_fact_ids": [], "created_evidence_hashes": [], "created_queue_ids": [], "processed_source_ids": [],
+            "created_fact_snapshots": {},
+            "touched_fact_ids": [],
+            "touched_fact_snapshots": {},
+        }
+        operation = await self.store.create_portrait_backfill_operation(operation_id=req.operation_id, payload_hash=payload_hash, snapshot=initial)
+        if not operation.get("ok"):
+            return operation
+        state = clean_text(operation.get("state"), 40)
+        snapshot = operation.get("snapshot") if isinstance(operation.get("snapshot"), dict) else initial
+        if state in {"complete", "rolled_back"}:
+            return {"ok": True, "code": "backfill_idempotent_replay", "operation_id": req.operation_id, "state": state, "counts": self._backfill_public_counts(snapshot)}
+        if state == "cancelled":
+            return {"ok": False, "code": "backfill_cancelled", "operation_id": req.operation_id, "state": state, "counts": self._backfill_public_counts(snapshot)}
+        try:
+            snapshot = await self._backfill_process(req, person, snapshot)
+        except Exception:
+            # Persist a bounded diagnostic marker without storing source text or
+            # exception details in the operation audit record.
+            snapshot["last_error"] = "backfill_processing_failed"
+            await self.store.update_portrait_backfill_operation(req.operation_id, snapshot, state="failed")
+            return {
+                "ok": False,
+                "code": "backfill_failed",
+                "operation_id": req.operation_id,
+                "state": "failed",
+                "counts": self._backfill_public_counts(snapshot),
+            }
+        # Cancellation may arrive while the current page is being committed.
+        # Re-read the authoritative operation state before deciding whether to
+        # aggregate or publish completion; a stale local snapshot must not
+        # resurrect a cancelled operation.
+        latest = await self.store.portrait_backfill_operation(req.operation_id)
+        if latest and clean_text(latest.get("state"), 40) in {"cancelled", "rolled_back"}:
+            snapshot["cancelled"] = True
+        if bool(snapshot.get("cancelled")):
+            final_state = "cancelled"
+            code = "backfill_cancelled"
+        elif bool(snapshot.get("exhausted")):
+            try:
+                aggregation = await self._backfill_aggregate(req, snapshot)
+                if not aggregation.get("ok"):
+                    if aggregation.get("code") == "operation_not_active":
+                        snapshot["cancelled"] = True
+                    else:
+                        snapshot["last_error"] = "backfill_aggregation_failed"
+                        await self.store.update_portrait_backfill_operation(req.operation_id, snapshot, state="failed")
+                        return {
+                            "ok": False,
+                            "code": "backfill_failed",
+                            "operation_id": req.operation_id,
+                            "state": "failed",
+                            "counts": self._backfill_public_counts(snapshot),
+                        }
+            except Exception:
+                snapshot["last_error"] = "backfill_aggregation_failed"
+                await self.store.update_portrait_backfill_operation(req.operation_id, snapshot, state="failed")
+                return {
+                    "ok": False,
+                    "code": "backfill_failed",
+                    "operation_id": req.operation_id,
+                    "state": "failed",
+                    "counts": self._backfill_public_counts(snapshot),
+                }
+            if snapshot.get("cancelled"):
+                final_state = "cancelled"
+                code = "backfill_cancelled"
+            else:
+                final_state = "complete"
+                code = "backfill_complete"
+        else:
+            final_state = "paused"
+            code = "backfill_paused"
+        await self.store.update_portrait_backfill_operation(req.operation_id, snapshot, state=final_state)
+        return {
+            "ok": final_state != "cancelled", "code": code, "operation_id": req.operation_id, "state": final_state,
+            "checkpoint": {"next_offset": int(snapshot.get("next_offset", 0) or 0), "exhausted": bool(snapshot.get("exhausted"))},
+            "counts": self._backfill_public_counts(snapshot),
+        }
+
+    async def status_history_backfill(self, operation_id: str) -> dict[str, Any]:
+        operation = await self.store.portrait_backfill_operation(clean_text(operation_id, 120))
+        if operation is None:
+            return {"ok": False, "code": "operation_not_found", "operation_id": clean_text(operation_id, 120)}
+        if clean_text(operation.get("operation_kind"), 80) != "historical_portrait_backfill":
+            return {"ok": False, "code": "operation_conflict", "operation_id": clean_text(operation_id, 120)}
+        snapshot = operation.get("snapshot") if isinstance(operation.get("snapshot"), dict) else {}
+        return {
+            "ok": True, "code": "backfill_status", "operation_id": operation["operation_id"], "state": operation["state"],
+            "checkpoint": {"next_offset": int(snapshot.get("next_offset", 0) or 0), "exhausted": bool(snapshot.get("exhausted"))},
+            "counts": self._backfill_public_counts(snapshot),
+            "last_error": clean_text(snapshot.get("last_error"), 120),
+            "created_at": operation.get("created_at", ""), "updated_at": operation.get("updated_at", ""),
+        }
+
+    async def cancel_history_backfill(self, operation_id: str) -> dict[str, Any]:
+        return await self.store.cancel_portrait_backfill_operation(clean_text(operation_id, 120))
+
+    async def rollback_history_backfill(self, operation_id: str, *, confirm: bool = False) -> dict[str, Any]:
+        if not confirm:
+            return {"ok": False, "code": "rollback_requires_confirmation", "operation_id": clean_text(operation_id, 120)}
+        return await self.store.rollback_portrait_backfill_operation(clean_text(operation_id, 120))
+
+    async def render_history_portrait(self, request: Any, *, limit: int = 32) -> dict[str, Any]:
+        req = PortraitBackfillRequest.from_value(request)
+        errors = req.validate()
+        if errors:
+            return {"ok": False, "code": "invalid_request", "errors": errors, "items": [], "groups": {}, "text": ""}
+        person = await self.store.portrait_backfill_person(req.target_person_id, req.target_identity)
+        if not person.get("ok"):
+            return {"ok": False, "code": person.get("code", "identity_mismatch"), "items": [], "groups": {}, "text": ""}
+        for scope in req.source_scopes:
+            capability = await self.store.portrait_backfill_scope_capability(req.target_person_id, scope)
+            if scope.startswith("group:") and not bool(capability.get("configured")):
+                return {"ok": False, "code": "scope_not_allowed", "scope": scope, "items": [], "groups": {}, "text": ""}
+            if not bool(capability.get("portrait_usage_enabled")):
+                return {"ok": False, "code": "portrait_usage_disabled", "scope": scope, "items": [], "groups": {}, "text": ""}
+        summary_reader = getattr(self.store, "portrait_summary", None)
+        legacy_renderer = getattr(self.store, "render_portrait_facts", None)
+        if not callable(summary_reader) and not callable(legacy_renderer):
+            return {"ok": False, "code": "portrait_renderer_unavailable", "items": [], "groups": {}, "text": ""}
+        if callable(summary_reader):
+            # Reuse the established read policy (identity assurance,
+            # capability, confidence, freshness, scope and suppression) for
+            # the backfill renderer instead of maintaining a second filter.
+            merged_items: list[dict[str, Any]] = []
+            portrait_revision = 0
+            last_synced_at = ""
+            for scope in req.source_scopes:
+                summary = await summary_reader(
+                    req.target_person_id,
+                    scope=scope,
+                    limit=max(1, min(32, int(limit))),
+                    low_only=True,
+                    usage_min_confidence=self.config.float("portrait.usage_min_confidence", 0.75),
+                    inferred_freshness_days=self.config.int("portrait.inferred_freshness_days", 90),
+                    include_provenance=True,
+                )
+                if not isinstance(summary, dict) or not summary.get("ok"):
+                    result = summary if isinstance(summary, dict) else {
+                        "ok": False, "code": "portrait_renderer_unavailable", "items": []
+                    }
+                    break
+                merged_items.extend(summary.get("items") if isinstance(summary.get("items"), list) else [])
+                portrait_revision = max(portrait_revision, int(summary.get("portrait_revision") or 0))
+                last_synced_at = clean_text(summary.get("last_synced_at"), 80) or last_synced_at
+            else:
+                seen_fact_ids: set[str] = set()
+                unique_items: list[dict[str, Any]] = []
+                for item in merged_items:
+                    fact_id = clean_text((item.get("provenance") or {}).get("fact_id"), 120) if isinstance(item, dict) else ""
+                    if fact_id and fact_id in seen_fact_ids:
+                        continue
+                    if fact_id:
+                        seen_fact_ids.add(fact_id)
+                    unique_items.append(item)
+                result = {
+                    "ok": True,
+                    "code": "profile_exact",
+                    "items": unique_items,
+                    "portrait_revision": portrait_revision,
+                    "last_synced_at": last_synced_at,
+                }
+        else:
+            result = await legacy_renderer(
+                person_id=req.target_person_id,
+                source_scopes=list(req.source_scopes),
+                limit=max(1, min(64, int(limit))),
+                usage_min_confidence=self.config.float("portrait.usage_min_confidence", 0.75),
+                inferred_freshness_days=self.config.int("portrait.inferred_freshness_days", 90),
+            )
+        result = result if isinstance(result, dict) else {}
+        rendered = render_portrait_items(
+            result.get("items"),
+            portrait_revision=result.get("portrait_revision", 0),
+            last_synced_at=result.get("last_synced_at", ""),
+            person_id=req.target_person_id if result.get("ok") else "",
+            code=clean_text(result.get("code"), 80) or "bridge_degraded",
+            ok=bool(result.get("ok")),
+        )
+        return {
+            **rendered,
+            "target_person_id": req.target_person_id,
+            "items": rendered.get("facts", []),
+            # Compatibility aliases used by the first backfill API draft.
+            "groups": rendered["dimensions"],
+            "text": rendered["natural_language"],
+        }
+
+    # Short aliases make the six-phase contract convenient for callers while
+    # retaining descriptive methods for existing plugin integrations.
+    backfill_preview = preview_history_backfill
+    backfill_start = start_history_backfill
+    backfill_status = status_history_backfill
+    backfill_cancel = cancel_history_backfill
+    backfill_rollback = rollback_history_backfill
+    backfill_render = render_history_portrait
+
+
+class PortraitService(_PortraitServiceCore, _PortraitBackfillMixin):
+    """Existing portrait runtime plus the opt-in historical backfill contract."""

--- a/core/service.py
+++ b/core/service.py
@@ -893,6 +893,25 @@ class MemoryCompanionService:
     async def run_unified_profile_portrait_batch(self, person_id: str, *, run_day: str = "") -> dict[str, Any]:
         return await self.portraits.run_daily_batch(person_id, run_day=run_day)
 
+    async def preview_portrait_history_backfill(self, request: Any) -> dict[str, Any]:
+        """Preview one explicitly scoped historical portrait operation."""
+        return await self.portraits.preview_history_backfill(request)
+
+    async def start_portrait_history_backfill(self, request: Any) -> dict[str, Any]:
+        return await self.portraits.start_history_backfill(request)
+
+    async def status_portrait_history_backfill(self, operation_id: str) -> dict[str, Any]:
+        return await self.portraits.status_history_backfill(operation_id)
+
+    async def cancel_portrait_history_backfill(self, operation_id: str) -> dict[str, Any]:
+        return await self.portraits.cancel_history_backfill(operation_id)
+
+    async def rollback_portrait_history_backfill(self, operation_id: str, *, confirm: bool = False) -> dict[str, Any]:
+        return await self.portraits.rollback_history_backfill(operation_id, confirm=confirm)
+
+    async def render_portrait_history_backfill(self, request: Any, *, limit: int = 32) -> dict[str, Any]:
+        return await self.portraits.render_history_portrait(request, limit=limit)
+
     def _portrait_window_hours(self) -> tuple[int, int]:
         start = max(0, min(23, self.config.int("portrait.update_window_start_hour", 3)))
         end = max(1, min(24, self.config.int("portrait.update_window_end_hour", 5)))

--- a/core/store.py
+++ b/core/store.py
@@ -704,6 +704,7 @@ class MemoryStore:
                     message_id TEXT NOT NULL DEFAULT '',
                     statement_fingerprint TEXT NOT NULL DEFAULT '',
                     context_refs TEXT NOT NULL DEFAULT '[]',
+                    operation_id TEXT NOT NULL DEFAULT '',
                     created_at TEXT NOT NULL DEFAULT ''
                 );
 
@@ -882,6 +883,9 @@ class MemoryStore:
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_portrait_evidence_person ON portrait_evidence(person_id, created_at)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_portrait_evidence_operation ON portrait_evidence(operation_id, person_id)"
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_portrait_facts_person ON portrait_facts(person_id, status, sensitivity, updated_at DESC)"
@@ -1468,6 +1472,8 @@ class MemoryStore:
         }
         if "statement_fingerprint" not in existing:
             self._conn.execute("ALTER TABLE portrait_evidence ADD COLUMN statement_fingerprint TEXT NOT NULL DEFAULT ''")
+        if "operation_id" not in existing:
+            self._conn.execute("ALTER TABLE portrait_evidence ADD COLUMN operation_id TEXT NOT NULL DEFAULT ''")
 
     async def upsert_portrait_person_projection(
         self,
@@ -1590,6 +1596,49 @@ class MemoryStore:
             return {"ok": False, "code": "bridge_person_mismatch"}
         return {"ok": True, "code": "profile_exact"}
 
+    def _portrait_backfill_write_allowed_sync(self, operation_id: str) -> tuple[bool, str]:
+        """Check a historical operation while holding the store lock.
+
+        The check belongs inside each mutator's transaction.  A service-level
+        read followed by a separate write leaves a cancellation/rollback race
+        in which a terminal operation can still acquire new side effects.
+        Non-backfill operation IDs retain the existing behavior.
+        """
+        operation_id = clean_text(operation_id, 120)
+        if not operation_id:
+            return True, ""
+        row = self._conn.execute(
+            "SELECT operation_kind, state FROM portrait_operations WHERE operation_id=?",
+            (operation_id,),
+        ).fetchone()
+        if row is None or clean_text(row["operation_kind"], 80) != "historical_portrait_backfill":
+            return True, ""
+        state = clean_text(row["state"], 40)
+        if state != "running":
+            return False, "operation_not_active"
+        return True, ""
+
+    def _portrait_backfill_scope_write_allowed_sync(
+        self, operation_id: str, person_id: str, source_scope: str
+    ) -> tuple[bool, str]:
+        """Apply the operation check plus the current learning capability."""
+        allowed, code = self._portrait_backfill_write_allowed_sync(operation_id)
+        if not allowed:
+            return False, code
+        operation_id = clean_text(operation_id, 120)
+        operation = self._conn.execute(
+            "SELECT operation_kind FROM portrait_operations WHERE operation_id=?",
+            (operation_id,),
+        ).fetchone() if operation_id else None
+        if operation is None or clean_text(operation["operation_kind"], 80) != "historical_portrait_backfill":
+            return True, ""
+        capability = self._portrait_scope_capability_sync(
+            clean_text(person_id, 80), clean_text(source_scope, 80)
+        )
+        if not bool(capability.get("portrait_learning_enabled")):
+            return False, "portrait_learning_disabled"
+        return True, ""
+
     async def add_portrait_evidence(self, evidence: dict[str, Any]) -> dict[str, Any]:
         return await asyncio.to_thread(self._add_portrait_evidence_sync, deepcopy(evidence))
 
@@ -1602,13 +1651,20 @@ class MemoryStore:
         if not re.fullmatch(r"[0-9a-f]{64}", statement_key):
             statement_key = evidence_key
         context_refs = evidence.get("context_refs") if isinstance(evidence.get("context_refs"), list) else []
+        operation_id = clean_text(evidence.get("operation_id"), 120)
         now = utc_now()
         with self._lock:
+            allowed, code = self._portrait_backfill_scope_write_allowed_sync(
+                operation_id, person_id, clean_text(evidence.get("scope"), 80)
+            )
+            if not allowed:
+                return {"ok": False, "code": code, "created": False}
             cur = self._conn.execute(
                 """
                 INSERT OR IGNORE INTO portrait_evidence(
-                    evidence_hash, person_id, origin_identity_key, scope, session_id, message_id, statement_fingerprint, context_refs, created_at
-                ) VALUES(?,?,?,?,?,?,?,?,?)
+                    evidence_hash, person_id, origin_identity_key, scope, session_id, message_id,
+                    statement_fingerprint, context_refs, operation_id, created_at
+                ) VALUES(?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     evidence_key,
@@ -1619,6 +1675,7 @@ class MemoryStore:
                     clean_text(evidence.get("message_id"), 120),
                     statement_key,
                     json_dumps([clean_text(item, 160) for item in context_refs if clean_text(item, 160)][:8]),
+                    operation_id,
                     now,
                 ),
             )
@@ -1691,6 +1748,7 @@ class MemoryStore:
             return value if isinstance(value, dict) else {}
         if (
             source_scope == "private"
+            or source_scope.startswith("private@")
             or source_scope.startswith("group:")
         ):
             person = self._conn.execute(
@@ -1729,6 +1787,7 @@ class MemoryStore:
             if re.fullmatch(r"[0-9a-f]{64}", clean_text(item, 80))
         ][:16]
         status = clean_text(fact.get("status"), 40) or "active"
+        operation_id = clean_text(fact.get("operation_id"), 120)
         cardinality = clean_text(fact.get("profile_cardinality"), 20).lower()
         single_value = (
             cardinality == "single"
@@ -1736,6 +1795,11 @@ class MemoryStore:
         )
         with self._lock:
             with self._transaction_sync():
+                allowed, code = self._portrait_backfill_scope_write_allowed_sync(
+                    operation_id, person_id, source_scope
+                )
+                if not allowed:
+                    return {"ok": False, "code": code, "created": False}
                 if self._portrait_suppressed_sync(person_id, dimension, claim_hash, source_scope):
                     return {"ok": False, "code": "portrait_suppressed", "created": False}
                 previous = self._conn.execute(
@@ -1745,6 +1809,28 @@ class MemoryStore:
                     """,
                     (person_id, dimension, claim_hash, tier, source_scope),
                 ).fetchone()
+                # Historical backfill is additive.  If an existing official
+                # active fact occupies the same single-value dimension, keep
+                # the migration candidate pending instead of superseding the
+                # official record (which would make rollback non-reversible).
+                if status == "active" and operation_id:
+                    operation = self._conn.execute(
+                        "SELECT operation_kind FROM portrait_operations WHERE operation_id=?",
+                        (operation_id,),
+                    ).fetchone()
+                    if operation is not None and clean_text(operation["operation_kind"], 80) == "historical_portrait_backfill":
+                        external_conflict = self._conn.execute(
+                            """
+                            SELECT 1 FROM portrait_facts
+                            WHERE person_id=? AND dimension=? AND source_scope=?
+                              AND status='active'
+                              AND operation_id!=?
+                            LIMIT 1
+                            """,
+                            (person_id, dimension, source_scope, operation_id),
+                        ).fetchone()
+                        if external_conflict is not None:
+                            status = "candidate"
                 previous_hashes = json_loads(previous["evidence_hashes"], []) if previous is not None else []
                 merged_hashes = list(dict.fromkeys([
                     clean_text(item, 80) for item in previous_hashes + evidence_hashes if clean_text(item, 80)
@@ -1801,7 +1887,7 @@ class MemoryStore:
                         sensitivity, status, json_dumps(merged_hashes),
                         json_dumps([clean_text(item, 160) for item in (fact.get("context_refs") or []) if clean_text(item, 160)][:8]),
                         first_at, now, clean_text(fact.get("expires_at"), 80), clean_text(fact.get("supersedes_id"), 120),
-                        revision, clean_text(fact.get("operation_id"), 120),
+                        revision, operation_id,
                         clean_text(previous["created_at"], 80) if previous is not None else now, now,
                     ),
                 )
@@ -1825,7 +1911,7 @@ class MemoryStore:
                                 operation_id=?, updated_at=?
                             WHERE id IN ({placeholders})
                             """,
-                            [fact_id, clean_text(fact.get("operation_id"), 120), now, *superseded_ids],
+                            [fact_id, operation_id, now, *superseded_ids],
                         )
                         self._conn.execute(
                             f"""
@@ -1841,6 +1927,7 @@ class MemoryStore:
             "code": "portrait_fact_upserted",
             "created": previous is None,
             "fact_id": fact_id,
+            "revision": revision,
             "portrait_revision": portrait_revision,
             "superseded": len(superseded_ids),
         }
@@ -1863,8 +1950,78 @@ class MemoryStore:
             for row in rows
         ]
 
-    async def enqueue_portrait_learning(self, *, person_id: str, fact_id: str, evidence_hash: str) -> dict[str, Any]:
-        return await asyncio.to_thread(self._enqueue_portrait_learning_sync, person_id, fact_id, evidence_hash)
+    async def enqueue_portrait_learning(
+        self, *, person_id: str, fact_id: str, evidence_hash: str, operation_id: str = ""
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._enqueue_portrait_learning_sync,
+            person_id,
+            fact_id,
+            evidence_hash,
+            clean_text(operation_id, 120),
+        )
+
+    async def append_portrait_fact_evidence(
+        self,
+        *,
+        person_id: str,
+        fact_id: str,
+        evidence_hash: str,
+        context_refs: list[str] | tuple[str, ...] = (),
+        operation_id: str = "",
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._append_portrait_fact_evidence_sync,
+            clean_text(person_id, 80), clean_text(fact_id, 120), clean_text(evidence_hash, 80),
+            [clean_text(item, 160) for item in context_refs if clean_text(item, 160)][:8],
+            clean_text(operation_id, 120),
+        )
+
+    def _append_portrait_fact_evidence_sync(
+        self, person_id: str, fact_id: str, evidence_hash: str, context_refs: list[str], operation_id: str = ""
+    ) -> dict[str, Any]:
+        if not person_id or not fact_id or not re.fullmatch(r"[0-9a-f]{64}", evidence_hash):
+            return {"ok": False, "code": "portrait_evidence_invalid", "created": False}
+        with self._lock:
+            allowed, code = self._portrait_backfill_write_allowed_sync(operation_id)
+            if not allowed:
+                return {"ok": False, "code": code, "created": False}
+            row = self._conn.execute(
+                "SELECT * FROM portrait_facts WHERE id=? AND person_id=?", (fact_id, person_id)
+            ).fetchone()
+            if row is None:
+                return {"ok": False, "code": "portrait_fact_not_found", "created": False}
+            if operation_id and clean_text(row["operation_id"], 120) != operation_id:
+                return {"ok": False, "code": "external_fact_protected", "created": False}
+            allowed, code = self._portrait_backfill_scope_write_allowed_sync(
+                operation_id, person_id, clean_text(row["source_scope"], 80)
+            )
+            if not allowed:
+                return {"ok": False, "code": code, "created": False}
+            if self._portrait_suppressed_sync(person_id, row["dimension"], row["normalized_claim_hash"], row["source_scope"]):
+                return {"ok": False, "code": "portrait_suppressed", "created": False}
+            hashes = json_loads(row["evidence_hashes"], [])
+            hashes = [clean_text(item, 80) for item in hashes if clean_text(item, 80)]
+            if evidence_hash in hashes:
+                return {"ok": True, "code": "portrait_evidence_idempotent_replay", "created": False, "fact_id": fact_id}
+            previous = {
+                "evidence_hashes": list(hashes),
+                "context_refs": list(json_loads(row["context_refs"], [])) if isinstance(json_loads(row["context_refs"], []), list) else [],
+                "last_evidence_at": clean_text(row["last_evidence_at"], 80),
+                "revision": int(row["revision"] or 1),
+                "updated_at": clean_text(row["updated_at"], 80),
+            }
+            hashes.append(evidence_hash)
+            refs = json_loads(row["context_refs"], [])
+            refs = list(dict.fromkeys([clean_text(item, 160) for item in refs if clean_text(item, 160)] + context_refs))[:8]
+            now = utc_now()
+            self._conn.execute(
+                "UPDATE portrait_facts SET evidence_hashes=?, context_refs=?, last_evidence_at=?, revision=revision+1, updated_at=? WHERE id=? AND person_id=?",
+                (json_dumps(hashes[:16]), json_dumps(refs), now, now, fact_id, person_id),
+            )
+            self._bump_portrait_revision_sync(person_id)
+            self._conn.commit()
+        return {"ok": True, "code": "portrait_evidence_appended", "created": True, "fact_id": fact_id, "previous": previous}
 
     async def list_pending_portrait_people(self, *, limit: int = 500) -> list[str]:
         return await asyncio.to_thread(self._list_pending_portrait_people_sync, limit)
@@ -1884,7 +2041,9 @@ class MemoryStore:
             ).fetchall()
         return [clean_text(row["person_id"], 80) for row in rows if clean_text(row["person_id"], 80)]
 
-    def _enqueue_portrait_learning_sync(self, person_id: str, fact_id: str, evidence_hash: str) -> dict[str, Any]:
+    def _enqueue_portrait_learning_sync(
+        self, person_id: str, fact_id: str, evidence_hash: str, operation_id: str = ""
+    ) -> dict[str, Any]:
         person_id = clean_text(person_id, 80)
         fact_id = clean_text(fact_id, 120)
         evidence_hash = clean_text(evidence_hash, 80)
@@ -1893,6 +2052,18 @@ class MemoryStore:
         queue_id = f"portrait_queue_{stable_fingerprint(person_id, fact_id, evidence_hash)[:24]}"
         now = utc_now()
         with self._lock:
+            fact_row = self._conn.execute(
+                "SELECT source_scope, operation_id FROM portrait_facts WHERE id=? AND person_id=?",
+                (fact_id, person_id),
+            ).fetchone()
+            source_scope = clean_text(fact_row["source_scope"], 80) if fact_row is not None else ""
+            allowed, code = self._portrait_backfill_scope_write_allowed_sync(
+                operation_id, person_id, source_scope
+            )
+            if not allowed:
+                return {"ok": False, "code": code, "created": False, "queue_id": queue_id}
+            if operation_id and fact_row is not None and clean_text(fact_row["operation_id"], 120) != operation_id:
+                return {"ok": False, "code": "external_fact_protected", "created": False, "queue_id": queue_id}
             cur = self._conn.execute(
                 """
                 INSERT OR IGNORE INTO portrait_learning_queue(queue_id, person_id, fact_id, evidence_hash, state, created_at, updated_at)
@@ -2082,6 +2253,7 @@ class MemoryStore:
         low_only: bool = True,
         usage_min_confidence: float = 0.75,
         inferred_freshness_days: int = 90,
+        include_provenance: bool = False,
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
             self._portrait_summary_sync,
@@ -2092,6 +2264,7 @@ class MemoryStore:
             low_only,
             usage_min_confidence,
             inferred_freshness_days,
+            include_provenance,
         )
 
     def _portrait_summary_sync(
@@ -2103,6 +2276,7 @@ class MemoryStore:
         low_only: bool,
         usage_min_confidence: float,
         inferred_freshness_days: int,
+        include_provenance: bool,
     ) -> dict[str, Any]:
         person_id = clean_text(person_id, 80)
         scope = clean_text(scope, 80)
@@ -2151,18 +2325,30 @@ class MemoryStore:
                     continue
                 if row["portrait_tier"] == "intelligent" and not self._portrait_timestamp_is_fresh(row["updated_at"], freshness_days):
                     continue
-                items.append(
-                    {
-                        "dimension": row["dimension"],
-                        "summary": row["claim_summary"],
-                        "portrait_tier": row["portrait_tier"],
-                        "epistemic_status": row["epistemic_status"],
-                        "confidence": confidence,
-                        "sensitivity": row["sensitivity"],
-                        "usable_scope": row["usable_scope"],
-                        "updated_at": row["updated_at"],
+                item = {
+                    "dimension": row["dimension"],
+                    "summary": row["claim_summary"],
+                    "portrait_tier": row["portrait_tier"],
+                    "epistemic_status": row["epistemic_status"],
+                    "confidence": confidence,
+                    "sensitivity": row["sensitivity"],
+                    "usable_scope": row["usable_scope"],
+                    "updated_at": row["updated_at"],
+                }
+                if include_provenance:
+                    evidence_hashes = json_loads(row["evidence_hashes"], [])
+                    item["provenance"] = {
+                        "fact_id": clean_text(row["id"], 120),
+                        "evidence_refs": [
+                            clean_text(value, 80)
+                            for value in evidence_hashes
+                            if re.fullmatch(r"[0-9a-f]{64}", clean_text(value, 80))
+                        ][:16],
+                        "source_scope": clean_text(row["source_scope"], 80),
+                        "first_evidence_at": clean_text(row["first_evidence_at"], 80),
+                        "last_evidence_at": clean_text(row["last_evidence_at"], 80),
                     }
-                )
+                items.append(item)
                 if len(items) >= max(1, min(32, int(limit))):
                     break
         return {
@@ -2377,6 +2563,718 @@ class MemoryStore:
     async def portrait_migration(self, *, operation_id: str, dry_run: bool = True) -> dict[str, Any]:
         return await asyncio.to_thread(self._portrait_migration_sync, operation_id, dry_run)
 
+    async def list_portrait_history_sources(
+        self,
+        *,
+        source_scopes: list[str] | tuple[str, ...],
+        from_time: str = "",
+        to_time: str = "",
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Read a bounded, metadata-filtered history page for portrait backfill.
+
+        The returned ``content`` is transient input for the rule extractor.  It
+        is intentionally not copied into portrait operations or audit payloads.
+        Identity and author exclusion are finalized by ``PortraitService``
+        because the authenticated identity representation is deployment-specific.
+        """
+        return await asyncio.to_thread(
+            self._list_portrait_history_sources_sync,
+            tuple(clean_text(item, 80) for item in (source_scopes or []) if clean_text(item, 80)),
+            clean_text(from_time, 80),
+            clean_text(to_time, 80),
+            max(0, int(offset or 0)),
+            max(1, min(500, int(limit or 100))),
+        )
+
+    def _list_portrait_history_sources_sync(
+        self,
+        source_scopes: tuple[str, ...],
+        from_time: str,
+        to_time: str,
+        offset: int,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        scopes = tuple(dict.fromkeys(scope for scope in source_scopes if scope))
+        if not scopes:
+            return []
+        scope_placeholders = ",".join("?" for _ in scopes)
+        time_where = ""
+        if from_time:
+            time_where += " AND occurred_at >= ?"
+        if to_time:
+            time_where += " AND occurred_at <= ?"
+        timeline_metadata_where = """
+          AND (
+                json_valid(metadata)=0
+                OR (
+                    COALESCE(json_extract(metadata, '$.lifecycle'), '') != 'archived'
+                    AND COALESCE(json_extract(metadata, '$.validity_status'), 'active') = 'active'
+                    AND COALESCE(json_extract(metadata, '$.review_status'), '') NOT IN ('pending', 'rejected')
+                    AND LOWER(CAST(COALESCE(json_extract(metadata, '$.visibility'), '') AS TEXT)) NOT IN ('internal', 'bot_self')
+                    AND LOWER(CAST(COALESCE(json_extract(metadata, '$.bot_generated'), '') AS TEXT)) NOT IN ('1', 'true', 'yes', 'on')
+                    AND LOWER(CAST(COALESCE(json_extract(metadata, '$.is_bot'), '') AS TEXT)) NOT IN ('1', 'true', 'yes', 'on')
+                    AND LOWER(CAST(COALESCE(json_extract(metadata, '$.author_role'), '') AS TEXT)) NOT IN ('bot', 'assistant', 'system')
+                    AND LOWER(CAST(COALESCE(json_extract(metadata, '$.sender_role'), '') AS TEXT)) NOT IN ('bot', 'assistant', 'system')
+                    AND LOWER(CAST(COALESCE(json_extract(metadata, '$.sender_kind'), '') AS TEXT)) NOT IN ('bot', 'assistant', 'system')
+                )
+              )
+        """
+        visible_memories = ("private_pair", "shareable", "group_public")
+        visibility_placeholders = ",".join("?" for _ in visible_memories)
+        memory_governance_where = f"""
+                  AND lifecycle != 'archived'
+                  AND validity_status = 'active'
+                  AND review_status NOT IN ('pending', 'rejected')
+                  AND visibility IN ({visibility_placeholders})
+        """
+        # Keep the query shape stable across SQLite versions.  The service
+        # applies the exact identity and quoted/forwarded exclusions below.
+        query = f"""
+            SELECT source_kind, source_id, event_type, scope, session_id,
+                   subject_id, object_id, subject_kind, subject_role,
+                   owner_bot_id, message_id, content, metadata,
+                   occurred_at, created_at
+            FROM (
+                SELECT 'timeline' AS source_kind, id AS source_id, event_type,
+                       scope, session_id, subject_id, object_id,
+                       '' AS subject_kind, '' AS subject_role, '' AS owner_bot_id,
+                       message_id, content, metadata, occurred_at, created_at
+                FROM timeline
+                WHERE scope IN ({scope_placeholders})
+                  {time_where}
+                  {timeline_metadata_where}
+                UNION ALL
+                SELECT 'memory' AS source_kind, id AS source_id, memory_type AS event_type,
+                       scope, session_id, subject_id, object_id,
+                       subject_kind, subject_role, owner_bot_id, message_id,
+                       content, metadata, occurred_at, created_at
+                FROM memories
+                WHERE scope IN ({scope_placeholders})
+                  {time_where}
+                  {memory_governance_where}
+            )
+            ORDER BY occurred_at ASC, created_at ASC, source_id ASC
+            LIMIT ? OFFSET ?
+        """
+        # The UNION has a separate scope/time parameter set for each branch.
+        branch_params = [*scopes]
+        if from_time:
+            branch_params.append(from_time)
+        if to_time:
+            branch_params.append(to_time)
+        branch_params.extend([*scopes])
+        if from_time:
+            branch_params.append(from_time)
+        if to_time:
+            branch_params.append(to_time)
+        branch_params.extend(visible_memories)
+        branch_params.extend([max(1, min(500, int(limit))), max(0, int(offset))])
+        with self._lock:
+            rows = self._conn.execute(query, branch_params).fetchall()
+        return [
+            {
+                "source_kind": clean_text(row["source_kind"], 16),
+                "source_id": clean_text(row["source_id"], 160),
+                "event_type": clean_text(row["event_type"], 80),
+                "scope": clean_text(row["scope"], 80),
+                "session_id": clean_text(row["session_id"], 200),
+                "subject_id": clean_text(row["subject_id"], 160),
+                "object_id": clean_text(row["object_id"], 160),
+                "subject_kind": clean_text(row["subject_kind"], 40),
+                "subject_role": clean_text(row["subject_role"], 40),
+                "owner_bot_id": clean_text(row["owner_bot_id"], 120),
+                "message_id": clean_text(row["message_id"], 160),
+                "content": clean_text(row["content"], 4000),
+                "metadata": json_loads(row["metadata"], {}) if isinstance(row["metadata"], str) else {},
+                "occurred_at": clean_text(row["occurred_at"], 80),
+                "created_at": clean_text(row["created_at"], 80),
+            }
+            for row in rows
+        ]
+
+    async def portrait_backfill_person(self, person_id: str, target_identity: str) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._portrait_backfill_person_sync,
+            clean_text(person_id, 80),
+            clean_text(target_identity, 160),
+        )
+
+    def _portrait_backfill_person_sync(self, person_id: str, target_identity: str) -> dict[str, Any]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM portrait_people WHERE person_id=?", (person_id,)
+            ).fetchone()
+        if row is None:
+            return {"ok": False, "code": "identity_mismatch", "person_id": person_id}
+        identity = clean_text(row["resolved_identity_key"], 160)
+        if not target_identity or identity != target_identity:
+            return {"ok": False, "code": "identity_mismatch", "person_id": person_id}
+        if clean_text(row["profile_status"], 40) != "active" or clean_text(row["identity_assurance"], 40) not in {
+            "observed", "verified", "explicit_linked"
+        }:
+            return {"ok": False, "code": "identity_mismatch", "person_id": person_id}
+        capabilities = json_loads(row["capability_summary"], {})
+        return {
+            "ok": True,
+            "code": "profile_exact",
+            "person_id": person_id,
+            "resolved_identity_key": identity,
+            "projection_revision": int(row["projection_revision"] or 0),
+            "identity_assurance": clean_text(row["identity_assurance"], 40),
+            "profile_status": clean_text(row["profile_status"], 40),
+            "capability_summary": capabilities if isinstance(capabilities, dict) else {},
+        }
+
+    async def portrait_backfill_scope_capability(self, person_id: str, source_scope: str) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._portrait_backfill_scope_capability_sync,
+            clean_text(person_id, 80),
+            clean_text(source_scope, 80),
+        )
+
+    def _portrait_backfill_scope_capability_sync(self, person_id: str, source_scope: str) -> dict[str, Any]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT capability_summary FROM portrait_scope_capabilities WHERE person_id=? AND source_scope=?",
+                (person_id, source_scope),
+            ).fetchone()
+            if row is not None:
+                value = json_loads(row["capability_summary"], {})
+                return {"configured": True, **(value if isinstance(value, dict) else {})}
+            # Private is the legacy/default capability namespace.  Group
+            # scopes are intentionally unconfigured until explicitly projected.
+            if source_scope == "private" or source_scope.startswith("private@"):
+                return {"configured": False, **self._portrait_scope_capability_sync(person_id, source_scope)}
+            return {"configured": False}
+
+    async def get_portrait_backfill_fact(
+        self,
+        *,
+        person_id: str,
+        dimension: str,
+        normalized_claim_hash: str,
+        source_scope: str,
+        portrait_tier: str = "base",
+    ) -> dict[str, Any] | None:
+        return await asyncio.to_thread(
+            self._get_portrait_backfill_fact_sync,
+            clean_text(person_id, 80),
+            clean_text(dimension, 80),
+            clean_text(normalized_claim_hash, 80),
+            clean_text(source_scope, 80),
+            clean_text(portrait_tier, 24) or "base",
+        )
+
+    def _get_portrait_backfill_fact_sync(
+        self, person_id: str, dimension: str, claim_hash: str, source_scope: str, tier: str
+    ) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM portrait_facts WHERE person_id=? AND dimension=? AND normalized_claim_hash=? AND source_scope=? AND portrait_tier=?",
+                (person_id, dimension, claim_hash, source_scope, tier),
+            ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["evidence_hashes"] = json_loads(result.get("evidence_hashes"), [])
+        return result
+
+    async def create_portrait_backfill_operation(
+        self, *, operation_id: str, payload_hash: str, snapshot: dict[str, Any]
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._create_portrait_backfill_operation_sync,
+            clean_text(operation_id, 120),
+            clean_text(payload_hash, 80),
+            deepcopy(snapshot),
+        )
+
+    def _create_portrait_backfill_operation_sync(
+        self, operation_id: str, payload_hash: str, snapshot: dict[str, Any]
+    ) -> dict[str, Any]:
+        if not operation_id or not payload_hash:
+            return {"ok": False, "code": "invalid_request"}
+        with self._lock:
+            previous = self._conn.execute(
+                "SELECT * FROM portrait_operations WHERE operation_id=?", (operation_id,)
+            ).fetchone()
+            if previous is not None:
+                if clean_text(previous["operation_kind"], 80) != "historical_portrait_backfill":
+                    return {"ok": False, "code": "operation_conflict", "operation_id": operation_id}
+                if clean_text(previous["payload_hash"], 80) != payload_hash:
+                    return {"ok": False, "code": "operation_conflict"}
+                return {
+                    "ok": True,
+                    "code": "backfill_resumed" if previous["state"] in {"running", "paused", "cancelled"} else "backfill_idempotent_replay",
+                    "operation_id": operation_id,
+                    "state": clean_text(previous["state"], 40),
+                    "snapshot": json_loads(previous["snapshot"], {}),
+                }
+            now = utc_now()
+            snapshot = redact_sensitive_value(snapshot)
+            self._conn.execute(
+                "INSERT INTO portrait_operations(operation_id, operation_kind, payload_hash, snapshot, state, created_at, updated_at) VALUES(?,?,?,?,?,?,?)",
+                (operation_id, "historical_portrait_backfill", payload_hash, json_dumps(snapshot), "running", now, now),
+            )
+            self._conn.commit()
+        return {"ok": True, "code": "backfill_started", "operation_id": operation_id, "state": "running", "snapshot": snapshot}
+
+    async def portrait_backfill_operation(self, operation_id: str) -> dict[str, Any] | None:
+        return await asyncio.to_thread(self._portrait_backfill_operation_sync, clean_text(operation_id, 120))
+
+    def _portrait_backfill_operation_sync(self, operation_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute("SELECT * FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
+        if row is None:
+            return None
+        snapshot = json_loads(row["snapshot"], {})
+        return {
+            "operation_id": clean_text(row["operation_id"], 120),
+            "operation_kind": clean_text(row["operation_kind"], 80),
+            "payload_hash": clean_text(row["payload_hash"], 80),
+            "state": clean_text(row["state"], 40),
+            "snapshot": snapshot if isinstance(snapshot, dict) else {},
+            "created_at": clean_text(row["created_at"], 80),
+            "updated_at": clean_text(row["updated_at"], 80),
+        }
+
+    async def update_portrait_backfill_operation(self, operation_id: str, snapshot: dict[str, Any], *, state: str | None = None) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._update_portrait_backfill_operation_sync,
+            clean_text(operation_id, 120),
+            deepcopy(snapshot),
+            clean_text(state, 40) if state is not None else None,
+        )
+
+    def _update_portrait_backfill_operation_sync(self, operation_id: str, snapshot: dict[str, Any], state: str | None) -> dict[str, Any]:
+        if not operation_id:
+            return {"ok": False, "code": "invalid_request"}
+        with self._lock:
+            row = self._conn.execute("SELECT operation_kind,state FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
+            if row is None:
+                return {"ok": False, "code": "operation_not_found"}
+            if clean_text(row["operation_kind"], 80) != "historical_portrait_backfill":
+                return {"ok": False, "code": "operation_conflict", "operation_id": operation_id}
+            current_state = clean_text(row["state"], 40)
+            next_state = state if state in {"running", "paused", "cancelled", "complete", "rolled_back", "failed"} else current_state
+            # A cancellation/terminal transition wins over a stale worker
+            # checkpoint.  This prevents an in-flight page from resurrecting
+            # an operation after an administrator has stopped or rolled it back.
+            if current_state in {"cancelled", "complete", "rolled_back"} and next_state != current_state:
+                current_snapshot = json_loads(
+                    self._conn.execute(
+                        "SELECT snapshot FROM portrait_operations WHERE operation_id=?",
+                        (operation_id,),
+                    ).fetchone()["snapshot"],
+                    {},
+                )
+                return {
+                    "ok": True,
+                    "code": "backfill_terminal_checkpoint_ignored",
+                    "operation_id": operation_id,
+                    "state": current_state,
+                    "snapshot": current_snapshot if isinstance(current_snapshot, dict) else {},
+                }
+            self._conn.execute(
+                "UPDATE portrait_operations SET snapshot=?, state=?, updated_at=? WHERE operation_id=?",
+                (json_dumps(redact_sensitive_value(snapshot)), next_state, utc_now(), operation_id),
+            )
+            self._conn.commit()
+        return {"ok": True, "code": "backfill_status_updated", "operation_id": operation_id, "state": next_state, "snapshot": snapshot}
+
+    async def cancel_portrait_backfill_operation(self, operation_id: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self._cancel_portrait_backfill_operation_sync, clean_text(operation_id, 120))
+
+    def _cancel_portrait_backfill_operation_sync(self, operation_id: str) -> dict[str, Any]:
+        with self._lock:
+            row = self._conn.execute("SELECT operation_kind,state,snapshot FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
+            if row is None:
+                return {"ok": False, "code": "operation_not_found"}
+            if clean_text(row["operation_kind"], 80) != "historical_portrait_backfill":
+                return {"ok": False, "code": "operation_conflict", "operation_id": operation_id}
+            state = clean_text(row["state"], 40)
+            if state == "rolled_back":
+                return {"ok": False, "code": "operation_already_rolled_back"}
+            if state == "complete":
+                return {"ok": False, "code": "operation_complete"}
+            self._conn.execute("UPDATE portrait_operations SET state='cancelled', updated_at=? WHERE operation_id=?", (utc_now(), operation_id))
+            self._conn.commit()
+        return {"ok": True, "code": "backfill_cancelled", "operation_id": operation_id, "state": "cancelled"}
+
+    async def rollback_portrait_backfill_operation(self, operation_id: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self._rollback_portrait_backfill_operation_sync, clean_text(operation_id, 120))
+
+    def _rollback_portrait_backfill_operation_sync(self, operation_id: str) -> dict[str, Any]:
+        with self._lock:
+            row = self._conn.execute("SELECT operation_kind,state,snapshot FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
+            if row is None:
+                return {"ok": False, "code": "operation_not_found"}
+            if clean_text(row["operation_kind"], 80) != "historical_portrait_backfill":
+                return {"ok": False, "code": "operation_conflict", "operation_id": operation_id}
+            current_state = clean_text(row["state"], 40)
+            if current_state == "rolled_back":
+                snapshot = json_loads(row["snapshot"], {})
+                rollback = snapshot.get("rollback") if isinstance(snapshot, dict) else None
+                return {
+                    "ok": True,
+                    "code": "backfill_already_rolled_back",
+                    "operation_id": operation_id,
+                    "deleted": rollback if isinstance(rollback, dict) else {},
+                }
+            if current_state in {"running", "paused"}:
+                return {"ok": False, "code": "operation_active", "operation_id": operation_id, "state": current_state}
+            snapshot = json_loads(row["snapshot"], {})
+            if not isinstance(snapshot, dict):
+                snapshot = {}
+            fact_ids = [clean_text(item, 120) for item in snapshot.get("created_fact_ids", []) if clean_text(item, 120)]
+            created_fact_snapshots = snapshot.get("created_fact_snapshots")
+            if not isinstance(created_fact_snapshots, dict):
+                created_fact_snapshots = {}
+            # The checkpoint is advisory.  A worker may have committed a fact
+            # immediately before a process crash, before its ID reached the
+            # operation snapshot.  Ownership in the fact row is authoritative
+            # for rollback recovery.
+            owned_fact_rows = self._conn.execute(
+                "SELECT id FROM portrait_facts WHERE person_id=? AND operation_id=?",
+                (clean_text(snapshot.get("target_person_id"), 80), operation_id),
+            ).fetchall()
+            fact_ids.extend(
+                clean_text(item["id"], 120)
+                for item in owned_fact_rows
+                if clean_text(item["id"], 120)
+            )
+            fact_ids = list(dict.fromkeys(fact_ids))
+            evidence_hashes = [clean_text(item, 80) for item in snapshot.get("created_evidence_hashes", []) if clean_text(item, 80)]
+            queue_ids = [clean_text(item, 120) for item in snapshot.get("created_queue_ids", []) if clean_text(item, 120)]
+            if fact_ids:
+                placeholders = ",".join("?" for _ in fact_ids)
+                owned_queue_rows = self._conn.execute(
+                    f"SELECT queue_id FROM portrait_learning_queue WHERE person_id=? AND fact_id IN ({placeholders})",
+                    [clean_text(snapshot.get("target_person_id"), 80), *fact_ids],
+                ).fetchall()
+                queue_ids.extend(
+                    clean_text(item["queue_id"], 120)
+                    for item in owned_queue_rows
+                    if clean_text(item["queue_id"], 120)
+                )
+                queue_ids = list(dict.fromkeys(queue_ids))
+            owned_evidence_rows = self._conn.execute(
+                "SELECT evidence_hash FROM portrait_evidence WHERE person_id=? AND operation_id=?",
+                (clean_text(snapshot.get("target_person_id"), 80), operation_id),
+            ).fetchall()
+            evidence_hashes.extend(
+                clean_text(item["evidence_hash"], 80)
+                for item in owned_evidence_rows
+                if clean_text(item["evidence_hash"], 80)
+            )
+            evidence_hashes = list(dict.fromkeys(evidence_hashes))
+            deleted = {"facts": 0, "evidence": 0, "queue": 0, "facts_restored": 0, "rollback_stale": 0}
+            if queue_ids:
+                placeholders = ",".join("?" for _ in queue_ids)
+                cur = self._conn.execute(f"DELETE FROM portrait_learning_queue WHERE queue_id IN ({placeholders}) AND person_id=?", [*queue_ids, clean_text(snapshot.get("target_person_id"), 80)])
+                deleted["queue"] = int(cur.rowcount or 0)
+            if fact_ids:
+                for fact_id in fact_ids:
+                    expected = created_fact_snapshots.get(fact_id)
+                    if isinstance(expected, dict):
+                        current = self._conn.execute(
+                            "SELECT operation_id, revision, evidence_hashes FROM portrait_facts WHERE id=? AND person_id=?",
+                            (fact_id, clean_text(snapshot.get("target_person_id"), 80)),
+                        ).fetchone()
+                        current_hashes = json_loads(current["evidence_hashes"], []) if current is not None else []
+                        expected_hashes = [
+                            clean_text(item, 80)
+                            for item in expected.get("evidence_hashes", [])
+                            if clean_text(item, 80)
+                        ]
+                        if (
+                            current is not None
+                            and clean_text(current["operation_id"], 120) == operation_id
+                            and int(current["revision"] or 0) == int(expected.get("revision") or 1)
+                            and current_hashes == expected_hashes
+                        ):
+                            self._conn.execute(
+                                "DELETE FROM portrait_facts WHERE id=? AND person_id=? AND operation_id=?",
+                                (fact_id, clean_text(snapshot.get("target_person_id"), 80), operation_id),
+                            )
+                            deleted["facts"] += 1
+                        else:
+                            deleted["rollback_stale"] += 1
+                    else:
+                        cur = self._conn.execute(
+                            "DELETE FROM portrait_facts WHERE id=? AND person_id=? AND operation_id=?",
+                            (fact_id, clean_text(snapshot.get("target_person_id"), 80), operation_id),
+                        )
+                        deleted["facts"] += int(cur.rowcount or 0)
+            touched = snapshot.get("touched_fact_snapshots")
+            if isinstance(touched, dict):
+                for fact_id, previous in touched.items():
+                    fact_key = clean_text(fact_id, 120)
+                    if not fact_key or not isinstance(previous, dict):
+                        continue
+                    before_hashes = [clean_text(item, 80) for item in previous.get("evidence_hashes", []) if clean_text(item, 80)]
+                    added_hashes = [clean_text(item, 80) for item in previous.get("added_evidence_hashes", []) if clean_text(item, 80)]
+                    current = self._conn.execute(
+                        "SELECT evidence_hashes, revision FROM portrait_facts WHERE id=? AND person_id=?",
+                        (fact_key, clean_text(snapshot.get("target_person_id"), 80)),
+                    ).fetchone()
+                    current_hashes = json_loads(current["evidence_hashes"], []) if current is not None else []
+                    expected_hashes = before_hashes + added_hashes
+                    if (
+                        current is not None
+                        and int(current["revision"] or 0) == int(previous.get("revision") or 0) + len(added_hashes)
+                        and current_hashes == expected_hashes
+                    ):
+                        self._conn.execute(
+                            """
+                            UPDATE portrait_facts
+                            SET evidence_hashes=?, context_refs=?, last_evidence_at=?,
+                                revision=?, updated_at=?
+                            WHERE id=? AND person_id=?
+                            """,
+                            (
+                                json_dumps(before_hashes),
+                                json_dumps(previous.get("context_refs", [])),
+                                clean_text(previous.get("last_evidence_at"), 80),
+                                int(previous.get("revision") or 1),
+                                clean_text(previous.get("updated_at"), 80),
+                                fact_key,
+                                clean_text(snapshot.get("target_person_id"), 80),
+                            ),
+                        )
+                        deleted["facts_restored"] += 1
+                    else:
+                        deleted["rollback_stale"] += 1
+            if evidence_hashes:
+                placeholders = ",".join("?" for _ in evidence_hashes)
+                # Evidence can be reused by a later operation.  Remove only
+                # orphaned rows so rollback never deletes another operation's
+                # provenance.
+                cur = self._conn.execute(
+                    f"""
+                    DELETE FROM portrait_evidence
+                    WHERE evidence_hash IN ({placeholders}) AND person_id=?
+                      AND NOT EXISTS (
+                          SELECT 1 FROM portrait_facts f
+                          WHERE f.person_id=portrait_evidence.person_id
+                            AND EXISTS (
+                                SELECT 1 FROM json_each(f.evidence_hashes)
+                                WHERE json_each.value=portrait_evidence.evidence_hash
+                            )
+                      )
+                    """,
+                    [*evidence_hashes, clean_text(snapshot.get("target_person_id"), 80)],
+                )
+                deleted["evidence"] = int(cur.rowcount or 0)
+            if any(deleted.values()):
+                self._bump_portrait_revision_sync(clean_text(snapshot.get("target_person_id"), 80))
+            snapshot["rollback"] = deleted
+            self._conn.execute(
+                "UPDATE portrait_operations SET snapshot=?, state='rolled_back', updated_at=? WHERE operation_id=?",
+                (json_dumps(redact_sensitive_value(snapshot)), utc_now(), operation_id),
+            )
+            self._conn.commit()
+        return {"ok": True, "code": "backfill_rolled_back", "operation_id": operation_id, "deleted": deleted}
+
+    async def run_portrait_backfill_aggregation(
+        self, *, operation_id: str, person_id: str, min_independent_evidence: int = 3,
+        fact_ids: list[str] | tuple[str, ...] = (), queue_ids: list[str] | tuple[str, ...] = ()
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._run_portrait_backfill_aggregation_sync,
+            clean_text(operation_id, 120), clean_text(person_id, 80), max(1, min(16, int(min_independent_evidence or 3))),
+            tuple(clean_text(item, 120) for item in (fact_ids or ()) if clean_text(item, 120)),
+            tuple(clean_text(item, 120) for item in (queue_ids or ()) if clean_text(item, 120)),
+        )
+
+    def _run_portrait_backfill_aggregation_sync(
+        self, operation_id: str, person_id: str, min_independent_evidence: int,
+        fact_ids: tuple[str, ...], queue_ids: tuple[str, ...]
+    ) -> dict[str, Any]:
+        created_ids: list[str] = []
+        created_snapshots: dict[str, dict[str, Any]] = {}
+        insufficient = 0
+        suppressed = 0
+        if not operation_id or not person_id:
+            return {"ok": False, "code": "invalid_request", "created": 0, "insufficient": 0, "created_fact_ids": []}
+        with self._lock:
+            allowed, code = self._portrait_backfill_write_allowed_sync(operation_id)
+            if not allowed:
+                return {"ok": False, "code": code, "created": 0, "insufficient": 0, "created_fact_ids": []}
+            if fact_ids:
+                placeholders = ",".join("?" for _ in fact_ids)
+                rows = self._conn.execute(
+                    f"SELECT * FROM portrait_facts WHERE person_id=? AND id IN ({placeholders}) AND portrait_tier='base' AND status IN ('active', 'candidate') ORDER BY created_at ASC",
+                    [person_id, *fact_ids],
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                "SELECT * FROM portrait_facts WHERE person_id=? AND operation_id=? AND portrait_tier='base' AND status IN ('active', 'candidate') ORDER BY created_at ASC",
+                    (person_id, operation_id),
+                ).fetchall()
+            for row in rows:
+                source_scope = clean_text(row["source_scope"], 80)
+                capabilities = self._portrait_scope_capability_sync(person_id, source_scope)
+                if not bool(capabilities.get("portrait_learning_enabled")):
+                    continue
+                evidence_hashes = json_loads(row["evidence_hashes"], [])
+                if self._portrait_distinct_statement_count_sync(evidence_hashes) < min_independent_evidence:
+                    insufficient += 1
+                    continue
+                if self._portrait_suppressed_sync(person_id, row["dimension"], row["normalized_claim_hash"], source_scope):
+                    suppressed += 1
+                    if queue_ids:
+                        placeholders = ",".join("?" for _ in queue_ids)
+                        self._conn.execute(
+                            f"UPDATE portrait_learning_queue SET state='suppressed', updated_at=? WHERE fact_id=? AND queue_id IN ({placeholders}) AND state='pending'",
+                            [utc_now(), row["id"], *queue_ids],
+                    )
+                    continue
+                external_conflict = self._conn.execute(
+                    """
+                    SELECT 1 FROM portrait_facts
+                    WHERE person_id=? AND dimension=? AND source_scope=?
+                      AND status='active'
+                      AND operation_id!=?
+                    LIMIT 1
+                    """,
+                    (person_id, row["dimension"], source_scope, operation_id),
+                ).fetchone()
+                if external_conflict is not None:
+                    # Keep the candidate pending for normal governance rather
+                    # than allowing a historical run to replace an official
+                    # fact in a single-value dimension.
+                    insufficient += 1
+                    continue
+                existing = self._conn.execute(
+                    "SELECT id FROM portrait_facts WHERE person_id=? AND dimension=? AND normalized_claim_hash=? AND portrait_tier='intelligent' AND source_scope=?",
+                    (person_id, row["dimension"], row["normalized_claim_hash"], source_scope),
+                ).fetchone()
+                if existing is not None:
+                    # Existing official/inferred facts are authoritative; do not
+                    # rewrite them merely because a migration saw the same claim.
+                    continue
+                inferred = {
+                    "person_id": person_id,
+                    "dimension": row["dimension"],
+                    "normalized_claim_hash": row["normalized_claim_hash"],
+                    "claim_summary": clean_text(f"可能{row['claim_summary']}", 180),
+                    "portrait_tier": "intelligent",
+                    "producer_kind": "historical_backfill",
+                    "producer_version": "req036.backfill.v1",
+                    "derivation_kind": "independent_evidence_aggregate",
+                    "epistemic_status": "inferred",
+                    "source_scope": source_scope,
+                    "usable_scope": row["usable_scope"],
+                    "confidence": min(0.95, max(0.75, float(row["confidence"] or 0.0))),
+                    "sensitivity": row["sensitivity"],
+                    "evidence_hashes": evidence_hashes,
+                    "context_refs": json_loads(row["context_refs"], []),
+                    "operation_id": operation_id,
+                }
+                result = self._upsert_portrait_fact_sync(inferred)
+                if result.get("ok") and result.get("created"):
+                    created_id = clean_text(result.get("fact_id"), 120)
+                    created_ids.append(created_id)
+                    created_snapshots[created_id] = {
+                        "revision": int(result.get("revision") or 1),
+                        "evidence_hashes": list(evidence_hashes),
+                        "operation_id": operation_id,
+                    }
+                    if queue_ids:
+                        placeholders = ",".join("?" for _ in queue_ids)
+                        self._conn.execute(
+                            f"UPDATE portrait_learning_queue SET state='processed', updated_at=? WHERE fact_id=? AND queue_id IN ({placeholders}) AND state='pending'",
+                            [utc_now(), row["id"], *queue_ids],
+                        )
+            self._conn.commit()
+        return {
+            "ok": True, "code": "backfill_aggregated", "created": len(created_ids),
+            "created_fact_ids": created_ids, "created_fact_snapshots": created_snapshots,
+            "insufficient": insufficient, "suppressed": suppressed,
+        }
+
+    async def render_portrait_facts(
+        self,
+        *,
+        person_id: str,
+        source_scopes: list[str] | tuple[str, ...],
+        limit: int = 32,
+        usage_min_confidence: float = 0.75,
+        inferred_freshness_days: int = 90,
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._render_portrait_facts_sync,
+            clean_text(person_id, 80), tuple(clean_text(item, 80) for item in (source_scopes or []) if clean_text(item, 80)),
+            max(1, min(64, int(limit or 32))),
+            max(0.0, min(1.0, float(usage_min_confidence or 0.75))),
+            max(1, min(3650, int(inferred_freshness_days or 90))),
+        )
+
+    def _render_portrait_facts_sync(
+        self,
+        person_id: str,
+        source_scopes: tuple[str, ...],
+        limit: int,
+        usage_min_confidence: float,
+        inferred_freshness_days: int,
+    ) -> dict[str, Any]:
+        with self._lock:
+            person = self._conn.execute("SELECT * FROM portrait_people WHERE person_id=?", (person_id,)).fetchone()
+            if person is None:
+                return {"ok": False, "code": "bridge_unavailable", "items": [], "portrait_revision": 0}
+            if clean_text(person["profile_status"], 40) != "active":
+                return {"ok": False, "code": "bridge_person_mismatch", "items": [], "portrait_revision": int(person["portrait_revision"] or 0)}
+            rows = self._conn.execute(
+                "SELECT * FROM portrait_facts WHERE person_id=? AND status='active' AND sensitivity='low' ORDER BY confidence DESC, updated_at DESC LIMIT ?",
+                (person_id, max(64, limit * 8)),
+            ).fetchall()
+            items: list[dict[str, Any]] = []
+            allowed = tuple(source_scopes)
+            for row in rows:
+                source_scope = clean_text(row["source_scope"], 80)
+                if allowed and not any(self._portrait_scope_allows_row(row, requested) for requested in allowed):
+                    continue
+                if self._portrait_suppressed_sync(person_id, row["dimension"], row["normalized_claim_hash"], source_scope):
+                    continue
+                confidence = float(row["confidence"] or 0.0)
+                if confidence < usage_min_confidence:
+                    continue
+                if row["portrait_tier"] == "intelligent" and not self._portrait_timestamp_is_fresh(row["updated_at"], inferred_freshness_days):
+                    continue
+                evidence_hashes = json_loads(row["evidence_hashes"], [])
+                evidence_refs = [clean_text(item, 80) for item in evidence_hashes if clean_text(item, 80)][:16]
+                items.append({
+                    "fact_id": clean_text(row["id"], 120),
+                    "dimension": clean_text(row["dimension"], 80),
+                    "summary": clean_text(row["claim_summary"], 180),
+                    "confidence": confidence,
+                    "sensitivity": clean_text(row["sensitivity"], 24),
+                    "portrait_tier": clean_text(row["portrait_tier"], 24),
+                    "epistemic_status": clean_text(row["epistemic_status"], 40),
+                    "source_scope": source_scope,
+                    "evidence_refs": evidence_refs,
+                    "updated_at": clean_text(row["updated_at"], 80),
+                    "provenance": {
+                        "fact_id": clean_text(row["id"], 120),
+                        "evidence_refs": evidence_refs,
+                        "source_scope": source_scope,
+                        "first_evidence_at": clean_text(row["first_evidence_at"], 80),
+                        "last_evidence_at": clean_text(row["last_evidence_at"], 80),
+                    },
+                })
+                if len(items) >= limit:
+                    break
+        return {
+            "ok": True,
+            "code": "profile_exact",
+            "items": items,
+            "portrait_revision": int(person["portrait_revision"] or 0),
+            "last_synced_at": clean_text(person["last_synced_at"], 80),
+        }
+
     def _portrait_migration_sync(self, operation_id: str, dry_run: bool) -> dict[str, Any]:
         operation_id = clean_text(operation_id, 120)
         if not operation_id:
@@ -2389,6 +3287,8 @@ class MemoryStore:
                 return {"ok": True, "code": "migration_dry_run", "write_count": 0, "legacy_candidate_count": count}
             prior = self._conn.execute("SELECT * FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
             if prior is not None:
+                if clean_text(prior["operation_kind"], 80) != "legacy_portrait_projection":
+                    return {"ok": False, "code": "operation_conflict", "operation_id": operation_id}
                 return {"ok": True, "code": "migration_idempotent_replay", "operation_id": operation_id}
             now = utc_now()
             self._conn.execute(
@@ -2404,9 +3304,11 @@ class MemoryStore:
     def _rollback_portrait_migration_sync(self, operation_id: str) -> dict[str, Any]:
         operation_id = clean_text(operation_id, 120)
         with self._lock:
-            row = self._conn.execute("SELECT snapshot FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
+            row = self._conn.execute("SELECT operation_kind, snapshot FROM portrait_operations WHERE operation_id=?", (operation_id,)).fetchone()
             if row is None:
                 return {"ok": False, "code": "migration_not_found"}
+            if clean_text(row["operation_kind"], 80) != "legacy_portrait_projection":
+                return {"ok": False, "code": "operation_conflict", "operation_id": operation_id}
             snapshot = json_loads(row["snapshot"], {})
             fact_ids = snapshot.get("fact_ids") if isinstance(snapshot, dict) and isinstance(snapshot.get("fact_ids"), list) else []
             if fact_ids:

--- a/page_api.py
+++ b/page_api.py
@@ -134,6 +134,12 @@ UI_ENDPOINT_EXPOSURE = {
     "/profiles": {"exposure": "compat", "reason": "旧 Bot profile 查询兼容入口"},
     "/user-memory-summary": {"exposure": "compat", "reason": "旧用户摘要工作区兼容入口"},
     "/portrait/migration": {"exposure": "internal", "reason": "画像迁移控制，不向普通面板暴露"},
+    "/portrait/backfill/preview": {"exposure": "internal", "reason": "单人历史画像回填只读预览"},
+    "/portrait/backfill/start": {"exposure": "internal", "reason": "单人历史画像回填启动"},
+    "/portrait/backfill/status": {"exposure": "internal", "reason": "单人历史画像回填状态"},
+    "/portrait/backfill/cancel": {"exposure": "internal", "reason": "单人历史画像回填取消"},
+    "/portrait/backfill/rollback": {"exposure": "internal", "reason": "单人历史画像回填回滚"},
+    "/portrait/backfill/render": {"exposure": "internal", "reason": "单人画像只读渲染"},
     "/capabilities/bot-personal": {"exposure": "internal", "reason": "跨插件能力探测"},
     "/companion/personal-photo": {"exposure": "internal", "reason": "图片代理兼容入口"},
     "/companion/personal-photo-data": {"exposure": "visible", "reason": "个人相册按需加载的数据端点"},
@@ -143,6 +149,9 @@ UI_DANGEROUS_ENDPOINTS = frozenset(
     {
         "/memory/delete",
         "/portrait/govern",
+        "/portrait/backfill/start",
+        "/portrait/backfill/cancel",
+        "/portrait/backfill/rollback",
         "/maintenance/audit/apply",
         "/maintenance/audit/rollback",
         "/data/import/run",
@@ -216,6 +225,12 @@ class PluginPageApi:
             ("/portrait/profile", self.portrait_profile, ["GET"], "MemoryCompanion unified portrait governance detail"),
             ("/portrait/govern", self.portrait_govern, ["POST"], "MemoryCompanion unified portrait governance"),
             ("/portrait/migration", self.portrait_migration, ["POST"], "MemoryCompanion portrait migration control"),
+            ("/portrait/backfill/preview", self.portrait_backfill_preview, ["POST"], "MemoryCompanion portrait history backfill preview"),
+            ("/portrait/backfill/start", self.portrait_backfill_start, ["POST"], "MemoryCompanion portrait history backfill start"),
+            ("/portrait/backfill/status", self.portrait_backfill_status, ["GET"], "MemoryCompanion portrait history backfill status"),
+            ("/portrait/backfill/cancel", self.portrait_backfill_cancel, ["POST"], "MemoryCompanion portrait history backfill cancel"),
+            ("/portrait/backfill/rollback", self.portrait_backfill_rollback, ["POST"], "MemoryCompanion portrait history backfill rollback"),
+            ("/portrait/backfill/render", self.portrait_backfill_render, ["POST"], "MemoryCompanion portrait history backfill render"),
             ("/capabilities/bot-personal", self.bot_personal_capabilities, ["GET"], "MemoryCompanion Bot Personal capability"),
             ("/companion/personal-memory", self.companion_personal_memory, ["GET"], "MemoryCompanion Page companion personal memory"),
             ("/companion/personal-photo", self.companion_personal_photo, ["GET"], "MemoryCompanion Page companion personal photo"),
@@ -406,6 +421,135 @@ class PluginPageApi:
         except Exception:
             logger.exception("统一画像迁移操作失败")
             return self._err("统一画像迁移操作失败", 500)
+        return self._ok({"result": result})
+
+    async def _portrait_backfill_service(self):
+        return getattr(getattr(self.plugin, "service", None), "portraits", None)
+
+    def _portrait_backfill_admin_required(self):
+        """Keep historical portrait operations behind the bound Dashboard admin.
+
+        The request body is never treated as an authority claim.  This mirrors
+        the existing diagnostic admin gate, which validates the framework-
+        injected Dashboard username against AstrBot's configured account.
+        """
+        if not self._is_bound_dashboard_admin():
+            return self._err("admin_required", 403)
+        return None
+
+    @staticmethod
+    def _portrait_backfill_actor() -> str:
+        try:
+            return clean_text(getattr(astrbot_web_request, "username", ""), 120) or "dashboard_admin"
+        except Exception:
+            return "dashboard_admin"
+
+    async def portrait_backfill_preview(self):
+        denied = self._portrait_backfill_admin_required()
+        if denied is not None:
+            return denied
+        payload = await self._json()
+        portraits = await self._portrait_backfill_service()
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        try:
+            result = await portraits.preview_history_backfill(payload)
+        except Exception:
+            logger.exception("历史画像回填预览失败")
+            return self._err("历史画像回填预览失败", 500)
+        return self._ok({"result": result})
+
+    async def portrait_backfill_start(self):
+        denied = self._portrait_backfill_admin_required()
+        if denied is not None:
+            return denied
+        payload = await self._json()
+        portraits = await self._portrait_backfill_service()
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        try:
+            result = await portraits.start_history_backfill(
+                payload,
+                actor=self._portrait_backfill_actor(),
+            )
+        except Exception:
+            logger.exception("历史画像回填启动失败")
+            return self._err("历史画像回填启动失败", 500)
+        return self._ok({"result": result})
+
+    async def portrait_backfill_status(self):
+        denied = self._portrait_backfill_admin_required()
+        if denied is not None:
+            return denied
+        operation_id = clean_text(request.args.get("operation_id", ""), 120)
+        if not operation_id:
+            return self._err("缺少 operation_id", 400)
+        portraits = await self._portrait_backfill_service()
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        try:
+            result = await portraits.status_history_backfill(operation_id)
+        except Exception:
+            logger.exception("历史画像回填状态读取失败")
+            return self._err("历史画像回填状态读取失败", 500)
+        return self._ok({"result": result})
+
+    async def portrait_backfill_cancel(self):
+        denied = self._portrait_backfill_admin_required()
+        if denied is not None:
+            return denied
+        payload = await self._json()
+        operation_id = clean_text(payload.get("operation_id"), 120)
+        if not operation_id:
+            return self._err("缺少 operation_id", 400)
+        portraits = await self._portrait_backfill_service()
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        try:
+            result = await portraits.cancel_history_backfill(operation_id)
+        except Exception:
+            logger.exception("历史画像回填取消失败")
+            return self._err("历史画像回填取消失败", 500)
+        return self._ok({"result": result})
+
+    async def portrait_backfill_rollback(self):
+        denied = self._portrait_backfill_admin_required()
+        if denied is not None:
+            return denied
+        payload = await self._json()
+        operation_id = clean_text(payload.get("operation_id"), 120)
+        if not operation_id:
+            return self._err("缺少 operation_id", 400)
+        portraits = await self._portrait_backfill_service()
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        try:
+            confirmation = clean_text(
+                payload.get("confirmation_token") or payload.get("confirm"),
+                40,
+            )
+            result = await portraits.rollback_history_backfill(
+                operation_id,
+                confirm=confirmation == "确认回滚",
+            )
+        except Exception:
+            logger.exception("历史画像回填回滚失败")
+            return self._err("历史画像回填回滚失败", 500)
+        return self._ok({"result": result})
+
+    async def portrait_backfill_render(self):
+        denied = self._portrait_backfill_admin_required()
+        if denied is not None:
+            return denied
+        payload = await self._json()
+        portraits = await self._portrait_backfill_service()
+        if portraits is None:
+            return self._err("统一画像服务不可用", 503)
+        try:
+            result = await portraits.render_history_portrait(payload)
+        except Exception:
+            logger.exception("历史画像渲染失败")
+            return self._err("历史画像渲染失败", 500)
         return self._ok({"result": result})
 
     async def bot_personal_capabilities(self):

--- a/tests/test_portrait_history_backfill.py
+++ b/tests/test_portrait_history_backfill.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "req036_history_backfill"
+if PACKAGE not in sys.modules:
+    module = types.ModuleType(PACKAGE)
+    module.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE] = module
+
+from req036_history_backfill.core.models import EntityRef, MemoryRecord, json_loads
+from req036_history_backfill.core.portrait import normalized_claim_hash
+from req036_history_backfill.core.portrait_service import PortraitBackfillRequest, PortraitService
+from req036_history_backfill.core.store import MemoryStore
+from req036_history_backfill.unified_profile_contract import build_capability_summary
+
+
+PERSON_ID = "person_" + "1" * 24
+IDENTITY = "chat-origin-v1:" + "2" * 64
+OTHER_IDENTITY = "chat-origin-v1:" + "3" * 64
+PERSON_REF = {
+    "person_id": PERSON_ID,
+    "resolved_identity_key": IDENTITY,
+    "projection_revision": 1,
+    "identity_assurance": "observed",
+    "profile_status": "active",
+}
+
+
+class Config:
+    @staticmethod
+    def int(key: str, default: int) -> int:
+        return {
+            "portrait.min_independent_evidence": 3,
+            "portrait.backfill_max_records": 5000,
+            "portrait.backfill_page_size": 2,
+        }.get(key, default)
+
+    @staticmethod
+    def float(key: str, default: float) -> float:
+        return default
+
+
+class PortraitHistoryBackfillTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        store = MemoryStore(Path(temp.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def project_person(self, store: MemoryStore, *, group: bool = False) -> None:
+        capabilities = build_capability_summary(
+            {
+                "private_companion_enabled": True,
+                "portrait_mode": "learn_and_use",
+                "grant_source": "test",
+            }
+        )
+        await store.upsert_portrait_person_projection(
+            PERSON_REF,
+            capabilities,
+            source_scope="private",
+        )
+        if group:
+            await store.upsert_portrait_person_projection(
+                PERSON_REF,
+                capabilities,
+                source_scope="group:onebot:g-1",
+            )
+
+    async def add_source(
+        self,
+        store: MemoryStore,
+        message_id: str,
+        content: str,
+        *,
+        identity: str = IDENTITY,
+        event_type: str = "user_message",
+        metadata: dict[str, object] | None = None,
+        scope: str = "private",
+    ) -> None:
+        payload = {"message_id": message_id, "source_identity_key": identity}
+        if metadata:
+            payload.update(metadata)
+        await store.add_timeline_event(
+            event_type=event_type,
+            session_id=f"onebot:FriendMessage:{identity[-8:]}",
+            scope=scope,
+            subject_id=identity,
+            object_id="self",
+            content=content,
+            metadata=payload,
+            occurred_at=f"2026-08-01T00:00:0{message_id[-1]}+00:00",
+        )
+
+    async def test_preview_is_read_only_and_exact_identity_excludes_other_subjects(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        await self.add_source(store, "m1", "我喜欢烤肉")
+        await self.add_source(store, "m2", "我喜欢烤肉", identity=OTHER_IDENTITY)
+        before = {
+            table: int(store._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for table in ("portrait_operations", "portrait_evidence", "portrait_facts", "portrait_learning_queue")
+        }
+        service = PortraitService(store, Config())
+        result = await service.preview_history_backfill(
+            {
+                "target_person_id": PERSON_ID,
+                "target_identity": IDENTITY,
+                "source_scopes": ["private"],
+                "operation_id": "preview-only",
+                "dry_run": True,
+            }
+        )
+        self.assertEqual("dry_run_ready", result["code"])
+        self.assertGreaterEqual(result["counts"]["eligible_sources"], 1)
+        self.assertEqual(1, result["counts"]["skipped"].get("identity_mismatch"))
+        after = {
+            table: int(store._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for table in before
+        }
+        self.assertEqual(before, after)
+
+    async def test_start_aggregates_independent_statements_and_is_idempotent(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        for index, content in enumerate(("我喜欢烤肉", "我真的喜欢烤肉", "我最喜欢烤肉"), 1):
+            await self.add_source(store, f"m{index}", content)
+        await self.add_source(store, "bot-1", "我喜欢烤肉", event_type="bot_response", metadata={"bot_generated": True})
+        await self.add_source(store, "quote-1", "我喜欢烤肉", metadata={"quoted": True})
+        service = PortraitService(store, Config())
+        request = {
+            "target_person_id": PERSON_ID,
+            "target_identity": IDENTITY,
+            "source_scopes": ["private"],
+            "operation_id": "backfill-1",
+        }
+        first = await service.start_history_backfill(request)
+        self.assertEqual("backfill_complete", first["code"])
+        self.assertGreaterEqual(first["counts"]["scanned"], 4)
+        self.assertGreaterEqual(first["counts"]["skipped"].get("excluded_context", 0), 1)
+        self.assertGreaterEqual(first["counts"]["accepted_fact_count"], 1)
+        self.assertGreaterEqual(first["counts"]["inferred_fact_count"], 1)
+        counts = {
+            table: int(store._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for table in ("portrait_evidence", "portrait_facts", "portrait_learning_queue")
+        }
+        replay = await service.start_history_backfill(request)
+        self.assertEqual("backfill_idempotent_replay", replay["code"])
+        self.assertEqual(counts, {
+            table: int(store._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            for table in counts
+        })
+        rendered = await service.render_history_portrait(request)
+        self.assertTrue(rendered.get("ok"), rendered)
+        self.assertTrue(rendered.get("items"), rendered)
+        self.assertNotIn("我喜欢烤肉", json_loads(store._conn.execute("SELECT snapshot FROM portrait_operations WHERE operation_id='backfill-1'").fetchone()[0], {}).__str__())
+        self.assertNotIn("我喜欢烤肉", str(await service.status_history_backfill("backfill-1")))
+
+    async def test_rollback_requires_confirmation_and_preserves_other_operation_fact(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        await self.add_source(store, "m1", "我喜欢烤肉")
+        service = PortraitService(store, Config())
+        request = {
+            "target_person_id": PERSON_ID,
+            "target_identity": IDENTITY,
+            "source_scopes": ["private"],
+            "operation_id": "backfill-rollback",
+        }
+        await service.start_history_backfill(request)
+        unrelated = await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_ID,
+                "dimension": "preference",
+                "normalized_claim_hash": "a" * 64,
+                "claim_summary": "独立事实",
+                "portrait_tier": "base",
+                "producer_kind": "test",
+                "producer_version": "test",
+                "derivation_kind": "explicit_statement",
+                "epistemic_status": "explicit",
+                "source_scope": "private",
+                "sensitivity": "low",
+                "confidence": 0.9,
+                "operation_id": "unrelated-operation",
+            }
+        )
+        self.assertTrue(unrelated["ok"])
+        self.assertEqual("rollback_requires_confirmation", (await service.rollback_history_backfill("backfill-rollback"))["code"])
+        rolled = await service.rollback_history_backfill("backfill-rollback", confirm=True)
+        self.assertEqual("backfill_rolled_back", rolled["code"])
+        replayed_rollback = await service.rollback_history_backfill("backfill-rollback", confirm=True)
+        self.assertEqual("backfill_already_rolled_back", replayed_rollback["code"])
+        self.assertIsNotNone(
+            await store.get_portrait_backfill_fact(
+                person_id=PERSON_ID,
+                dimension="preference",
+                normalized_claim_hash="a" * 64,
+                source_scope="private",
+            )
+        )
+        self.assertEqual("rolled_back", (await service.status_history_backfill("backfill-rollback"))["state"])
+
+    async def test_backfill_does_not_mutate_existing_official_fact(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        existing = await store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_ID,
+                "dimension": "preference",
+                "normalized_claim_hash": normalized_claim_hash("preference", "like:烤肉"),
+                "claim_summary": "喜欢 烤肉",
+                "portrait_tier": "base",
+                "producer_kind": "official",
+                "producer_version": "fixture",
+                "derivation_kind": "explicit_statement",
+                "epistemic_status": "explicit",
+                "source_scope": "private",
+                "sensitivity": "low",
+                "confidence": 0.95,
+                "evidence_hashes": ["a" * 64],
+                "operation_id": "official-operation",
+            }
+        )
+        await self.add_source(store, "append-1", "我喜欢烤肉")
+        service = PortraitService(store, Config())
+        request = {
+            "target_person_id": PERSON_ID,
+            "target_identity": IDENTITY,
+            "source_scopes": ["private"],
+            "operation_id": "backfill-append-existing",
+        }
+        result = await service.start_history_backfill(request)
+        self.assertEqual(1, result["counts"]["skipped"].get("external_fact_protected"))
+        after_backfill = await store.get_portrait_backfill_fact(
+            person_id=PERSON_ID,
+            dimension="preference",
+            normalized_claim_hash=normalized_claim_hash("preference", "like:烤肉"),
+            source_scope="private",
+        )
+        self.assertEqual(existing["fact_id"], after_backfill["id"])
+        self.assertEqual(["a" * 64], after_backfill["evidence_hashes"])
+
+    async def test_legacy_operation_id_cannot_be_reused_by_history_backfill(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        legacy = await store.portrait_migration(operation_id="legacy-operation", dry_run=False)
+        self.assertEqual("migration_applied", legacy["code"])
+        result = await PortraitService(store, Config()).start_history_backfill(
+            {
+                "target_person_id": PERSON_ID,
+                "target_identity": IDENTITY,
+                "source_scopes": ["private"],
+                "operation_id": "legacy-operation",
+            }
+        )
+        self.assertEqual("operation_conflict", result["code"])
+
+    async def test_rollback_keeps_operation_fact_when_external_evidence_was_appended(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        await self.add_source(store, "created-1", "我喜欢茶")
+        service = PortraitService(store, Config())
+        request = {
+            "target_person_id": PERSON_ID,
+            "target_identity": IDENTITY,
+            "source_scopes": ["private"],
+            "operation_id": "backfill-stale-created",
+        }
+        await service.start_history_backfill(request)
+        created = await store.get_portrait_backfill_fact(
+            person_id=PERSON_ID,
+            dimension="preference",
+            normalized_claim_hash=normalized_claim_hash("preference", "like:茶"),
+            source_scope="private",
+        )
+        self.assertIsNotNone(created)
+        await store.append_portrait_fact_evidence(
+            person_id=PERSON_ID,
+            fact_id=created["id"],
+            evidence_hash="f" * 64,
+        )
+        rolled = await service.rollback_history_backfill("backfill-stale-created", confirm=True)
+        self.assertEqual(1, rolled["deleted"]["rollback_stale"])
+        self.assertIsNotNone(
+            await store.get_portrait_backfill_fact(
+                person_id=PERSON_ID,
+                dimension="preference",
+                normalized_claim_hash=normalized_claim_hash("preference", "like:茶"),
+                source_scope="private",
+            )
+        )
+
+    async def test_identity_mismatch_and_unconfigured_group_scope_are_rejected(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        service = PortraitService(store, Config())
+        wrong = await service.start_history_backfill(
+            {
+                "target_person_id": PERSON_ID,
+                "target_identity": OTHER_IDENTITY,
+                "source_scopes": ["private"],
+                "operation_id": "wrong-identity",
+            }
+        )
+        self.assertEqual("identity_mismatch", wrong["code"])
+        group = await service.start_history_backfill(
+            {
+                "target_person_id": PERSON_ID,
+                "target_identity": IDENTITY,
+                "source_scopes": ["group:onebot:g-1"],
+                "operation_id": "group-not-allowed",
+            }
+        )
+        self.assertEqual("scope_not_allowed", group["code"])
+
+    async def test_memory_sources_use_authenticated_subject_not_owner_bot_and_exclude_bot_subjects(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        await store.insert_memory(
+            MemoryRecord(
+                id="memory-user-source",
+                memory_type="manual_memory",
+                subject=EntityRef(kind="user", id=IDENTITY),
+                scope="private",
+                session_id="memory-session",
+                visibility="private_pair",
+                content="我喜欢咖啡",
+                metadata={"source_identity_key": IDENTITY, "owner_bot_id": "fixture-bot"},
+                owner_bot_id="fixture-bot",
+                occurred_at="2026-08-01T00:00:01+00:00",
+            )
+        )
+        await store.insert_memory(
+            MemoryRecord(
+                id="memory-bot-source",
+                memory_type="manual_memory",
+                subject=EntityRef(kind="bot", id="fixture-bot"),
+                scope="private",
+                session_id="memory-bot-session",
+                visibility="private_pair",
+                content="我喜欢咖啡",
+                metadata={"source_identity_key": IDENTITY, "bot_generated": True},
+                owner_bot_id="fixture-bot",
+                occurred_at="2026-08-01T00:00:02+00:00",
+            )
+        )
+        result = await PortraitService(store, Config()).preview_history_backfill(
+            {
+                "target_person_id": PERSON_ID,
+                "target_identity": IDENTITY,
+                "source_scopes": ["private"],
+                "operation_id": "memory-source-preview",
+                "dry_run": True,
+            }
+        )
+        self.assertEqual("dry_run_ready", result["code"])
+        self.assertGreaterEqual(result["counts"]["eligible_sources"], 1)
+        self.assertGreaterEqual(result["counts"]["skipped"].get("bot_subject", 0), 1)
+
+    async def test_sources_without_message_id_are_deduplicated_by_content_time_and_scope(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        for source_id in ("no-message-a", "no-message-b"):
+            await store.add_timeline_event(
+                event_type="user_message",
+                session_id="same-session",
+                scope="private",
+                subject_id=IDENTITY,
+                object_id="self",
+                content="我喜欢茶",
+                metadata={"source_identity_key": IDENTITY},
+                occurred_at="2026-08-01T00:00:03+00:00",
+            )
+        result = await PortraitService(store, Config()).preview_history_backfill(
+            {
+                "target_person_id": PERSON_ID,
+                "target_identity": IDENTITY,
+                "source_scopes": ["private"],
+                "operation_id": "content-dedupe-preview",
+                "dry_run": True,
+            }
+        )
+        self.assertEqual("dry_run_ready", result["code"])
+        self.assertEqual(1, result["counts"]["eligible_sources"])
+        self.assertEqual(1, result["counts"]["skipped"].get("duplicate_source"))
+
+    async def test_history_sources_apply_memory_governance_and_timeline_metadata_filters(self) -> None:
+        store = self.make_store()
+        await self.project_person(store)
+        await store.insert_memory(
+            MemoryRecord(
+                id="memory-visible",
+                memory_type="manual_memory",
+                subject=EntityRef(kind="user", id=IDENTITY),
+                scope="private",
+                session_id="memory-visible-session",
+                visibility="private_pair",
+                content="我喜欢咖啡",
+                metadata={"source_identity_key": IDENTITY},
+                occurred_at="2026-08-01T00:00:01+00:00",
+            )
+        )
+        for memory_id, visibility, lifecycle, validity_status, review_status in (
+            ("memory-internal", "internal", "raw_event", "active", "auto"),
+            ("memory-bot-self", "bot_self", "raw_event", "active", "auto"),
+            ("memory-archived", "private_pair", "archived", "active", "auto"),
+            ("memory-deleted", "private_pair", "raw_event", "deleted", "auto"),
+            ("memory-pending", "private_pair", "raw_event", "active", "pending"),
+            ("memory-rejected", "private_pair", "raw_event", "active", "rejected"),
+        ):
+            await store.insert_memory(
+                MemoryRecord(
+                    id=memory_id,
+                    memory_type="manual_memory",
+                    subject=EntityRef(kind="user", id=IDENTITY),
+                    scope="private",
+                    session_id=f"{memory_id}-session",
+                    visibility=visibility,
+                    lifecycle=lifecycle,
+                    validity_status=validity_status,
+                    review_status=review_status,
+                    content="我喜欢咖啡",
+                    metadata={"source_identity_key": IDENTITY},
+                    occurred_at="2026-08-01T00:00:02+00:00",
+                )
+            )
+        timeline_visible = await store.add_timeline_event(
+            event_type="user_message",
+            session_id="timeline-visible",
+            scope="private",
+            subject_id=IDENTITY,
+            object_id="self",
+            content="我喜欢茶",
+            metadata={"source_identity_key": IDENTITY},
+            occurred_at="2026-08-01T00:00:03+00:00",
+        )
+        for metadata in (
+            {"source_identity_key": IDENTITY, "lifecycle": "archived"},
+            {"source_identity_key": IDENTITY, "review_status": "pending"},
+            {"source_identity_key": IDENTITY, "visibility": "internal"},
+            {"source_identity_key": IDENTITY, "bot_generated": True},
+        ):
+            await store.add_timeline_event(
+                event_type="user_message",
+                session_id="timeline-filtered",
+                scope="private",
+                subject_id=IDENTITY,
+                object_id="self",
+                content="我喜欢茶",
+                metadata=metadata,
+                occurred_at="2026-08-01T00:00:04+00:00",
+            )
+        rows = await store.list_portrait_history_sources(
+            source_scopes=["private"],
+            from_time="2026-08-01T00:00:00+00:00",
+            to_time="2026-08-01T00:00:59+00:00",
+            offset=0,
+            limit=100,
+        )
+        source_ids = {row["source_id"] for row in rows}
+        self.assertIn("memory-visible", source_ids)
+        self.assertIn(timeline_visible, source_ids)
+        self.assertEqual(2, len(rows))
+
+    def test_request_normalizes_scope_order_and_utc_time_bounds(self) -> None:
+        request = PortraitBackfillRequest.from_value(
+            {
+                "target_person_id": PERSON_ID,
+                "target_identity": IDENTITY,
+                "source_scopes": ["group:z", "private", "group:z", "private@persona"],
+                "from_time": "2026-08-01T08:00:00+08:00",
+                "to_time": "2026-08-02T00:00:00Z",
+                "operation_id": "canonical-request",
+            }
+        )
+        self.assertEqual(("group:z", "private", "private@persona"), request.source_scopes)
+        self.assertEqual("2026-08-01T00:00:00+00:00", request.from_time)
+        self.assertEqual("2026-08-02T00:00:00+00:00", request.to_time)
+        self.assertEqual(list(request.source_scopes), request.payload()["source_scopes"])
+
+    def test_source_key_keeps_message_ids_separate_by_kind_and_scope(self) -> None:
+        key_timeline_private = PortraitService._backfill_source_key(
+            {"source_kind": "timeline", "scope": "private", "message_id": "same-message"}
+        )
+        key_memory_private = PortraitService._backfill_source_key(
+            {"source_kind": "memory", "scope": "private", "message_id": "same-message"}
+        )
+        key_timeline_group = PortraitService._backfill_source_key(
+            {"source_kind": "timeline", "scope": "group:onebot:g-1", "message_id": "same-message"}
+        )
+        self.assertEqual(len({key_timeline_private, key_memory_private, key_timeline_group}), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portrait_renderer.py
+++ b/tests/test_portrait_renderer.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = "portrait_renderer_memory"
+if PACKAGE not in sys.modules:
+    module = types.ModuleType(PACKAGE)
+    module.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE] = module
+
+from portrait_renderer_memory.core.portrait import build_evidence, normalized_claim_hash
+from portrait_renderer_memory.core.portrait_renderer import (
+    PortraitRenderer,
+    render_portrait_items,
+)
+from portrait_renderer_memory.core.portrait_service import PortraitService
+from portrait_renderer_memory.core.store import MemoryStore
+from portrait_renderer_memory.unified_profile_contract import (
+    build_capability_summary,
+    build_portrait_request,
+    build_profile_dto,
+)
+
+
+PERSON_REF = {
+    "person_id": "person_" + "1" * 24,
+    "resolved_identity_key": "chat-origin-v1:" + "2" * 64,
+    "projection_revision": 1,
+    "identity_assurance": "verified",
+    "profile_status": "active",
+}
+
+
+class _Config:
+    @staticmethod
+    def int(_key: str, default: int) -> int:
+        return default
+
+    @staticmethod
+    def float(_key: str, default: float) -> float:
+        return default
+
+
+class PortraitRendererTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        store = MemoryStore(Path(temp.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def asyncSetUp(self) -> None:
+        self.store = self.make_store()
+        await self.store.upsert_portrait_person_projection(
+            PERSON_REF,
+            build_capability_summary(
+                {
+                    "private_companion_enabled": True,
+                    "portrait_mode": "learn_and_use",
+                    "grant_source": "administrator",
+                }
+            ),
+            source_scope="private",
+        )
+        self.service = PortraitService(self.store, _Config())
+        self.request = build_portrait_request(
+            person_ref=PERSON_REF,
+            requester_person_id=PERSON_REF["person_id"],
+            target_person_id=PERSON_REF["person_id"],
+            scope="private",
+            purpose="summarize_to_subject",
+        )
+
+    async def add_fact(
+        self,
+        *,
+        key: str,
+        dimension: str,
+        summary: str,
+        epistemic_status: str = "explicit",
+        sensitivity: str = "low",
+        tier: str = "base",
+    ) -> dict[str, object]:
+        evidence = build_evidence(
+            person_ref=PERSON_REF,
+            scope="private",
+            session_id="fixture-session",
+            message_id=f"fixture-{key}",
+            source_identity_key=PERSON_REF["resolved_identity_key"],
+            text=f"synthetic source {key}",
+        )
+        await self.store.add_portrait_evidence(evidence)
+        return await self.store.upsert_portrait_fact(
+            {
+                "person_id": PERSON_REF["person_id"],
+                "dimension": dimension,
+                "normalized_claim_hash": normalized_claim_hash(dimension, key),
+                "claim_summary": summary,
+                "portrait_tier": tier,
+                "producer_kind": "renderer_fixture",
+                "producer_version": "renderer.fixture.v1",
+                "derivation_kind": "explicit_statement",
+                "epistemic_status": epistemic_status,
+                "source_scope": "private",
+                "usable_scope": "self_low_global",
+                "confidence": 0.93,
+                "sensitivity": sensitivity,
+                "evidence_hashes": [evidence["evidence_hash"]],
+                "operation_id": f"renderer-fixture-{key}",
+            }
+        )
+
+    async def test_store_provenance_is_opt_in_and_contains_only_opaque_refs(self) -> None:
+        await self.add_fact(
+            key="food",
+            dimension="preference",
+            summary="喜欢烤肉",
+        )
+        plain = await self.store.portrait_summary(PERSON_REF["person_id"], scope="private")
+        self.assertNotIn("provenance", plain["items"][0])
+        detailed = await self.store.portrait_summary(
+            PERSON_REF["person_id"],
+            scope="private",
+            include_provenance=True,
+        )
+        provenance = detailed["items"][0]["provenance"]
+        self.assertTrue(provenance["fact_id"])
+        self.assertRegex(provenance["evidence_refs"][0], r"^[0-9a-f]{64}$")
+        self.assertNotIn("synthetic source", str(detailed))
+
+    async def test_renderer_groups_stable_dimensions_and_traces_each_sentence(self) -> None:
+        await self.add_fact(
+            key="food",
+            dimension="preference",
+            summary="喜欢烤肉",
+        )
+        await self.add_fact(
+            key="chat",
+            dimension="communication_preference",
+            summary="通常希望回复简短",
+        )
+        await self.add_fact(
+            key="unknown",
+            dimension="future_unreviewed_dimension",
+            summary="不应显示",
+        )
+        await self.add_fact(
+            key="health",
+            dimension="preference",
+            summary="敏感内容",
+            sensitivity="high",
+        )
+
+        rendered = await PortraitRenderer(self.service).render(self.request)
+
+        self.assertTrue(rendered["ok"])
+        self.assertTrue(rendered["read_only"])
+        self.assertEqual(["preference", "communication_preference"], list(rendered["dimensions"]))
+        self.assertEqual({"preference", "communication_preference"}, {fact["dimension"] for fact in rendered["facts"]})
+        self.assertEqual(len(rendered["facts"]), len(rendered["sentences"]))
+        self.assertEqual(
+            {sentence["fact_id"] for sentence in rendered["sentences"]},
+            {fact["fact_id"] for fact in rendered["facts"]},
+        )
+        for sentence in rendered["sentences"]:
+            self.assertTrue(sentence["evidence_refs"])
+            self.assertIn(sentence["fact_id"], str(rendered["facts"]))
+        self.assertIn("喜欢烤肉", rendered["natural_language"])
+        self.assertNotIn("不应显示", str(rendered))
+        self.assertNotIn("敏感内容", str(rendered))
+        # The store's low-sensitivity gate removes the high-sensitivity row;
+        # the renderer then omits the unsupported dimension.
+        self.assertEqual(1, rendered["omitted"]["count"])
+
+    async def test_inferred_fact_uses_cautious_language(self) -> None:
+        await self.add_fact(
+            key="inferred-food",
+            dimension="preference",
+            summary="喜欢烤肉",
+            epistemic_status="inferred",
+            tier="intelligent",
+        )
+        rendered = await PortraitRenderer(self.service).render(self.request)
+        self.assertIn("从多条独立证据看", rendered["natural_language"])
+        self.assertEqual("inferred", rendered["facts"][0]["epistemic_status"])
+
+    async def test_service_exposes_the_same_read_only_renderer(self) -> None:
+        await self.add_fact(
+            key="service-adapter",
+            dimension="preference",
+            summary="喜欢烤肉",
+        )
+        rendered = await self.service.render_readonly_portrait(self.request)
+        self.assertTrue(rendered["read_only"])
+        self.assertEqual(1, len(rendered["facts"]))
+        self.assertTrue(rendered["sentences"][0]["evidence_refs"])
+        history_rendered = await self.service.render_history_portrait(
+            {
+                "target_person_id": PERSON_REF["person_id"],
+                "target_identity": PERSON_REF["resolved_identity_key"],
+                "source_scopes": ["private"],
+                "operation_id": "renderer-history-read",
+            }
+        )
+        self.assertTrue(history_rendered["read_only"])
+        self.assertEqual(1, len(history_rendered["facts"]))
+
+    async def test_renderer_is_read_only_and_denied_request_returns_no_portrait(self) -> None:
+        await self.add_fact(
+            key="food",
+            dimension="preference",
+            summary="喜欢烤肉",
+        )
+        with self.store._lock:
+            before = self.store._conn.execute(
+                "SELECT COUNT(*) AS count FROM portrait_facts"
+            ).fetchone()["count"]
+        await PortraitRenderer(self.service).render(self.request)
+        with self.store._lock:
+            after = self.store._conn.execute(
+                "SELECT COUNT(*) AS count FROM portrait_facts"
+            ).fetchone()["count"]
+        self.assertEqual(before, after)
+
+        denied = dict(self.request)
+        denied["requester_person_id"] = "person_" + "9" * 24
+        denied_result = await PortraitRenderer(self.service).render(denied)
+        self.assertFalse(denied_result["ok"])
+        self.assertEqual([], denied_result["facts"])
+        self.assertEqual("", denied_result["natural_language"])
+        self.assertEqual("", denied_result["person_id"])
+
+    def test_renderer_omits_untraceable_and_empty_dimensions(self) -> None:
+        rendered = render_portrait_items(
+            [
+                {
+                    "dimension": "preference",
+                    "summary": "没有证据引用",
+                    "sensitivity": "low",
+                    "epistemic_status": "explicit",
+                    "confidence": 0.9,
+                },
+                {
+                    "dimension": "preference",
+                    "summary": "应显示",
+                    "sensitivity": "low",
+                    "epistemic_status": "explicit",
+                    "confidence": 0.9,
+                    "provenance": {
+                        "fact_id": "fact-fixture",
+                        "evidence_refs": ["a" * 64],
+                        "source_scope": "private",
+                    },
+                },
+                {
+                    "dimension": "preference",
+                    "summary": "置信度无效",
+                    "sensitivity": "low",
+                    "epistemic_status": "explicit",
+                    "confidence": "not-a-number",
+                    "provenance": {
+                        "fact_id": "fact-invalid-confidence",
+                        "evidence_refs": ["b" * 64],
+                    },
+                },
+            ]
+        )
+        self.assertEqual(["preference"], list(rendered["dimensions"]))
+        self.assertNotIn("没有证据引用", str(rendered))
+        self.assertNotIn("置信度无效", str(rendered))
+        self.assertEqual(1, rendered["omitted"]["reasons"]["provenance_missing"])
+        self.assertEqual(1, rendered["omitted"]["reasons"]["confidence_invalid"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复了什么

落地单人、显式身份和作用域约束的历史画像回填，以及只读画像渲染。回填现在支持预览、启动/恢复、状态、取消、确认回滚和渲染六阶段；历史来源治理会排除 Bot、第三方、引用/转发、归档、删除、隔离、待审核和不允许可见性记录。原有官方事实不会被历史回填追加或替换。

## 怎么修复

- 复用现有显式候选提取、画像证据、事实、学习队列和独立证据聚合规则。
- 使用配置化的记录、分页、字符、维度和运行时间上限，保存无原文的 checkpoint 与审计快照；请求身份、作用域、时间和 actor 均规范化并参与幂等校验。
- 将 `operation_id` 绑定到回填证据和事实写入事务的状态门禁，取消/回滚后阻止过期 worker 继续写入；回滚同时按操作归属扫描事实、队列和孤立证据，处理 checkpoint 尚未落盘的中断场景。
- 画像 renderer 复用正式读取边界，只输出 active、low sensitivity、置信度/新鲜度合格且有 fact/evidence provenance 的稳定维度，并对 inferred 事实使用谨慎措辞。
- 页面 API 全部要求 Dashboard 管理员，回滚要求 `确认回滚`。

## 已验证

- `python -m pytest -q`：563 passed，142 subtests passed。
- 画像回填/renderer 专项测试：18 passed。
- `python -m compileall -q core page_api.py tests`：通过。
- `git diff --check`：通过。
- 当前环境未安装 `ruff`，未执行 `ruff format` / `ruff check`。
