### PR TITLE
修复：对话总结长期记忆因 owner_bot_id 不匹配被永久误杀，恢复对话总结长期记忆召回

### DIFF
--- a/core/memory_lifecycle.py
+++ b/core/memory_lifecycle.py
@@ -106,7 +106,13 @@ def evaluate_memory_lifecycle(
 
     owner_bot_id = clean_text(_field(memory, "owner_bot_id", ""), 160)
     context_bot_id = clean_text(getattr(ctx, "bot_id", ""), 160)
-    if owner_bot_id and (not context_bot_id or owner_bot_id != context_bot_id):
+    # owner_bot_id 为 '' 或 'self' 时视为「无特定 bot owner」放行（对齐
+    # visibility._bot_owner_visible 对 'self' 的排除）。写入侧经 bridge
+    # 记录时 bot_id 可能缺失并回退为 'self'，此处避免这类记忆在检索时
+    # 因 owner_bot_mismatch 被永久剔除。
+    if owner_bot_id and owner_bot_id != "self" and (
+        not context_bot_id or owner_bot_id != context_bot_id
+    ):
         return LifecycleScore(False, "owner_bot_mismatch", 0.0, 0.0, 0.0)
     persona_id = clean_text(_field(memory, "persona_id", ""), 96)
     context_persona_id = clean_text(getattr(ctx, "persona_id", ""), 96)

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -2464,6 +2464,11 @@ class RetrievalEngine:
             }
         ):
             return "self_timeline"
