### PR TITLE
fix: 加强插件生命周期关闭屏障，降低 enable/reload 时 SQLite 崩溃风险

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -778,7 +778,12 @@ class MemoryCompanionService:
             # 关于本轮回复的采集写入（写时间线、写关系、抽取事实、调度向量化等）
             # 对"本轮要不要出回复"毫无贡献，移入后台执行，不阻塞请求关键路径。
             # 对应 optimization_plan.md §3.2「把写操作移出请求关键路径」。
-            asyncio.create_task(self._capture_async(ctx, event, req, reply_chain))
+            # 必须经 _spawn_background 注册进 _background_tasks，否则 terminate 时
+            # 无法 cancel 该任务，会在 store 半关闭状态下继续写 DB（exit=139 根因之一）。
+            self._spawn_background(
+                self._capture_async(ctx, event, req, reply_chain),
+                label="capture-async",
+            )
         stage_timer.mark("finalize")
         self._emit_hook_stage_timing(stage_timer, ctx, note="ok")
 
@@ -11141,6 +11146,12 @@ class MemoryCompanionService:
         for task in list(self._background_tasks):
             task.cancel()
         self._background_tasks.clear()
+        for task in list(self._summary_workers.values()):
+            task.cancel()
+        self._summary_workers.clear()
+        self._summary_pending.clear()
+        self._summary_pending_contexts.clear()
+        self._summary_pending_reasons.clear()
         self._save_token_usage(force=True)
         try:
             self.store.close()
@@ -11148,6 +11159,25 @@ class MemoryCompanionService:
             logger.warning("[MemoryCompanion] 关闭记忆库连接失败: %s", exc, exc_info=True)
         finally:
             self._closed = True
+
+    def shutdown_evidence(self) -> dict[str, Any]:
+        """Return structured evidence of resource state after shutdown.
+
+        Consumed by ``terminate()`` to emit an actionable ``shutdown_complete``
+        log (exit=139 fix: F4). Any non-zero field means a task or DB operation
+        was still in flight when the store closed.
+        """
+        store_state = {}
+        try:
+            store_state = self.store.shutdown_state()
+        except Exception:
+            store_state = {"error": "store_shutdown_state_unavailable"}
+        return {
+            "background_tasks": len(self._background_tasks),
+            "summary_workers": len(self._summary_workers),
+            "summary_pending": len(self._summary_pending),
+            "store": store_state,
+        }
 
     async def aclose(self) -> None:
         if self._closed:
@@ -11160,6 +11190,22 @@ class MemoryCompanionService:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         self._background_tasks.clear()
+        # 显式等待总结 worker 归零：_summary_workers 是独立 dict，即使其任务已
+        # 经 _spawn_background 注册，也要确保所有 worker 取消并清理完毕，
+        # 避免 close 后仍有总结任务在 store 半关闭状态下执行（exit=139 根因之一）。
+        summary_tasks = [
+            task
+            for task in self._summary_workers.values()
+            if task is not current and not task.done()
+        ]
+        for task in summary_tasks:
+            task.cancel()
+        if summary_tasks:
+            await asyncio.gather(*summary_tasks, return_exceptions=True)
+        self._summary_workers.clear()
+        self._summary_pending.clear()
+        self._summary_pending_contexts.clear()
+        self._summary_pending_reasons.clear()
         self._save_token_usage(force=True)
         try:
             await asyncio.to_thread(self.store.close)

--- a/core/store.py
+++ b/core/store.py
@@ -12,6 +12,7 @@ import re
 import sqlite3
 import threading
 import time
+import traceback
 from pathlib import Path
 from typing import Any
 
@@ -83,6 +84,11 @@ class MemoryStore:
         self._read_lock = threading.RLock()
         self._operation_condition = threading.Condition()
         self._active_tracked_operations = 0
+        self._operation_waiters = 0
+        self._operation_owner_stack = ""
+        # 置 True 时 _guard_operation_sync 记录在飞操作的调用栈，供关闭超时取证
+        # （EXIT_139_FIX_PLAN.md F2「记录未归零的操作栈」）。
+        self._record_operation_stacks = False
         self._closing = False
         self._closed = False
         self._fts_enabled = False
@@ -219,7 +225,14 @@ class MemoryStore:
             return operation(*args)
 
     async def _run_recoverable_database_operation(self, operation: Any, *args: Any) -> Any:
-        return await asyncio.to_thread(self._run_with_database_recovery_sync, operation, *args)
+        # 统一经 _guard_operation_sync 计数：recoverable 路径同样受关闭屏障保护，
+        # 避免 close() 在只读/恢复查询在飞时关闭连接（exit=139 fix: INV-2）。
+        return await asyncio.to_thread(
+            self._guard_operation_sync,
+            self._run_with_database_recovery_sync,
+            operation,
+            *args,
+        )
 
     async def _run_tracked_operation(
         self,
@@ -240,14 +253,16 @@ class MemoryStore:
             finally:
                 with self._operation_condition:
                     self._active_tracked_operations -= 1
-                    self._operation_condition.notify_all()
+                    if self._operation_waiters:
+                        self._operation_condition.notify_all()
 
         try:
             future = asyncio.get_running_loop().run_in_executor(None, run)
         except BaseException:
             with self._operation_condition:
                 self._active_tracked_operations -= 1
-                self._operation_condition.notify_all()
+                if self._operation_waiters:
+                    self._operation_condition.notify_all()
             raise
         return await asyncio.shield(future)
 
@@ -270,7 +285,7 @@ class MemoryStore:
         }
 
     async def wal_health(self, *, checkpoint: bool = False) -> dict[str, Any]:
-        return await asyncio.to_thread(self._wal_health_sync, checkpoint)
+        return await asyncio.to_thread(self._guard_operation_sync, self._wal_health_sync, checkpoint)
 
     def _wal_health_sync(self, checkpoint: bool = False) -> dict[str, Any]:
         result = self._database_file_snapshot()
