### PR TITLE
fix: defer background task spawn during startup grace period (avoid SQLAlchemy deque race on AstrBot 4.27.4)

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -244,6 +244,15 @@ class MemoryCompanionService:
         self.plugin_root = Path(plugin_root)
         self.data_dir = Path(data_dir)
 
+        # 启动宽限期：插件加载后的前 N 秒内暂缓创建任何后台任务，
+        # 避开 AstrBot 核心加载完插件后执行的 SQLAlchemy 连接池迁移窗口，
+        # 防止插件后台线程的高频 DB 并发撞上核心 deque 迭代（RuntimeError: deque mutated during iteration）。
+        self._service_created_at = time.monotonic()
+        self._background_grace_seconds = max(
+            0,
+            self.config.int("startup.background_grace_seconds", 60),
+        )
+
         self.store = MemoryStore(self.data_dir / "memory_companion.db")
         try:
             self.store.initialize()
@@ -3908,6 +3917,20 @@ class MemoryCompanionService:
             if callable(close):
                 close()
             return None
+        # 启动宽限期屏障：核心迁移窗口内不真正创建后台任务，避免并发 DB 风暴。
+        if self._background_grace_seconds > 0:
+            elapsed = time.monotonic() - self._service_created_at
+            if elapsed < self._background_grace_seconds:
+                close = getattr(coro, "close", None)
+                if callable(close):
+                    close()
+                logger.debug(
+                    "[MemoryCompanion] 启动宽限期内暂缓后台任务 %s (%.0fs/%.0fs)",
+                    label,
+                    elapsed,
+                    self._background_grace_seconds,
+                )
+                return None
         try:
             task = asyncio.create_task(coro, name=f"memory_companion:{label}")
         except RuntimeError:


### PR DESCRIPTION
## 背景（Background）

AstrBot 4.27.4 在**加载完所有插件后**执行 `_migrate_legacy_plugin_tool_inactivation_state`（`star_manager.py:956`，SQLAlchemy 连接池迁移）。而本插件在 `initialize()` 中**立即**通过 `_spawn_background` 创建多个后台任务（lifecycle-maintenance 调度、portrait-daily 调度等）。

这些后台任务在核心迁移查询的 `await` 间隙抢到事件循环控制权，开始高频并发 DB 操作，撞上核心 SQLAlchemy 连接池的 event-listener deque 迭代，触发：

```
RuntimeError: deque mutated during iteration
（崩溃点：sqlalchemy/pool/impl.py _do_get）
```

单独跑核心或插件都不崩，**插件 + 4.27.4 启动时序**组合必崩（复现 3 次）。核心引入了新触发窗口，本插件提供了病态并发源 —— 各打五十大板，本 PR 从插件侧消除并发源。

## 改动（Changes）

在 `_spawn_background`（**所有后台任务的唯一创建入口**）加一个**启动宽限期屏障**：

- 插件 Service 创建后的前 N 秒内（默认 **60s**），`_spawn_background` 直接关闭协程并返回 `None`，**不创建后台任务**
- 宽限期过后（或下一条消息触发 `_ensure_*` 时），后台调度**自动正常启动** —— 幂等的 `_ensure_*` 保证自愈，不丢任何调度
- 可通过配置 `startup.background_grace_seconds` 调整，设 `0` 即恢复旧行为

只改了 1 个文件，净增 23 行。

## 验证（Testing）

搭建独立测试实例（无 AstrBot 环境直接加载 core 包），三个场景全部通过：

1. **宽限期窗口内 initialize()** → 后台任务被屏障拦截（`maintenance=None, portrait=None`），避开核心迁移窗口 ✅
2. **宽限期过后再次触发** → 后台任务正常创建（自愈机制生效）✅
3. **禁用宽限期（=0）** → 行为与旧版完全一致（兼容性）✅

`python3 -m py_compile` 语法检查通过；所有 `_spawn_background` 调用方对 `None` 返回值本就有兜底（`if task is not None` / `if task is None: return`），无需额外改动。