+        # conversation_summary 优先归 summary 槽：避免被 open_loop 权重判定
+        # 吸进 open_loop 槽（limit=1）导致 summary 槽空置。群聊总结已在
+        # _memory_is_open_loop 内排除该判定，私聊总结同样应优先归 summary 槽。
+        if memory_type == "conversation_summary" or "summary" in tags:
+            return "conversation_summary"
         if self._memory_is_open_loop(memory, metadata):
             return "open_loop"
         if (

--- a/tests/test_owner_bot_mismatch.py
+++ b/tests/test_owner_bot_mismatch.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from .package_bootstrap import bootstrap_package
+except ImportError:
+    from package_bootstrap import bootstrap_package
+
+ROOT = bootstrap_package()
+
+from astrbot_plugin_memory_companion.core.memory_lifecycle import evaluate_memory_lifecycle
+from astrbot_plugin_memory_companion.core.models import EntityRef, MemoryRecord, SessionContext
+from astrbot_plugin_memory_companion.core.retrieval import RetrievalEngine
+from astrbot_plugin_memory_companion.core.store import MemoryStore
+from astrbot_plugin_memory_companion.core.visibility import VisibilityPolicy
+
+
+def make_engine() -> RetrievalEngine:
+    """Build a RetrievalEngine backed by a throwaway store."""
+    temp_dir = tempfile.TemporaryDirectory()
+    store = MemoryStore(Path(temp_dir.name) / "test.db")
+    store.close()
+    return RetrievalEngine(
+        store,
+        VisibilityPolicy(
+            allow_self_timeline_everywhere=True,
+            allow_group_public_in_private=False,
+            hide_pending_review=True,
+            include_raw_events=False,
+            enable_acl_rules=True,
+        ),
+        retrieval_mode="basic",
+        embedding_enabled=False,
+        knowledge_graph_enabled=False,
+    )
+
+
+class OwnerBotLifecycleTests(unittest.TestCase):
+    def ctx(self, bot_id: str = "unknown_selfid") -> SessionContext:
+        return SessionContext(
+            session_id="qq:FriendMessage:u1",
+            scope="private",
+            platform="qq",
+            user_id="u1",
+            bot_id=bot_id,
+            message_text="hi",
+        )
+
+    def summary(self, owner_bot_id: str = "") -> MemoryRecord:
+        return MemoryRecord(
+            id="summary",
+            memory_type="conversation_summary",
+            subject=EntityRef(kind="user", id="u1", name="user"),
+            object=EntityRef.bot_self("unknown_selfid"),
+            scope="private",
+            session_id="qq:FriendMessage:u1",
+            visibility="private_pair",
+            reality_level="llm_summary",
+            lifecycle="stable_memory",
+            owner_bot_id=owner_bot_id,
+            content="2026-08-27 凌晨，用户和 Bot 聊了特调配方。",
+            confidence=0.72,
+            importance=0.9,
+        )
+
+    def test_owner_bot_self_is_released_from_mismatch(self) -> None:
+        """owner_bot_id='self' 视为无特定 bot owner，不再被 owner_bot_mismatch 误杀。
+
+        背景：写入侧经 bridge 记录时 bot_id 缺失回退为 'self'，检索侧
+        ctx.bot_id 是具体值（如 'unknown_selfid'），旧逻辑会把这类记忆永久剔除。
+        """
+        lifecycle = evaluate_memory_lifecycle(self.summary(owner_bot_id="self"), self.ctx())
+        self.assertTrue(lifecycle.eligible)
+        self.assertNotIn("owner_bot_mismatch", lifecycle.reason)
+
+    def test_empty_owner_bot_is_released(self) -> None:
+        """owner_bot_id='' 同样放行。"""
+        lifecycle = evaluate_memory_lifecycle(self.summary(owner_bot_id=""), self.ctx())
+        self.assertTrue(lifecycle.eligible)
+
+    def test_other_bot_owner_still_mismatched(self) -> None:
+        """明确的其他 bot owner 仍被隔离（owner_bot_mismatch 保持生效）。"""
+        lifecycle = evaluate_memory_lifecycle(self.summary(owner_bot_id="other_bot"), self.ctx())
+        self.assertFalse(lifecycle.eligible)
+        self.assertIn("owner_bot_mismatch", lifecycle.reason)
+
+    def test_matching_owner_bot_id_still_eligible(self) -> None:
+        """owner_bot_id 与 ctx.bot_id 一致时正常放行（不破坏原有匹配逻辑）。"""
+        lifecycle = evaluate_memory_lifecycle(
+            self.summary(owner_bot_id="unknown_selfid"), self.ctx(bot_id="unknown_selfid")
+        )
+        self.assertTrue(lifecycle.eligible)
+
+
+class SummarySlotRoutingTests(unittest.TestCase):
+    def ctx(self) -> SessionContext:
+        return SessionContext(
+            session_id="qq:FriendMessage:u1",
+            scope="private",
+            platform="qq",
+            user_id="u1",
+            bot_id="unknown_selfid",
+            message_text="hi",
+        )
+
+    def test_private_summary_routes_to_summary_slot(self) -> None:
+        """私聊 conversation_summary 优先归 summary 槽，即使 promise 权重很高。
+
+        旧逻辑会被 _memory_is_open_loop（promise_weight >= 0.35）吸进 open_loop 槽
+        （limit=1），导致 summary 槽长期空置。
+        """
+        engine = make_engine()
+        memory = MemoryRecord(
+            id="summary",
+            memory_type="conversation_summary",
+            subject=EntityRef(kind="user", id="u1", name="user"),
+            object=EntityRef.bot_self("unknown_selfid"),
+            scope="private",
+            session_id="qq:FriendMessage:u1",
+            visibility="private_pair",
+            reality_level="llm_summary",
+            lifecycle="stable_memory",
+            content="用户和 Bot 聊了后续安排。",
+            confidence=0.72,
+            importance=0.9,
+            metadata={
+                "promise_weight": 0.85,
+                "open_loop_weight": 0.62,
+                "relationship_phase": "repair",
+            },
+        )
+        self.assertEqual("conversation_summary", engine._slot_for_memory(memory, self.ctx()))
+
+    def test_group_summary_routes_to_self_timeline(self) -> None:
+        """群聊总结 subject=bot，走 self_timeline 槽（原版行为，本修复不改变）。"""
+        engine = make_engine()
+        memory = MemoryRecord(
+            id="group-summary",
+            memory_type="conversation_summary",
+            subject=EntityRef.bot_self("b1", "bot"),
+            object=EntityRef(kind="group", id="g1", name="group"),
+            scope="group",
+            session_id="qq:GroupMessage:g1",
+            group_id="g1",
+            visibility="group_public",
+            reality_level="llm_summary",
+            lifecycle="stable_memory",
+            content="群成员讨论了计划。",
+            confidence=0.72,
+            importance=0.9,
+            metadata={"promise_weight": 0.8},
+        )
+        ctx = SessionContext(
+            session_id="qq:GroupMessage:g1",
+            scope="group",
+            platform="qq",
+            user_id="u1",
+            group_id="g1",
+            bot_id="b1",
+            message_text="hi",
+        )
+        self.assertEqual("self_timeline", engine._slot_for_memory(memory, ctx))
+
+    def test_promise_memory_still_routes_to_open_loop(self) -> None:
+        """非总结类的高 promise 权重记忆仍归 open_loop 槽（open_loop 判定未被破坏）。"""
+        engine = make_engine()
+        memory = MemoryRecord(
+            id="promise",
+            memory_type="observation",
+            subject=EntityRef(kind="user", id="u1", name="user"),
+            object=EntityRef.bot_self("unknown_selfid"),
+            scope="private",
+            session_id="qq:FriendMessage:u1",
+            visibility="private_pair",
+            reality_level="real_user_fact",
+            lifecycle="stable_memory",
+            content="用户承诺明天一起去买琴弦。",
+            confidence=0.7,
+            importance=0.6,
+            metadata={"promise_weight": 0.9},
+        )
+        self.assertEqual("open_loop", engine._slot_for_memory(memory, self.ctx()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题背景

`evaluate_memory_lifecycle` 的 `owner_bot_mismatch` 判定（`core/memory_lifecycle.py`）用记忆记录列 `owner_bot_id` 对比检索侧 `ctx.bot_id`，不匹配即判 `ineligible` 剔除。

实际运行中发现两条写入路径的 bot id 不一致：

- **bridge 路径**（陪伴插件通过 `record_visible_turn` 记录 bot 回复）：调用方 metadata **不带 bot_id**，memory_companion 侧 `EntityRef.bot_self('')` 回退为 `'self'`，因此写入的 conversation_summary 及 timeline bot_response 事件的 owner_bot_id 全部是 `'self'`。
- **检索侧**：部分平台（如 qqofficial C2C）的 `ctx.bot_id` 是固定占位值，与 `'self'` 不一致。

结果：**`owner_bot_id='self'` 的全部 conversation_summary 被永久误杀**——实测 08-23 之后新写入的 22 条当天对话总结注入命中率为 0%（此前一段为 91%），当天最有价值的浓缩记忆永远进不了注入包。

## 改动

### 1. `core/memory_lifecycle.py`

`owner_bot_id in {'', 'self'}` 视为「无特定 bot owner」放行（与 `visibility._bot_owner_visible` 对 `'self'` 的排除逻辑对齐）：

```python
if owner_bot_id and owner_bot_id != "self" and (
    not context_bot_id or owner_bot_id != context_bot_id
):
    return LifecycleScore(False, "owner_bot_mismatch", 0.0, 0.0, 0.0)
```

有明确 bot owner（非空且非 `'self'`）的记忆仍保持严格隔离，不受影响。

### 2. `core/retrieval.py`

私聊 `conversation_summary` **优先归 summary 槽**（在 `_memory_is_open_loop` 判定之前）：

```python
if memory_type == "conversation_summary" or "summary" in tags:
    return "conversation_summary"
```

这是顺带发现的第二个结构性问题：大量私聊总结的 metadata 权重（`promise_weight`/`open_loop_weight` 等 ≥0.35）会被 `_memory_is_open_loop` 吸进 open_loop 槽（limit=1），导致 conversation_summary 槽（limit=2）长期空置、每天最多注入 1 条总结且常是最老的。群聊总结已在 `_memory_is_open_loop` 内排除该判定，私聊总结同样应优先归 summary 槽。

## 测试

新增 `tests/test_owner_bot_mismatch.py`（7 个用例），覆盖：

- `owner_bot_id in {'', 'self'}` 放行（不再被 `owner_bot_mismatch` 误杀）；明确的其他 bot owner 仍被隔离；owner 匹配时正常放行
- 私聊 `conversation_summary`（即使 `promise_weight` 很高）归 summary 槽；非总结的高 promise 记忆仍归 open_loop 槽；群聊总结保持原行为

完整测试集：`python -m unittest discover -s tests -t .` → **568 tests OK**（基线 561 + 新增 7）。

## 验证

- 真实库检索复现（`search_by_slots`，C2C 会话）：`owner_bot_mismatch` 拦截数 66~67 → **0**
- `'self'` 总结恢复进入注入候选，summary 槽恢复填充（每轮 2~3 条，含当天最新总结）
- 兼容性：仅放宽无特定 owner（`''`/`'self'`）的记忆，有明确 bot owner 的记忆隔离不变

## 补充

`owner_bot_id` 漂移还与 bridge 调用方 `record_visible_turn` 的 metadata 不带 bot_id 有关；本 PR 从检索侧宽容修复（存量与新增均生效），调用方补 bot_id 可作为后续规范化改进。