### PR TITLE
feat: 注入单条记忆内容上限参数化（memory_injection.max_item_chars，默认 220 保持原行为）

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -597,6 +597,12 @@
         "type": "int",
         "default": 1800
       },
+      "max_item_chars": {
+        "description": "单条记忆内容上限",
+        "hint": "每条注入记忆的内容最多保留多少字符（默认 220）。对话总结等长记忆默认会被截断到该上限、细节需靠 navigate/recall 工具补；若工具使用率低、希望注入里保留更多原文可调大（注入包总长仍受「最大注入字数」限制）。",
+        "type": "int",
+        "default": 220
+      },
       "temporal_aggregate_max_chars": {
         "description": "时间聚合注入字数",
         "hint": "当用户问最近一周、最近几天、本周这类需要汇总多条记忆的问题时使用。默认更宽，且会用精简证据格式注入。",

--- a/core/injection.py
+++ b/core/injection.py
@@ -44,6 +44,7 @@ class InjectionComposer:
         included_memory_ids: list[str] | None = None,
         core_memories: list[MemoryRecord] | None = None,
         core_memory_max_chars: int = 800,
+        max_item_chars: int = 220,
     ) -> str:
         results, slot_sections = self._filter_injection_results(results, slot_sections)
         core_memories = list(core_memories or [])
@@ -191,6 +192,7 @@ class InjectionComposer:
             inner_limit=inner_limit,
             short_rest_check=bool(rest_check_hint),
             included_memory_ids=included_memory_ids,
+            max_item_chars=max_item_chars,
         )
         if memory_lines:
             lines.extend(memory_lines)
@@ -304,6 +306,7 @@ class InjectionComposer:
         inner_limit: int,
         short_rest_check: bool = False,
         included_memory_ids: list[str] | None = None,
+        max_item_chars: int = 220,
     ) -> list[str]:
         if short_rest_check:
             return self._build_short_rest_memory_lines(
@@ -364,7 +367,10 @@ class InjectionComposer:
         memory_lines: list[str] = []
         total_items = max(1, sum(len(items) for items in grouped.values()))
         available = max(0, inner_limit - len("\n".join([*base_lines, *closing_lines])))
-        detail_limit = max(32, min(220, available // total_items - 42))
+        # 单条记忆内容上限可配置（memory_injection.max_item_chars，默认 220）：
+        # 作者原意是按「内心提示」级信息量截断、细节由 navigate/recall 工具补；
+        # 对 summary 等长记忆，若工具使用率低则截断信息会丢失，调大该上限可减少截断。
+        detail_limit = max(32, min(max(1, max_item_chars), available // total_items - 42))
 
         def fits(candidate: list[str]) -> bool:
             return len("\n".join([*base_lines, *candidate, *closing_lines])) <= inner_limit

--- a/core/service.py
+++ b/core/service.py
@@ -2554,6 +2554,7 @@ class MemoryCompanionService:
                 max_chars or self.config.int("memory_injection.max_chars", 1800),
                 core_memories=core_memories,
                 core_memory_max_chars=core_memory_max_chars,
+                max_item_chars=self.config.int("memory_injection.max_item_chars", 220),
             )
 
         schedule_types = {"schedule_fragment", "persona_life", "companion_note"}
@@ -2691,6 +2692,7 @@ class MemoryCompanionService:
                 max_chars or self.config.int("memory_injection.max_chars", 1800),
                 core_memories=core_memories,
                 core_memory_max_chars=core_memory_max_chars,
+                max_item_chars=self.config.int("memory_injection.max_item_chars", 220),
             )
 
         slot_map: dict[str, list[SearchResult]] = {"self_timeline": [], "user_profile": []}
@@ -2740,6 +2742,7 @@ class MemoryCompanionService:
             address_hint="" if outfit_focus else self._address_hint_for_injection(ctx),
             core_memories=core_memories,
             core_memory_max_chars=core_memory_max_chars,
+            max_item_chars=self.config.int("memory_injection.max_item_chars", 220),
         )
         logger.info(
             "[MemoryCompanion] %s快速上下文已生成: session=%s candidates=%s selected=%s chars=%s elapsed_ms=%s",
@@ -7474,6 +7477,7 @@ class MemoryCompanionService:
                 core_memories=core_memories,
                 core_memory_max_chars=core_memory_max_chars,
                 included_memory_ids=static_included_memory_ids,
+                max_item_chars=self.config.int("memory_injection.max_item_chars", 220),
             )
 
         if decision.suppress_long_memory:
@@ -7633,6 +7637,7 @@ class MemoryCompanionService:
             included_memory_ids=included_memory_ids,
             core_memories=core_memories,
             core_memory_max_chars=core_memory_max_chars,
+            max_item_chars=self.config.int("memory_injection.max_item_chars", 220),
         )
         injection_omissions, _diagnostic_included_memory_ids = self.injection.diagnostic_snapshot()
         blocked.extend(injection_omissions)
@@ -7828,6 +7833,7 @@ class MemoryCompanionService:
                     core_memories=core_memories,
                     core_memory_max_chars=core_memory_max_chars,
                     included_memory_ids=actual_injected_memory_ids,
+                    max_item_chars=self.config.int("memory_injection.max_item_chars", 220),
                 )
             self._log_injection_debug(
                 ctx=ctx,
@@ -7997,6 +8003,7 @@ class MemoryCompanionService:
             included_memory_ids=actual_injected_memory_ids,
             core_memories=core_memories,
             core_memory_max_chars=core_memory_max_chars,
+            max_item_chars=self.config.int("memory_injection.max_item_chars", 220),
         )
         injection_omissions, _diagnostic_included_memory_ids = self.injection.diagnostic_snapshot()
         blocked.extend(injection_omissions)


### PR DESCRIPTION
## 背景

注入包的每条记忆内容上限 `detail_limit = max(32, min(220, available // total_items - 42))` 中 **220 是硬编码**（`core/injection.py`）。

对话总结（conversation_summary）等长记忆默认被截断到该上限：
- 普通轮：summary 条目 94% 顶满 220 字符（约只保留 key_facts 前 2~3 条）
- 时间聚合轮（用户问「最近一周/这几天」）：条目 11\~14 条，单条上限掉到 32~144 字符，一条总结只剩 ~1 条关键事实的 60%

原设计假设「截断的细节模型可按需调 navigate/recall 工具补」，但在工具使用率低的场景（实测 500+ 用户轮次记忆工具仅调用 2 次），截断信息会真实丢失——模型对一条记忆的认知只有注入包里的片段。

## 改动

- `core/injection.py`：`InjectionComposer.compose` / `_build_grouped_memory_lines` 增加 `max_item_chars` 参数（默认 220），`detail_limit` 用参数替换 220 硬编码（保留 32 下限）
- `core/service.py`：7 处 `injection.compose` 调用统一传入配置值
- `_conf_schema.json`：`memory_injection` 组新增 `max_item_chars`（WebUI 可配）

## 兼容性

- 默认值 220 = 原行为，零改动用户不受影响
- 注入包总长仍受 `memory_injection.max_chars` 约束；调大 `max_item_chars` 只影响单条内容上限（`min(max_item_chars, available//total_items - 42)` 仍按预算均分）
- 建议值 360~480：summary 条目可保留约 2~4 条完整 key_fact，聚合轮截断明显缓解

## 验证

- `py_compile` 通过；`_conf_schema.json` JSON 校验通过
- 注入相关测试 `test_memory_v2_injection_feedback` 9/9 通过
- 全量测试失败项均为环境既有问题（UI backend contract / panel / exit139，与本次改动无关，stash 基线对比确认）