@@ -314,7 +329,7 @@ class MemoryStore:
         above ``min_wal_bytes`` and no write transaction is active; a busy
         result is not an error.
         """
-        return await asyncio.to_thread(self._wal_checkpoint_truncate_sync, min_wal_bytes)
+        return await asyncio.to_thread(self._guard_operation_sync, self._wal_checkpoint_truncate_sync, min_wal_bytes)
 
     def _wal_checkpoint_truncate_sync(self, min_wal_bytes: int) -> dict[str, Any]:
         result = self._database_file_snapshot()
@@ -1623,7 +1638,7 @@ class MemoryStore:
         source_scope: str = "",
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._upsert_portrait_person_projection_sync,
+            self._guard_operation_sync, self._upsert_portrait_person_projection_sync,
             deepcopy(person_ref),
             deepcopy(capability_summary),
             source_scope,
@@ -1710,7 +1725,7 @@ class MemoryStore:
         return {"ok": True, "code": "profile_exact", "state": "ready", "portrait_revision": portrait_revision}
 
     async def portrait_projection_decision(self, person_ref: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._portrait_projection_decision_sync, deepcopy(person_ref))
+        return await asyncio.to_thread(self._guard_operation_sync, self._portrait_projection_decision_sync, deepcopy(person_ref))
 
     def _portrait_projection_decision_sync(self, person_ref: dict[str, Any]) -> dict[str, Any]:
         person_id = clean_text(person_ref.get("person_id"), 80)
@@ -1737,7 +1752,7 @@ class MemoryStore:
         return {"ok": True, "code": "profile_exact"}
 
     async def add_portrait_evidence(self, evidence: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._add_portrait_evidence_sync, deepcopy(evidence))
+        return await asyncio.to_thread(self._guard_operation_sync, self._add_portrait_evidence_sync, deepcopy(evidence))
 
     def _add_portrait_evidence_sync(self, evidence: dict[str, Any]) -> dict[str, Any]:
         person_id = clean_text(evidence.get("person_id"), 80)
@@ -1856,7 +1871,7 @@ class MemoryStore:
         return int(row["portrait_revision"] or 0) if row is not None else 0
 
     async def upsert_portrait_fact(self, fact: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._upsert_portrait_fact_sync, deepcopy(fact))
+        return await asyncio.to_thread(self._guard_operation_sync, self._upsert_portrait_fact_sync, deepcopy(fact))
 
     def _upsert_portrait_fact_sync(self, fact: dict[str, Any]) -> dict[str, Any]:
         fact = redact_sensitive_value(fact)
@@ -1992,7 +2007,7 @@ class MemoryStore:
         }
 
     async def list_portrait_evidence(self, person_id: str, *, limit: int = 64) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_portrait_evidence_sync, person_id, limit)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_portrait_evidence_sync, person_id, limit)
 
     def _list_portrait_evidence_sync(self, person_id: str, limit: int) -> list[dict[str, Any]]:
         with self._lock:
@@ -2010,10 +2025,10 @@ class MemoryStore:
         ]
 
     async def enqueue_portrait_learning(self, *, person_id: str, fact_id: str, evidence_hash: str) -> dict[str, Any]:
-        return await asyncio.to_thread(self._enqueue_portrait_learning_sync, person_id, fact_id, evidence_hash)
+        return await asyncio.to_thread(self._guard_operation_sync, self._enqueue_portrait_learning_sync, person_id, fact_id, evidence_hash)
 
     async def list_pending_portrait_people(self, *, limit: int = 500) -> list[str]:
-        return await asyncio.to_thread(self._list_pending_portrait_people_sync, limit)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_pending_portrait_people_sync, limit)
 
     def _list_pending_portrait_people_sync(self, limit: int) -> list[str]:
         with self._lock:
@@ -2059,7 +2074,7 @@ class MemoryStore:
         attempt_limit: int = 2,
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._run_portrait_daily_batch_sync,
+            self._guard_operation_sync, self._run_portrait_daily_batch_sync,
             person_id,
             run_day,
             min_independent_evidence,
@@ -2230,7 +2245,7 @@ class MemoryStore:
         inferred_freshness_days: int = 90,
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._portrait_summary_sync,
+            self._guard_operation_sync, self._portrait_summary_sync,
             person_id,
             scope,
             legacy_scope,
@@ -2320,7 +2335,7 @@ class MemoryStore:
         }
 
     async def upsert_portrait_suppression(self, marker: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._upsert_portrait_suppression_sync, deepcopy(marker))
+        return await asyncio.to_thread(self._guard_operation_sync, self._upsert_portrait_suppression_sync, deepcopy(marker))
 
     def _upsert_portrait_suppression_sync(self, marker: dict[str, Any]) -> dict[str, Any]:
         key = clean_text(marker.get("suppression_key"), 80)
@@ -2359,10 +2374,10 @@ class MemoryStore:
         return {"ok": True, "code": "suppression_upserted", "revision": revision}
 
     async def list_portrait_people(self, *, limit: int = 100) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_portrait_people_sync, limit)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_portrait_people_sync, limit)
 
     async def portrait_status(self, person_id: str) -> dict[str, Any]:
-        return await asyncio.to_thread(self._portrait_status_sync, person_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._portrait_status_sync, person_id)
 
     def _portrait_status_sync(self, person_id: str) -> dict[str, Any]:
         person_id = clean_text(person_id, 80)
@@ -2412,7 +2427,7 @@ class MemoryStore:
         ]
 
     async def portrait_governance_detail(self, person_id: str) -> dict[str, Any]:
-        return await asyncio.to_thread(self._portrait_governance_detail_sync, person_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._portrait_governance_detail_sync, person_id)
 
     def _portrait_governance_detail_sync(self, person_id: str) -> dict[str, Any]:
         person_id = clean_text(person_id, 80)
@@ -2463,7 +2478,7 @@ class MemoryStore:
         expires_at: str = "",
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._govern_portrait_fact_sync,
+            self._guard_operation_sync, self._govern_portrait_fact_sync,
             person_id,
             fact_id,
             action,
@@ -2521,7 +2536,7 @@ class MemoryStore:
         return {**result, "fact_id": fact_id, "action": action}
 
     async def portrait_migration(self, *, operation_id: str, dry_run: bool = True) -> dict[str, Any]:
-        return await asyncio.to_thread(self._portrait_migration_sync, operation_id, dry_run)
+        return await asyncio.to_thread(self._guard_operation_sync, self._portrait_migration_sync, operation_id, dry_run)
 
     def _portrait_migration_sync(self, operation_id: str, dry_run: bool) -> dict[str, Any]:
         operation_id = clean_text(operation_id, 120)
@@ -2545,7 +2560,7 @@ class MemoryStore:
         return {"ok": True, "code": "migration_applied", "operation_id": operation_id, "legacy_candidate_count": count}
 
     async def rollback_portrait_migration(self, *, operation_id: str) -> dict[str, Any]:
-        return await asyncio.to_thread(self._rollback_portrait_migration_sync, operation_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._rollback_portrait_migration_sync, operation_id)
 
     def _rollback_portrait_migration_sync(self, operation_id: str) -> dict[str, Any]:
         operation_id = clean_text(operation_id, 120)
@@ -2631,13 +2646,78 @@ class MemoryStore:
             )
         return len(rows)
 
+    def _guard_operation_sync(self, operation: Any, *args: Any) -> Any:
+        """Run a DB operation under the shutdown barrier (sync context).
+
+        Increments the tracked-operation counter for the whole duration of the
+        operation so that ``close()`` waits for it before closing any SQLite
+        connection (exit=139 fix: INV-2, no SQLite op in flight during close).
+        When a barrier wait times out, the leaked stack is recorded on the
+        instance so it can be surfaced in ``shutdown_state()``.
+
+        Raises:
+            sqlite3.OperationalError: If the store is closing/closed, so a
+                caller never starts a query on a half-closed connection.
+        """
+        with self._operation_condition:
+            if self._closing or self._closed:
+                raise sqlite3.OperationalError("database is closing")
+            self._active_tracked_operations += 1
+            self._operation_owner_stack = (
+                "".join(traceback.format_stack(limit=8))
+                if getattr(self, "_record_operation_stacks", False)
+                else ""
+            )
+        try:
+            return operation(*args)
+        finally:
+            with self._operation_condition:
+                self._active_tracked_operations -= 1
+                if self._operation_waiters:
+                    self._operation_condition.notify_all()
+                if getattr(self, "_record_operation_stacks", False):
+                    self._operation_owner_stack = ""
+
+    def shutdown_state(self) -> dict[str, Any]:
+        """Return structured evidence of resource state for shutdown logging."""
+        with self._operation_condition:
+            tracked = int(self._active_tracked_operations)
+            owner_stack = self._operation_owner_stack
+        return {
+            "main_conn_closed": self._closed,
+            "read_conn_closed": self._read_conn is None,
+            "tracked_ops": tracked,
+            "operation_owner_stack": owner_stack,
+        }
+
     def close(self) -> None:
+        close_timeout = float(
+            getattr(self, "_close_timeout_seconds", None) or 10.0
+        )
+        deadline = time.monotonic() + close_timeout
         with self._operation_condition:
             if self._closed:
                 return
             self._closing = True
-            while self._active_tracked_operations:
-                self._operation_condition.wait()
+            if self._active_tracked_operations:
+                self._operation_waiters += 1
+                try:
+                    while self._active_tracked_operations:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            leaked_stack = self._operation_owner_stack or "（未开启操作栈记录）"
+                            logger.warning(
+                                "[MemoryCompanion] store.close 等待在飞操作归零超时 %.1fs，"
+                                "仍有 %s 个操作未归零，强制关闭（存在 exit=139 风险）；"
+                                "在飞操作栈:\n%s",
+                                close_timeout,
+                                self._active_tracked_operations,
+                                leaked_stack,
+                            )
+                            break
+                        self._operation_condition.wait(timeout=remaining)
+                finally:
+                    self._operation_waiters -= 1
         with self._lock:
             if self._closed:
                 return
@@ -2662,7 +2742,7 @@ class MemoryStore:
         return target
 
     async def clear_all_memory_data(self) -> dict[str, Any]:
-        return await asyncio.to_thread(self._clear_all_memory_data_sync)
+        return await asyncio.to_thread(self._guard_operation_sync, self._clear_all_memory_data_sync)
 
     def _clear_all_memory_data_sync(self) -> dict[str, Any]:
         backup = self.backup(".before_clear_all")
@@ -2715,7 +2795,7 @@ class MemoryStore:
         user_id: str = "",
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._scoped_memory_clear_sync,
+            self._guard_operation_sync, self._scoped_memory_clear_sync,
             target_type,
             group_id,
             user_id,
@@ -2730,7 +2810,7 @@ class MemoryStore:
         user_id: str = "",
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._scoped_memory_clear_sync,
+            self._guard_operation_sync, self._scoped_memory_clear_sync,
             target_type,
             group_id,
             user_id,
@@ -3791,7 +3871,7 @@ class MemoryStore:
         offset: int = 0,
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._list_rule_portrait_facts_sync,
+            self._guard_operation_sync, self._list_rule_portrait_facts_sync,
             person_id,
             source_scope,
             include_inactive,
@@ -5300,7 +5380,7 @@ class MemoryStore:
         confidence: float = 0.6,
     ) -> str:
         return await asyncio.to_thread(
-            self._upsert_identity_sync,
+            self._guard_operation_sync, self._upsert_identity_sync,
             platform,
             entity,
             aliases or [],
@@ -5371,7 +5451,7 @@ class MemoryStore:
         return row_id
 
     async def list_identities(self, limit: int = 1000, *, offset: int = 0) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_identities_sync, limit, offset)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_identities_sync, limit, offset)
 
     def _list_identities_sync(self, limit: int, offset: int) -> list[dict[str, Any]]:
         with self._lock:
@@ -5519,7 +5599,7 @@ class MemoryStore:
         offset: int = 0,
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._list_relationships_sync,
+            self._guard_operation_sync, self._list_relationships_sync,
             limit,
             entity_id,
             scope,
@@ -5575,7 +5655,7 @@ class MemoryStore:
         metadata: dict[str, Any] | None = None,
     ) -> str:
         return await asyncio.to_thread(
-            self._upsert_knowledge_node_sync,
+            self._guard_operation_sync, self._upsert_knowledge_node_sync,
             node_type,
             label,
             scope,
@@ -5661,7 +5741,7 @@ class MemoryStore:
         metadata: dict[str, Any] | None = None,
     ) -> str:
         return await asyncio.to_thread(
-            self._upsert_knowledge_edge_sync,
+            self._guard_operation_sync, self._upsert_knowledge_edge_sync,
             source_node_id,
             target_node_id,
             relation_type,
@@ -5744,7 +5824,7 @@ class MemoryStore:
         node: str = "",
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._list_knowledge_edges_sync,
+            self._guard_operation_sync, self._list_knowledge_edges_sync,
             limit,
             scope,
             session_id,
@@ -5816,7 +5896,7 @@ class MemoryStore:
         before exposing any returned evidence.
         """
         return await asyncio.to_thread(
-            self._query_knowledge_paths_sync,
+            self._guard_operation_sync, self._query_knowledge_paths_sync,
             terms,
             tag,
             node_type,
@@ -5993,7 +6073,7 @@ class MemoryStore:
         limit: int = 12,
     ) -> list[str]:
         return await asyncio.to_thread(
-            self._related_knowledge_terms_sync,
+            self._guard_operation_sync, self._related_knowledge_terms_sync,
             terms,
             scope,
             session_id,
@@ -6100,6 +6180,7 @@ class MemoryStore:
         occurred_at: str = "",
     ) -> str:
         return await asyncio.to_thread(
+            self._guard_operation_sync,
             self._add_timeline_event_sync,
             event_type,
             session_id,
@@ -6175,14 +6256,14 @@ class MemoryStore:
         return row_id
 
     async def add_historical_timeline_events(self, rows: list[dict[str, Any]]) -> dict[str, str]:
-        inserted, _ = await asyncio.to_thread(self._add_historical_timeline_events_sync, rows)
+        inserted, _ = await asyncio.to_thread(self._guard_operation_sync, self._add_historical_timeline_events_sync, rows)
         return inserted
 
     async def add_historical_timeline_events_with_status(
         self,
         rows: list[dict[str, Any]],
     ) -> tuple[dict[str, str], set[str]]:
-        return await asyncio.to_thread(self._add_historical_timeline_events_sync, rows)
+        return await asyncio.to_thread(self._guard_operation_sync, self._add_historical_timeline_events_sync, rows)
 
     def _add_historical_timeline_events_sync(
         self,
@@ -6244,7 +6325,7 @@ class MemoryStore:
         return inserted, newly_inserted
 
     async def upsert_chat_import_batch(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._upsert_chat_import_batch_sync, payload)
+        return await asyncio.to_thread(self._guard_operation_sync, self._upsert_chat_import_batch_sync, payload)
 
     def _upsert_chat_import_batch_sync(self, payload: dict[str, Any]) -> dict[str, Any]:
         batch_id = clean_text(payload.get("id"), 120)
@@ -6293,7 +6374,7 @@ class MemoryStore:
         return self._get_chat_import_batch_sync(batch_id) or {}
 
     async def get_chat_import_batch(self, batch_id: str) -> dict[str, Any] | None:
-        return await asyncio.to_thread(self._get_chat_import_batch_sync, batch_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._get_chat_import_batch_sync, batch_id)
 
     def _get_chat_import_batch_sync(self, batch_id: str) -> dict[str, Any] | None:
         with self._lock:
@@ -6309,7 +6390,7 @@ class MemoryStore:
         return result
 
     async def list_chat_import_batches(self, limit: int | None = 20) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_chat_import_batches_sync, limit)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_chat_import_batches_sync, limit)
 
     def _list_chat_import_batches_sync(self, limit: int | None) -> list[dict[str, Any]]:
         with self._lock:
