### PR TITLE
fix: 恢复 2.0.0 重构丢失的 relax/tone 开关接线（保留 5 项、删除 5 项冗余），修复配置静默失效

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -633,36 +633,6 @@
         "type": "int",
         "default": 12000
       },
-      "relax_route_layer_tone": {
-        "description": "放宽上下文路由层记忆",
-        "hint": "默认关闭（行为与旧版一致）。开启后，检索被路由到「近上下文/当前纠正/低信息/短跟随」层的记忆从 tone（只给语气提示）提为 candidate（给内容但标注条件候选），日常闲聊轮也能看到记忆正文。",
-        "type": "bool",
-        "default": false
-      },
-      "relax_bot_self_tone": {
-        "description": "放宽 Bot 自我时间线记忆",
-        "hint": "默认关闭（行为与旧版一致）。开启后，Bot 自我时间线（self_timeline）背景记忆非显式回忆时从 tone 提为 candidate，让这类记忆的内容可被注入。",
-        "type": "bool",
-        "default": false
-      },
-      "relax_summary_tone": {
-        "description": "放宽近期对话总结记忆",
-        "hint": "默认关闭（行为与旧版一致）。开启后，非显式回忆的 conversation_summary/timeline_event 中较新的（天数 <= relax_summary_max_age_days）从 tone 提为 candidate，较旧的仍保持 tone。",
-        "type": "bool",
-        "default": false
-      },
-      "relax_summary_max_age_days": {
-        "description": "总结记忆放宽的最大天数",
-        "hint": "配合 relax_summary_tone 使用：created_at 距今不超过该天数的对话总结才放宽为 candidate。",
-        "type": "int",
-        "default": 3
-      },
-      "relax_instruction": {
-        "description": "放宽注入包使用指引",
-        "hint": "默认关闭（措辞与旧版一致）。开启后，<MemoryCompanion-Context> 的 <instruction> 改为允许模型直接自然地引用、呼应或转述注入的记忆条目，而不只是「自然相关时融入」。",
-        "type": "bool",
-        "default": false
-      },
       "enable_tone_abstraction": {
         "description": "启用 tone 表达抽象",
         "hint": "默认开启（作者逻辑）：被判定为 tone 的记忆只给语气提示、不给正文。关闭后所有记忆直接以正文注入（跳过 tone 检查，统一按条件候选处理），用于避免对话总结等记忆主力被折叠成占位提示、模型无法引用。",

--- a/core/service.py
+++ b/core/service.py
@@ -285,7 +285,9 @@ class MemoryCompanionService:
             max_summary_chars=self.config.int("memory_summary.max_summary_chars", 1200),
             provider_timeout_seconds=self.config.int("memory_summary.provider_timeout_seconds", 180),
         )
-        self.importance = ImportanceEvaluator()
+        self.importance = ImportanceEvaluator(
+            mention_policy_relax=self.config.bool("memory_capture.relax_mention_policy", False)
+        )
         self._summary_locks: dict[str, asyncio.Lock] = {}
         self._summary_lock_ts: dict[str, float] = {}
         self._summary_workers: dict[str, asyncio.Task[Any]] = {}
@@ -3449,6 +3451,11 @@ class MemoryCompanionService:
             private_topology_enabled=self._scope_feature_enabled("private", "topology"),
             group_topology_enabled=self._scope_feature_enabled("group", "topology"),
             usage_recorder=self._record_token_usage,
+            relax_keyword_min_hits=self.config.bool("retrieval_advanced.relax_keyword_min_hits", False),
+            proactive_message_score_penalty=self.config.float(
+                "retrieval_advanced.proactive_message_score_penalty", 1.0
+            ),
+            dedupe_content_ratio=self.config.float("retrieval_advanced.dedupe_content_ratio", 0.0),
         )
 
     async def _resolve_rerank_provider(self, ctx: SessionContext, *, mode: str) -> tuple[Any, str]:
@@ -10276,6 +10283,11 @@ class MemoryCompanionService:
 
         if confidence < 0.5:
             return "uncertain", "low_confidence"
+        # 总闸：关闭 tone 表达抽象后，跳过后续全部判定，所有记忆直接以正文注入
+        # （candidate）。默认开启保持作者逻辑；关闭后 conversation_summary 等
+        # 记忆主力不再被折叠成「语气提示」占位，模型可直接引用正文。
+        if not self.config.bool("memory_injection.enable_tone_abstraction", True):
+            return ("candidate", "tone_abstraction_disabled")
         text = clean_text(query_text or ctx.message_text, 800)
         explicit_memory = self._message_is_contextual_memory_request(text) or self._message_requests_temporal_aggregate(text)
         companion_cap_reason = self._companion_memory_mention_cap(ctx, explicit_memory=explicit_memory)