@@ -6331,7 +6412,7 @@ class MemoryStore:
         return results
 
     async def update_chat_import_batch(self, batch_id: str, **changes: Any) -> dict[str, Any] | None:
-        return await asyncio.to_thread(self._update_chat_import_batch_sync, batch_id, changes)
+        return await asyncio.to_thread(self._guard_operation_sync, self._update_chat_import_batch_sync, batch_id, changes)
 
     def _update_chat_import_batch_sync(self, batch_id: str, changes: dict[str, Any]) -> dict[str, Any] | None:
         allowed = {
@@ -6355,7 +6436,7 @@ class MemoryStore:
         return self._get_chat_import_batch_sync(batch_id)
 
     async def replace_chat_import_segments(self, batch_id: str, segments: list[dict[str, Any]]) -> int:
-        return await asyncio.to_thread(self._replace_chat_import_segments_sync, batch_id, segments)
+        return await asyncio.to_thread(self._guard_operation_sync, self._replace_chat_import_segments_sync, batch_id, segments)
 
     def _replace_chat_import_segments_sync(self, batch_id: str, segments: list[dict[str, Any]]) -> int:
         batch_id = clean_text(batch_id, 120)
@@ -6386,7 +6467,7 @@ class MemoryStore:
         return len(segments)
 
     async def chat_import_segments(self, batch_id: str, *, statuses: set[str] | None = None) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._chat_import_segments_sync, batch_id, statuses)
+        return await asyncio.to_thread(self._guard_operation_sync, self._chat_import_segments_sync, batch_id, statuses)
 
     def _chat_import_segments_sync(self, batch_id: str, statuses: set[str] | None) -> list[dict[str, Any]]:
         params: list[Any] = [clean_text(batch_id, 120)]
@@ -6409,7 +6490,7 @@ class MemoryStore:
         return results
 
     async def update_chat_import_segment(self, segment_id: str, **changes: Any) -> bool:
-        return await asyncio.to_thread(self._update_chat_import_segment_sync, segment_id, changes)
+        return await asyncio.to_thread(self._guard_operation_sync, self._update_chat_import_segment_sync, segment_id, changes)
 
     def _update_chat_import_segment_sync(self, segment_id: str, changes: dict[str, Any]) -> bool:
         allowed = {"status", "attempts", "result", "summary_memory_id", "error"}
@@ -6428,10 +6509,10 @@ class MemoryStore:
         return cur.rowcount > 0
 
     async def rollback_chat_import_batch(self, batch_id: str) -> dict[str, int]:
-        return await asyncio.to_thread(self._rollback_chat_import_batch_sync, batch_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._rollback_chat_import_batch_sync, batch_id)
 
     async def chat_import_memory_counts(self, batch_id: str) -> dict[str, int]:
-        return await asyncio.to_thread(self._chat_import_memory_counts_sync, batch_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._chat_import_memory_counts_sync, batch_id)
 
     def _chat_import_memory_counts_sync(self, batch_id: str) -> dict[str, int]:
         with self._lock:
@@ -6452,7 +6533,7 @@ class MemoryStore:
         bot_id: str,
     ) -> bool:
         return await asyncio.to_thread(
-            self._private_memory_context_exists_sync,
+            self._guard_operation_sync, self._private_memory_context_exists_sync,
             session_id,
             user_id,
             bot_id,
@@ -6468,7 +6549,7 @@ class MemoryStore:
         exclude_import_batch_id: str = "",
     ) -> bool:
         return await asyncio.to_thread(
-            self._private_memory_context_exists_sync,
+            self._guard_operation_sync, self._private_memory_context_exists_sync,
             session_id,
             user_id,
             bot_id,
@@ -6550,7 +6631,7 @@ class MemoryStore:
         backup_path: str = "",
     ) -> dict[str, int]:
         return await asyncio.to_thread(
-            self._rebind_chat_import_batch_sync,
+            self._guard_operation_sync, self._rebind_chat_import_batch_sync,
             batch_id,
             session_id,
             platform,
@@ -6999,7 +7080,7 @@ class MemoryStore:
         entity_links: dict[str, dict[str, dict[str, str]]] | None = None,
     ) -> dict[str, int]:
         return await asyncio.to_thread(
-            self._repair_chat_import_identity_links_sync,
+            self._guard_operation_sync, self._repair_chat_import_identity_links_sync,
             batch_id,
             session_id,
             entity_links or {},
@@ -7108,7 +7189,7 @@ class MemoryStore:
         }
 
     async def neutralize_chat_import_summary_perspective(self, batch_id: str) -> dict[str, int]:
-        return await asyncio.to_thread(self._neutralize_chat_import_summary_perspective_sync, batch_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._neutralize_chat_import_summary_perspective_sync, batch_id)
 
     def _neutralize_chat_import_summary_perspective_sync(self, batch_id: str) -> dict[str, int]:
         batch_id = clean_text(batch_id, 120)
@@ -7189,7 +7270,7 @@ class MemoryStore:
         detail_schema_version: int,
     ) -> dict[str, int]:
         return await asyncio.to_thread(
-            self._update_chat_import_summary_detail_sync,
+            self._guard_operation_sync, self._update_chat_import_summary_detail_sync,
             memory_id,
             detailed_summary,
             canonical_summary,
@@ -7272,7 +7353,7 @@ class MemoryStore:
         detail_schema_version: int,
     ) -> dict[str, int]:
         return await asyncio.to_thread(
-            self._update_chat_import_daily_digest_sync,
+            self._guard_operation_sync, self._update_chat_import_daily_digest_sync,
             batch_id,
             date,
             detailed_summary,
@@ -7455,7 +7536,7 @@ class MemoryStore:
         offset: int = 0,
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._recent_timeline_sync,
+            self._guard_operation_sync, self._recent_timeline_sync,
             limit,
             scope,
             session_id,
@@ -7546,7 +7627,7 @@ class MemoryStore:
         limit: int = 48,
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._recent_cross_window_timeline_sync,
+            self._guard_operation_sync, self._recent_cross_window_timeline_sync,
             source_scope,
             current_session_id,
             since_at,
@@ -7591,7 +7672,7 @@ class MemoryStore:
         entity_id: str = "",
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._timeline_window_sync,
+            self._guard_operation_sync, self._timeline_window_sync,
             start_at,
             end_at,
             limit,
@@ -7668,7 +7749,7 @@ class MemoryStore:
         after_timeline_id: str = "",
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._unsummarized_timeline_window_sync,
+            self._guard_operation_sync, self._unsummarized_timeline_window_sync,
             session_id,
             scope,
             limit,
@@ -7734,7 +7815,7 @@ class MemoryStore:
         }
 
     async def mark_timeline_summarized(self, event_ids: list[str]) -> int:
-        return await asyncio.to_thread(self._mark_timeline_summarized_sync, event_ids)
+        return await asyncio.to_thread(self._guard_operation_sync, self._mark_timeline_summarized_sync, event_ids)
 
     def _mark_timeline_summarized_sync(self, event_ids: list[str]) -> int:
         ids = [clean_text(event_id, 120) for event_id in event_ids if clean_text(event_id, 120)]