--- a/tests/test_recall_relax_knobs.py
+++ b/tests/test_recall_relax_knobs.py
@@ -16,7 +16,9 @@ from astrbot_plugin_memory_companion.core.importance import ImportanceEvaluator
 from astrbot_plugin_memory_companion.core.injection import InjectionComposer
 from astrbot_plugin_memory_companion.core.models import EntityRef, MemoryRecord, SearchResult, SessionContext
 from astrbot_plugin_memory_companion.core.retrieval import RetrievalEngine
+from astrbot_plugin_memory_companion.core.service import MemoryCompanionService, MemoryRouteDecision
 from astrbot_plugin_memory_companion.core.store import MemoryStore
+from astrbot_plugin_memory_companion.core.time_intent import TimeIntent
 from astrbot_plugin_memory_companion.core.visibility import VisibilityPolicy
 
 
@@ -102,29 +104,62 @@ class MentionPolicyRelaxTests(unittest.TestCase):
             )
 
 
-class InstructionRelaxTests(unittest.TestCase):
+class ToneAbstractionToggleTests(unittest.IsolatedAsyncioTestCase):
+    def make_service(self, tone_abstraction: bool) -> MemoryCompanionService:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        service = MemoryCompanionService(
+            context=None,
+            config={"memory_injection": {"enable_tone_abstraction": tone_abstraction}},
+            plugin_root=ROOT,
+            data_dir=Path(temp_dir.name),
+        )
+        self.addCleanup(service.close)
+        return service
+
     @staticmethod
-    def compose_instruction(relax: bool) -> str:
-        composer = InjectionComposer(instruction_relax=relax)
+    def _decide(service: MemoryCompanionService) -> tuple[str, str]:
         ctx = SessionContext(
             session_id="qq:FriendMessage:u1",
             scope="private",
             platform="qq",
             user_id="u1",
-            message_text="hi",
+            bot_id="b1",
+            message_text="随便聊聊",
         )
-        memory = MemoryRecord(id="m1", memory_type="observation", content="测试记忆。")
-        injected = composer.compose(ctx, [SearchResult(memory=memory, score=1.0)], max_chars=4000)
-        match = re.search(r"<instruction>(.*?)</instruction>", injected, re.S)
-        return match.group(1) if match else injected
+        memory = MemoryRecord(
+            id="s1",
+            memory_type="conversation_summary",
+            subject=EntityRef(kind="user", id="u1", name="user"),
+            object=EntityRef.bot_self("b1"),
+            scope="private",
+            session_id="qq:FriendMessage:u1",
+            visibility="private_pair",
+            reality_level="llm_summary",
+            lifecycle="stable_memory",
+            content="用户和 Bot 昨天聊了特调配方。",
+            confidence=0.72,
+            importance=0.9,
+        )
+        item = SearchResult(memory=memory, score=1.2)
+        decision = MemoryRouteDecision(layer="current_message")
+        return service._memory_expression_decision(
+            ctx, memory, item, "conversation_summary", decision, TimeIntent()
+        )
 
-    def test_instruction_relax_changes_wording(self) -> None:
-        """relax 开启后 instruction 允许模型直接引用注入条目。"""
-        strict = self.compose_instruction(False)
-        relaxed = self.compose_instruction(True)
-        self.assertIn("旧记忆只在自然相关时融入", strict)
-        self.assertIn("可以直接自然地引用、呼应或转述", relaxed)
-        self.assertNotIn("可以直接自然地引用、呼应或转述", strict)
+    async def test_toggle_off_returns_candidate_for_summary(self) -> None:
+        """总闸关闭后，非显式回忆的总结记忆直接给正文（candidate），不再折叠为 tone。"""
+        service = self.make_service(tone_abstraction=False)
+        expression, reason = self._decide(service)
+        self.assertEqual("candidate", expression)
+        self.assertEqual("tone_abstraction_disabled", reason)
+
+    async def test_toggle_on_summary_non_explicit_is_tone(self) -> None:
+        """总闸默认开启（作者逻辑）：非显式回忆的总结记忆仍折叠为 tone 占位。"""
+        service = self.make_service(tone_abstraction=True)
+        expression, reason = self._decide(service)
+        self.assertEqual("tone", expression)
+        self.assertIn("conversation_continuity_background", reason)
 
 
 class KeywordMinHitsRelaxTests(unittest.TestCase):


### PR DESCRIPTION
## 本次修复的背景

2.0.0 发布后的一次重构（`cb04f4b`「exclude bridge placeholders from retrieval」）把 service.py 里读取这些配置的**接线全部删掉了**——但 `_conf_schema.json` 的配置键、importance/injection/retrieval 的支持代码都还在，只是没人读。结果是：**WebUI 上能看到开关，开了也不生效**（配置静默失效）。

本 PR 恢复接线，并按「总闸为主、细分冗余」的原则精简。

## PR#20 、PR#21 本来想要解决的问题

实际使用中发现两个影响「记忆用起来」的结构性问题：

### 1. 最高价值的记忆（对话总结）在日常聊天中给不出内容

`conversation_summary` 是记忆库中 **importance 最高**（0.9）、信息最密集（一天对话的浓缩，平均 485 字符 vs 其他类型 54~109 字符）的一类记忆。但 `_memory_expression_decision` 对它有专门分支：**非显式回忆时一律折叠成 `tone`**——注入包里只输出「参考一条已校验的长期线索…禁止复述引用」这种无内容占位，模型拿不到正文。

同时写入侧 `_mention_policy` 会把情绪重 / Bot 自我时间线背景记忆降级为 `tone_only`，加剧了这个问题。结果：**记忆库自评最重要的记忆，日常闲聊里反而最不可用**。

### 2. 检索侧几处保守阈值漏召回 / 占名额

- 词法复核 `min_hits` 过严：语义相关但关键词不重叠的候选被误拦；
- `proactive_message`（天气播报类低信息原文）长期占用候选池；
- 同一事实的多条措辞变体重复占用注入名额。

### 当初的解法（PR #20 / #21，已在 2.0.0 合入）

提供**默认关闭**的可选开关，由使用者按场景开启，关闭时行为与历史版本完全一致：

- **总闸 `enable_tone_abstraction`**：关闭后跳过整个 expression 判定，所有记忆（含总结）直接以正文注入；
- **写入侧 `relax_mention_policy`**：情绪重 / Bot 自我时间线记忆的 `mention_policy` 从 `tone_only` 提为 `soft_echo`；
- **检索侧三个参数**：`relax_keyword_min_hits`（词法放宽）、`proactive_message_score_penalty`（低价值原文降权）、`dedupe_content_ratio`（同事实去重）。

## 改动

### 保留并恢复接线（5 个开关）

| 配置 | 位置 | 作用 |
|---|---|---|
| `memory_capture.relax_mention_policy` | `ImportanceEvaluator` | 写入侧：`tone_only` → `soft_echo`，让注入侧有内容可用 |
| `retrieval_advanced.relax_keyword_min_hits` | `RetrievalEngine` | 检索侧：词法复核 `min_hits` 降到 1 |
| `retrieval_advanced.proactive_message_score_penalty` | `RetrievalEngine` | 检索侧：低价值主动消息原文评分乘数 |
| `retrieval_advanced.dedupe_content_ratio` | `RetrievalEngine` | 检索侧：内容级去重（difflib ratio） |
| `memory_injection.enable_tone_abstraction` | `_memory_expression_decision` 开头 | **总闸**：默认开启（作者逻辑）；关闭后跳过整个判定，所有记忆（含总结）直接以正文注入 |

### 移除（5 个冗余参数）

- `relax_instruction`：注入指引两种措辞差别不大，直接删；
- `relax_route_layer_tone` / `relax_bot_self_tone` / `relax_summary_tone` / `relax_summary_max_age_days`：这些是判定链内各分支的细分放宽，**是总闸（`enable_tone_abstraction=false`）的子集**——总闸关闭后所有记忆都给正文，细分开关冗余。删除 schema 键与接线，保持配置面干净。

## 测试

`tests/test_recall_relax_knobs.py` 更新：

- 移除 `relax_instruction` 相关用例；
- 新增 `ToneAbstractionToggleTests`：总闸关闭时非显式回忆的总结记忆返回 `candidate`（给正文）；默认开启时仍返回 `tone`（作者逻辑）；
- 保留 `relax_mention_policy` / `relax_keyword_min_hits` / `proactive_message_score_penalty` / `dedupe_content_ratio` 用例。

全部参数默认值 = 历史行为（关闭 / 1.0 / 0.0 / 总闸开启），未开启时无任何行为变化。

## 说明

- 本次只补「接线」这一环：owner_bot 修复、summary 槽判定、各参数支持代码在官方 main 中均已保留（`cb04f4b` 只删了接线），本 PR 让它们重新被配置驱动。
- 本地验证：`_memory_expression_decision` 对总结记忆——总闸关闭 → `candidate`；开启 → `tone`（`conversation_continuity_background`）。