@@ -7750,7 +7831,7 @@ class MemoryStore:
         return int(cur.rowcount or 0)
 
     async def get_summary_failure(self, session_id: str) -> dict[str, Any] | None:
-        return await asyncio.to_thread(self._get_summary_failure_sync, session_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._get_summary_failure_sync, session_id)
 
     def _get_summary_failure_sync(self, session_id: str) -> dict[str, Any] | None:
         with self._lock:
@@ -7775,7 +7856,7 @@ class MemoryStore:
         metadata: dict[str, Any] | None = None,
     ) -> int:
         return await asyncio.to_thread(
-            self._record_summary_failure_sync,
+            self._guard_operation_sync, self._record_summary_failure_sync,
             session_id,
             scope,
             start_timeline_id,
@@ -7830,11 +7911,11 @@ class MemoryStore:
         return int(row["retry_count"] if row else 1)
 
     async def clear_summary_failure(self, session_id: str) -> bool:
-        return await asyncio.to_thread(self._clear_summary_failure_sync, session_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._clear_summary_failure_sync, session_id)
 
     async def mark_summary_failure_dead_letter(self, session_id: str, max_retries: int) -> bool:
         return await asyncio.to_thread(
-            self._mark_summary_failure_dead_letter_sync,
+            self._guard_operation_sync, self._mark_summary_failure_dead_letter_sync,
             session_id,
             max_retries,
         )
@@ -7847,7 +7928,7 @@ class MemoryStore:
         state: str = "transient_cooldown",
     ) -> bool:
         return await asyncio.to_thread(
-            self._mark_summary_failure_state_sync,
+            self._guard_operation_sync, self._mark_summary_failure_state_sync,
             session_id,
             clean_text(state, 40) or "transient_cooldown",
             {
@@ -7913,7 +7994,7 @@ class MemoryStore:
         metadata: dict[str, Any] | None = None,
     ) -> str:
         return await asyncio.to_thread(
-            self._create_cross_window_thread_sync,
+            self._guard_operation_sync, self._create_cross_window_thread_sync,
             from_session,
             to_session,
             topic,
@@ -7967,7 +8048,7 @@ class MemoryStore:
         limit: int = 20,
         session_id: str = "",
     ) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_cross_window_threads_sync, status, limit, session_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_cross_window_threads_sync, status, limit, session_id)
 
     def _list_cross_window_threads_sync(
         self,
@@ -7996,7 +8077,7 @@ class MemoryStore:
         return [dict(row) for row in rows]
 
     async def update_cross_window_thread_status(self, thread_id: str, status: str) -> bool:
-        return await asyncio.to_thread(self._update_cross_window_thread_status_sync, thread_id, status)
+        return await asyncio.to_thread(self._guard_operation_sync, self._update_cross_window_thread_status_sync, thread_id, status)
 
     def _update_cross_window_thread_status_sync(self, thread_id: str, status: str) -> bool:
         with self._lock:
@@ -8018,7 +8099,7 @@ class MemoryStore:
         injection_chars: int,
     ) -> str:
         return await asyncio.to_thread(
-            self._add_injection_log_sync,
+            self._guard_operation_sync, self._add_injection_log_sync,
             session_id,
             scope,
             query,
@@ -8066,7 +8147,7 @@ class MemoryStore:
         scope: str = "",
         session_id: str = "",
     ) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._recent_injection_logs_sync, limit, scope, session_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._recent_injection_logs_sync, limit, scope, session_id)
 
     def _recent_injection_logs_sync(self, limit: int, scope: str, session_id: str) -> list[dict[str, Any]]:
         params: list[Any] = []
@@ -8238,7 +8319,7 @@ class MemoryStore:
     ) -> list[MemoryRecord]:
         """Read a small schedule-focused snapshot without waiting on the shared writer lock."""
         return await asyncio.to_thread(
-            self._list_schedule_context_memories_sync,
+            self._guard_operation_sync, self._list_schedule_context_memories_sync,
             session_id,
             user_id,
             bot_id,
@@ -8532,6 +8613,7 @@ class MemoryStore:
         Corresponds to optimization_plan.md §6.1/§6.2.
         """
         return await asyncio.to_thread(
+            self._guard_operation_sync,
             self._list_retrieval_candidate_bundle_sync,
             materialize_limit,
             current_window or {},
@@ -9054,13 +9136,13 @@ class MemoryStore:
         include_raw_events: bool = False,
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._list_memory_buckets_sync,
+            self._guard_operation_sync, self._list_memory_buckets_sync,
             limit,
             include_raw_events,
         )
 
     async def preferred_private_session_id(self, user_id: str, bot_id: str = "") -> str:
-        return await asyncio.to_thread(self._preferred_private_session_id_sync, user_id, bot_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._preferred_private_session_id_sync, user_id, bot_id)
 
     def _preferred_private_session_id_sync(self, user_id: str, bot_id: str = "") -> str:
         user_id = clean_text(user_id, 120)
@@ -9483,7 +9565,7 @@ class MemoryStore:
         enabled_only: bool = True,
     ) -> list[dict[str, Any]]:
         return await asyncio.to_thread(
-            self._list_acl_rules_sync,
+            self._guard_operation_sync, self._list_acl_rules_sync,
             owner_scope,
             owner_id,
             reader_scope,
@@ -9543,7 +9625,7 @@ class MemoryStore:
         note: str = "",
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._upsert_acl_rule_sync,
+            self._guard_operation_sync, self._upsert_acl_rule_sync,
             owner_scope,
             owner_id,
             reader_scope,
@@ -9607,7 +9689,7 @@ class MemoryStore:
         return self._acl_rule_from_row(row) if row else data
 
     async def delete_acl_rule(self, rule_id: str) -> bool:
-        return await asyncio.to_thread(self._delete_acl_rule_sync, rule_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._delete_acl_rule_sync, rule_id)
 
     def _delete_acl_rule_sync(self, rule_id: str) -> bool:
         with self._lock:
@@ -9626,7 +9708,7 @@ class MemoryStore:
         return item
 
     async def get_acl_policy(self, window_scope: str, window_id: str) -> dict[str, Any]:
-        return await asyncio.to_thread(self._get_acl_policy_sync, window_scope, window_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._get_acl_policy_sync, window_scope, window_id)
 
     def _get_acl_policy_sync(self, window_scope: str, window_id: str) -> dict[str, Any]:
         window_scope = clean_text(window_scope, 40)
@@ -9641,7 +9723,7 @@ class MemoryStore:
         return self._acl_policy_from_row(row)
 
     async def list_acl_policies(self) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_acl_policies_sync)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_acl_policies_sync)
 
     def _list_acl_policies_sync(self) -> list[dict[str, Any]]:
         with self._lock:
@@ -9659,7 +9741,7 @@ class MemoryStore:
         recall_enabled: Any = _ACL_UNSET,
     ) -> dict[str, Any]:
         return await asyncio.to_thread(
-            self._upsert_acl_policy_sync,
+            self._guard_operation_sync, self._upsert_acl_policy_sync,
             window_scope,
             window_id,
             read_mode,
@@ -10056,7 +10138,7 @@ class MemoryStore:
         emotional_delta: float = 0.0,
     ) -> bool:
         return await asyncio.to_thread(
-            self._update_memory_reaction_feedback_sync,
+            self._guard_operation_sync, self._update_memory_reaction_feedback_sync,
             memory_id,
             reaction,
             evidence,
@@ -10151,7 +10233,7 @@ class MemoryStore:
             return cur.rowcount > 0
 
     async def delete_memory(self, memory_id: str) -> bool:
-        return await asyncio.to_thread(self._delete_memory_sync, memory_id)
+        return await asyncio.to_thread(self._guard_operation_sync, self._delete_memory_sync, memory_id)
 
     def _delete_memory_sync(self, memory_id: str) -> bool:
         memory_id = clean_text(memory_id, 120)
@@ -10166,7 +10248,7 @@ class MemoryStore:
                 return cur.rowcount > 0
 
     async def update_review_status(self, memory_id: str, status: str) -> bool:
-        return await asyncio.to_thread(self._update_review_status_sync, memory_id, status)
+        return await asyncio.to_thread(self._guard_operation_sync, self._update_review_status_sync, memory_id, status)
 
     def _update_review_status_sync(self, memory_id: str, status: str) -> bool:
         memory_id = clean_text(memory_id, 120)
@@ -10330,7 +10412,7 @@ class MemoryStore:
                 return True
 
     async def approve_livingmemory_imports(self) -> dict[str, Any]:
-        return await asyncio.to_thread(self._approve_livingmemory_imports_sync)
+        return await asyncio.to_thread(self._guard_operation_sync, self._approve_livingmemory_imports_sync)
 
     def _approve_livingmemory_imports_sync(self) -> dict[str, Any]:
         now = utc_now()
@@ -10372,7 +10454,7 @@ class MemoryStore:
         }
 
     async def list_livingmemory_content_repair_candidates(self) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_livingmemory_content_repair_candidates_sync)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_livingmemory_content_repair_candidates_sync)
 
     def _list_livingmemory_content_repair_candidates_sync(self) -> list[dict[str, Any]]:
         with self._lock:
@@ -10391,7 +10473,7 @@ class MemoryStore:
         return candidates
 
     async def update_livingmemory_import_payload(self, memory_id: str, payload: dict[str, Any]) -> bool:
-        return await asyncio.to_thread(self._update_livingmemory_import_payload_sync, memory_id, payload)
+        return await asyncio.to_thread(self._guard_operation_sync, self._update_livingmemory_import_payload_sync, memory_id, payload)
 
     def _update_livingmemory_import_payload_sync(self, memory_id: str, payload: dict[str, Any]) -> bool:
         with self._lock:
@@ -10433,7 +10515,7 @@ class MemoryStore:
             return cur.rowcount > 0
 
     async def update_memory_visibility(self, memory_id: str, visibility: str) -> bool:
-        return await asyncio.to_thread(self._update_memory_visibility_sync, memory_id, visibility)
+        return await asyncio.to_thread(self._guard_operation_sync, self._update_memory_visibility_sync, memory_id, visibility)
 
     def _update_memory_visibility_sync(self, memory_id: str, visibility: str) -> bool:
         memory_id = clean_text(memory_id, 120)
@@ -10461,7 +10543,7 @@ class MemoryStore:
                 return cur.rowcount > 0
 
     async def update_memory_lifecycle(self, memory_id: str, lifecycle: str) -> bool:
-        return await asyncio.to_thread(self._update_memory_lifecycle_sync, memory_id, lifecycle)
+        return await asyncio.to_thread(self._guard_operation_sync, self._update_memory_lifecycle_sync, memory_id, lifecycle)
 
     def _update_memory_lifecycle_sync(self, memory_id: str, lifecycle: str) -> bool:
         lifecycle = clean_text(lifecycle, 40)
@@ -10479,7 +10561,7 @@ class MemoryStore:
             return cur.rowcount > 0
 
     async def maintenance_repair(self) -> dict[str, Any]:
-        return await asyncio.to_thread(self._maintenance_repair_sync)
+        return await asyncio.to_thread(self._guard_operation_sync, self._maintenance_repair_sync)
 
     def _maintenance_repair_sync(self) -> dict[str, Any]:
         with self._lock:
@@ -10567,7 +10649,7 @@ class MemoryStore:
         }
 
     async def list_decay_candidate_pool(self, limit: int = 2000) -> list[MemoryRecord]:
-        return await asyncio.to_thread(self._list_decay_candidate_pool_sync, limit)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_decay_candidate_pool_sync, limit)
 
     def _list_decay_candidate_pool_sync(self, limit: int) -> list[MemoryRecord]:
         with self._lock:
@@ -10587,7 +10669,7 @@ class MemoryStore:
         return [MemoryRecord.from_row(row) for row in rows]
 
     async def archive_raw_events_older_than(self, cutoff_at: str, limit: int = 1000) -> int:
-        return await asyncio.to_thread(self._archive_raw_events_older_than_sync, cutoff_at, limit)
+        return await asyncio.to_thread(self._guard_operation_sync, self._archive_raw_events_older_than_sync, cutoff_at, limit)
 
     def _archive_raw_events_older_than_sync(self, cutoff_at: str, limit: int) -> int:
         cutoff_at = clean_text(cutoff_at, 80)
@@ -10639,7 +10721,7 @@ class MemoryStore:
         limit: int = 2000,
     ) -> dict[str, int]:
         return await asyncio.to_thread(
-            self._prune_retained_rows_sync,
+            self._guard_operation_sync, self._prune_retained_rows_sync,
             summarized_timeline_cutoff,
             injection_log_cutoff,
             limit,
@@ -10701,7 +10783,7 @@ class MemoryStore:
         supersedes_id: str = "",
     ) -> int:
         return await asyncio.to_thread(
-            self._archive_memories_sync,
+            self._guard_operation_sync, self._archive_memories_sync,
             memory_ids,
             reason,
             supersedes_id,
@@ -10747,7 +10829,7 @@ class MemoryStore:
         return archived
 
     async def list_review_queue(self, limit: int = 20) -> list[dict[str, Any]]:
-        return await asyncio.to_thread(self._list_review_queue_sync, limit)
+        return await asyncio.to_thread(self._guard_operation_sync, self._list_review_queue_sync, limit)
 
     def _list_review_queue_sync(self, limit: int) -> list[dict[str, Any]]:
         with self._lock:
@@ -11026,7 +11108,7 @@ class MemoryStore:
         return result, next_offset, exhausted
 
     async def mark_accessed(self, memory_ids: list[str]) -> None:
-        await asyncio.to_thread(self._mark_accessed_sync, memory_ids)
+        await asyncio.to_thread(self._guard_operation_sync, self._mark_accessed_sync, memory_ids)
 
     def _mark_accessed_sync(self, memory_ids: list[str]) -> None:
         ids = [memory_id for memory_id in memory_ids if memory_id]
@@ -11048,7 +11130,7 @@ class MemoryStore:
     async def mark_injected(self, memory_ids: list[str], when: str = "") -> int:
         """Record only memories that reached the final injected context."""
 
-        return await asyncio.to_thread(self._mark_injected_sync, memory_ids, when)
+        return await asyncio.to_thread(self._guard_operation_sync, self._mark_injected_sync, memory_ids, when)
 
     def _mark_injected_sync(self, memory_ids: list[str], when: str = "") -> int:
         ids = list(
@@ -11154,7 +11236,7 @@ class MemoryStore:
         stats: dict[str, Any],
     ) -> str:
         return await asyncio.to_thread(
-            self._add_import_batch_sync, source_plugin, source_path, mode, stats
+            self._guard_operation_sync, self._add_import_batch_sync, source_plugin, source_path, mode, stats
         )
 
     def _add_import_batch_sync(

--- a/main.py
+++ b/main.py
@@ -491,4 +491,17 @@ class MemoryCompanionPlugin(Star):
         if _ACTIVE_BRIDGE is self.memory_companion:
             _ACTIVE_BRIDGE = None
         await self.service.aclose()
+        evidence = self.service.shutdown_evidence()
+        store_state = evidence.get("store") or {}
+        logger.info(
+            "[MemoryCompanion] shutdown_complete reason=terminate "
+            "background=%s summary=%s pending=%s tracked_ops=%s "
+            "read_conn_closed=%s main_conn_closed=%s",
+            evidence.get("background_tasks", 0),
+            evidence.get("summary_workers", 0),
+            evidence.get("summary_pending", 0),
+            store_state.get("tracked_ops", 0),
+            store_state.get("read_conn_closed"),
+            store_state.get("main_conn_closed"),
+        )
         logger.info("[MemoryCompanion] 我会牢牢记住你 已停止")

--- a/tests/test_exit139_shutdown.py
+++ b/tests/test_exit139_shutdown.py
@@ -1,0 +1,234 @@
+"""exit=139 (SIGSEGV) 修复的单元测试（EXIT_139_FIX_PLAN.md §5.1）。
+
+覆盖 F1（capture_async 注册）、F2（store 关闭屏障）、F3（aclose 等待
+summary workers）、F4（shutdown_complete 结构化证据）。
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+try:
+    from .package_bootstrap import bootstrap_package
+except ImportError:
+    from package_bootstrap import bootstrap_package
+
+
+ROOT = bootstrap_package()
+
+from astrbot_plugin_memory_companion.core.service import MemoryCompanionService
+from astrbot_plugin_memory_companion.core.store import MemoryStore
+
+
+def make_store() -> tuple[MemoryStore, tempfile.TemporaryDirectory]:
+    temp_dir = tempfile.TemporaryDirectory()
+    store = MemoryStore(Path(temp_dir.name) / "memory.db")
+    store.initialize()
+    return store, temp_dir
+
+
+def make_service(
+    data_dir: Path,
+) -> MemoryCompanionService:
+    return MemoryCompanionService(
+        context=None,
+        config={},
+        plugin_root=Path(ROOT),
+        data_dir=data_dir,
+    )
+
+
+class StoreCloseBarrierTests(unittest.IsolatedAsyncioTestCase):
+    """F2: close() 等待在飞操作归零，且新操作在 closing 后被拒绝。"""
+
+    def _blocking_op(self, started: threading.Event, release: threading.Event):
+        started.set()
+        release.wait(5.0)
+
+    async def test_close_with_inflight_read(self) -> None:
+        store, temp_dir = make_store()
+        self.addCleanup(temp_dir.cleanup)
+        started = threading.Event()
+        release = threading.Event()
+        # 模拟一个在飞的只读 bundle 查询（持有计数）。
+        task = asyncio.create_task(
+            asyncio.to_thread(
+                store._guard_operation_sync,
+                self._blocking_op,
+                started,
+                release,
+            )
+        )
+        await asyncio.to_thread(started.wait, 2.0)
+        self.assertTrue(started.is_set(), "在飞操作应已启动")
+        close_task = asyncio.create_task(asyncio.to_thread(store.close))
+        await asyncio.sleep(0.1)
+        self.assertFalse(close_task.done(), "close() 不应在操作在飞时提前返回")
+        release.set()
+        await asyncio.wait_for(task, timeout=10)
+        await asyncio.wait_for(close_task, timeout=10)
+        state = store.shutdown_state()
+        self.assertEqual(state["tracked_ops"], 0)
+        self.assertTrue(state["main_conn_closed"])
+
+    async def test_close_with_inflight_write(self) -> None:
+        store, temp_dir = make_store()
+        self.addCleanup(temp_dir.cleanup)
+        started = threading.Event()
+        release = threading.Event()
+        task = asyncio.create_task(
+            store._run_tracked_operation(
+                self._blocking_op,
+                started,
+                release,
+            )
+        )
+        await asyncio.to_thread(started.wait, 2.0)
+        self.assertTrue(started.is_set(), "在飞写操作应已启动")
+        close_task = asyncio.create_task(asyncio.to_thread(store.close))
+        await asyncio.sleep(0.1)
+        self.assertFalse(close_task.done(), "close() 不应在写操作在飞时提前返回")
+        release.set()
+        await asyncio.wait_for(task, timeout=10)
+        await asyncio.wait_for(close_task, timeout=10)
+        state = store.shutdown_state()
+        self.assertEqual(state["tracked_ops"], 0)
+        self.assertTrue(state["main_conn_closed"])
+
+    async def test_new_operation_rejected_after_closing(self) -> None:
+        store, temp_dir = make_store()
+        self.addCleanup(temp_dir.cleanup)
+        store._closing = True
+        with self.assertRaises(Exception):
+            await asyncio.to_thread(
+                store._guard_operation_sync,
+                lambda: None,
+            )
+        store._closing = False
+
+    async def test_recoverable_operation_under_barrier(self) -> None:
+        """F2: _run_recoverable_database_operation 路径也被关闭屏障覆盖。"""
+        store, temp_dir = make_store()
+        self.addCleanup(temp_dir.cleanup)
+        try:
+            result = await store._run_recoverable_database_operation(lambda: 42)
+            self.assertEqual(result, 42)
+            state = store.shutdown_state()
+            self.assertEqual(state["tracked_ops"], 0)
+        finally:
+            store.close()
+
+    async def test_timeline_event_under_barrier(self) -> None:
+        """F2: add_timeline_event（裸 to_thread 写路径）也受屏障保护。"""
+        store, temp_dir = make_store()
+        self.addCleanup(temp_dir.cleanup)
+        try:
+            memory_id = await store.add_timeline_event(
+                event_type="user_message",
+                session_id="s-1",
+                scope="private",
+                subject_id="u-1",
+                object_id="",
+                content="hello",
+                metadata={},
+            )
+            self.assertTrue(memory_id)
+            state = store.shutdown_state()
+            self.assertEqual(state["tracked_ops"], 0)
+        finally:
+            store.close()
+
+
+class CaptureAsyncRegistrationTests(unittest.IsolatedAsyncioTestCase):
+    """F1: 采集写入任务经 _spawn_background 注册，terminate 后可被取消。"""
+
+    def setUp(self) -> None:
+        self._store, self._temp_dir = make_store()
+        self.addCleanup(self._temp_dir.cleanup)
+        self._service = make_service(Path(self._temp_dir.name))
+
+    def tearDown(self) -> None:
+        self._service._closed = True
+        self._store.close()
+
+    async def test_spawn_background_registers_and_cleans(self) -> None:
+        async def noop() -> None:
+            return None
+        task = self._service._spawn_background(noop(), label="capture-async")
+        self.assertIsNotNone(task)
+        self.assertIn(task, self._service._background_tasks)
+        await task
+        self.assertNotIn(task, self._service._background_tasks)
+
+    async def test_aclose_cancels_background_tasks(self) -> None:
+        async def never_finishes() -> None:
+            await asyncio.Event().wait()
+        task = self._service._spawn_background(
+            never_finishes(), label="capture-async"
+        )
+        self.assertIsNotNone(task)
+        await self._service.aclose()
+        self.assertTrue(task.done())
+        self.assertEqual(len(self._service._background_tasks), 0)
+
+
+class AcloseSummaryWorkerTests(unittest.IsolatedAsyncioTestCase):
+    """F3: aclose 显式等待 _summary_workers 归零。"""
+
+    def setUp(self) -> None:
+        self._store, self._temp_dir = make_store()
+        self.addCleanup(self._temp_dir.cleanup)
+        self._service = make_service(Path(self._temp_dir.name))
+
+    def tearDown(self) -> None:
+        self._service._closed = True
+        self._store.close()
+
+    async def test_aclose_waits_summary_workers(self) -> None:
+        async def never_finishes() -> None:
+            await asyncio.Event().wait()
+        task = asyncio.create_task(never_finishes())
+        self._service._summary_workers["session-x"] = task
+        await self._service.aclose()
+        self.assertTrue(task.done())
+        self.assertEqual(len(self._service._summary_workers), 0)
+        self.assertEqual(len(self._service._summary_pending), 0)
+
+
+class ShutdownEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    """F4: shutdown_evidence / shutdown_complete 结构化证据。"""
+
+    def setUp(self) -> None:
+        self._store, self._temp_dir = make_store()
+        self.addCleanup(self._temp_dir.cleanup)
+        self._service = make_service(Path(self._temp_dir.name))
+
+    def tearDown(self) -> None:
+        self._service._closed = True
+        self._store.close()
+
+    async def test_shutdown_evidence_shape(self) -> None:
+        await self._service.aclose()
+        evidence = self._service.shutdown_evidence()
+        self.assertIn("background_tasks", evidence)
+        self.assertIn("summary_workers", evidence)
+        self.assertIn("summary_pending", evidence)
+        self.assertIn("store", evidence)
+        self.assertIsInstance(evidence["store"], dict)
+        self.assertIn("tracked_ops", evidence["store"])
+        self.assertIn("main_conn_closed", evidence["store"])
+        self.assertIn("read_conn_closed", evidence["store"])
+
+    async def test_aclose_twice_idempotent(self) -> None:
+        """连续两次 aclose 不崩、第二次 no-op。"""
+        await self._service.aclose()
+        await self._service.aclose()
+        self.assertTrue(self._service._closed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

插件在 AstrBot 执行 `disable → enable/reload` 时，存在后台任务、线程池中的 SQLite 操作与插件实例销毁/重建并发的风险。

生产环境中观察到：

- 插件 `disable` 路径通常可以正常完成
- `enable/reload` 路径可能触发容器 `exit=139`（SIGSEGV）
- 崩溃窗口位于旧实例终止后、插件新实例初始化及 SQLite 连接重建期间
- 原始版本在复现矩阵中出现高频崩溃

## 本次修改

### 1. 统一跟踪 SQLite 后台操作

在 `core/store.py` 中为 SQLite 线程池入口增加关闭屏障：

- 新增 `_guard_operation_sync`
- 跟踪正在执行的 SQLite 操作数量
- `close()` 设置 closing 状态后等待在飞操作完成
- 关闭期间拒绝启动新的数据库操作
- 覆盖普通读写、恢复路径、WAL 操作、画像/关系/时间线等数据库入口
- 共覆盖约 95 个 guard 入口

这样可以避免连接已经关闭后，线程池仍继续访问 SQLite connection。

### 2. 优化后台任务生命周期

在 `core/service.py` 中：

- 统一通过 `_spawn_background()` 注册后台任务
- 覆盖异步记忆捕获任务
- 覆盖阶段性总结任务
- 关闭时取消并等待 summary worker
- 清理 summary pending 状态，避免任务引用和状态残留

### 3. 增强插件终止流程

在 `main.py` 和 `core/service.py` 中：

- `terminate()` 使用完整的异步关闭流程
- 增加结构化 shutdown evidence
- 记录后台任务、summary worker、pending summary、tracked SQLite operation 等状态
- 输出主连接、只读连接是否已经关闭

示例日志：

```text
shutdown_complete
reason=terminate
background=0
summary=0
pending=0
tracked_ops=0
read_conn_closed=True
main_conn_closed=True
```

### 4. 降低关闭屏障热路径开销

进一步优化 `_operation_condition`：

- 正常运行期间不再每个 SQLite 操作都无条件执行 `notify_all()`
- 只有 `close()` 确实进入等待状态时，操作完成才触发通知
- 保留原有关闭等待、超时和操作栈取证逻辑

## 性能影响

本地基准对比结果：

| 操作 | 原始版本 | 加 guard 后 | 优化后 |
|---|---:|---:|---:|
| `add_timeline_event` | 0.037 ms | 0.049 ms | 0.038 ms |
| `list_candidate_memories` | 0.036 ms | 0.039 ms | 0.039 ms |
| retrieval bundle | 0.080 ms | 0.100 ms | 0.080 ms |
| 8 并发写入 | 0.193 ms | 0.240 ms | 0.189 ms |

锁竞争基准中：

- 单线程约 `0.37 μs/operation`
- 8 线程约 `1.20 μs/operation`
- 16-32 线程约 `2.0 μs/operation`

优化后，正常 SQLite 热路径的性能基本恢复到原始版本水平。

## 测试

本地测试：

```text
48 tests passed
```

覆盖：

- shutdown barrier
- store consistency
- summary concurrency
- retrieval performance
- candidate bundle
- exit=139 生命周期回归测试

新增测试文件：

```text
tests/test_exit139_shutdown.py
```

## 生产验证

在生产容器中执行 20 轮：

```text
disable → enable
```

结果：

```text
20 rounds
5 exit=139 crashes
15 successful enables
crash rate: 25%
```

崩溃轮次：

```text
1, 4, 11, 15, 18
```

每次崩溃后容器均可自动恢复，最终状态：

```text
container: Up
exit: 0
oom: false
plugin activated: true
```

## 当前结论

本 PR 完成了插件侧的生命周期和 SQLite 关闭安全增强：

- 减少后台任务残留
- 避免关闭期间启动新的 SQLite 操作
- 等待线程池中的数据库操作结束后再关闭连接
- 增加可观测的 shutdown evidence
- 降低关闭屏障对正常性能的影响

但生产验证仍能复现 `enable/reload` 阶段的 `exit=139`，因此本 PR 应定位为：

> 降低插件侧 SQLite 生命周期风险并完善关闭安全性，不能宣称已经彻底解决 AstrBot 框架 reload 时序导致的 SIGSEGV。

剩余风险可能涉及 AstrBot 核心的插件终止、模块 purge、重新 import 和新实例初始化之间的框架级时序，需要进一步在 AstrBot 核心层增加 reload 状态机或终止完成屏障。
