### PR TITLE
perf: 选择性整合 PR29 已验证优化

### DIFF
--- a/core/audit.py
+++ b/core/audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 import hashlib
 import json
 import os
@@ -607,4 +608,5 @@ class MemoryAuditManager:
 
     @staticmethod
     def _public_batch(batch: dict[str, Any]) -> dict[str, Any]:
-        return json.loads(json.dumps(batch, ensure_ascii=False))
+        # 深拷贝防止调用方修改原始数据；JSON 往返是多余的序列化开销。
+        return deepcopy(batch)

--- a/core/operations.py
+++ b/core/operations.py
@@ -17,6 +17,7 @@ PORTABLE_FORMAT = "astrbot-memory-jsonl"
 PORTABLE_VERSION = 1
 MAX_PORTABLE_BYTES = 64 * 1024 * 1024
 PORTABLE_EXPORT_PAGE_SIZE = 500
+PORTABLE_IMPORT_BATCH_SIZE = 200
 
 
 PRESETS: dict[str, dict[str, Any]] = {
@@ -395,6 +396,7 @@ class PortableMemoryArchive:
         imported: Counter[str] = Counter()
         skipped: Counter[str] = Counter()
         errors: list[str] = []
+        ops: list[dict[str, Any]] = []
         for index, item in enumerate(records, start=2):
             kind = clean_text(item.get("record_type"), 40)
             data = item.get("data")
@@ -402,93 +404,32 @@ class PortableMemoryArchive:
                 skipped[kind or "unknown"] += 1
                 continue
             try:
-                if kind == "memory":
-                    record = self._memory_record(data, batch_id)
-                    if not record.content:
-                        skipped[kind] += 1
-                        continue
-                    await self.store.insert_memory(record)
-                elif kind == "identity":
-                    await self.store.upsert_identity(
-                        platform=clean_text(data.get("platform"), 80),
-                        entity=EntityRef(
-                            kind=clean_text(data.get("entity_kind"), 40) or "user",
-                            id=clean_text(data.get("entity_id"), 120),
-                            name=clean_text(data.get("display_name"), 80),
-                            role=clean_text(data.get("role"), 80) or "unknown",
-                        ),
-                        aliases=self._list(data.get("aliases")),
-                        profile=self._dict(data.get("profile")),
-                        confidence=self._float(data.get("confidence"), 0.6),
-                    )
-                elif kind == "relationship":
-                    await self.store.upsert_relationship(
-                        subject=EntityRef(
-                            kind=clean_text(data.get("subject_kind"), 40),
-                            id=clean_text(data.get("subject_id"), 120),
-                            name=clean_text(data.get("subject_name"), 80),
-                        ),
-                        object=EntityRef(
-                            kind=clean_text(data.get("object_kind"), 40),
-                            id=clean_text(data.get("object_id"), 120),
-                            name=clean_text(data.get("object_name"), 80),
-                        ),
-                        relation_type=clean_text(data.get("relation_type"), 80),
-                        scope=clean_text(data.get("scope"), 40),
-                        session_id=clean_text(data.get("session_id"), 200),
-                        group_id=clean_text(data.get("group_id"), 120),
-                        visibility=clean_text(data.get("visibility"), 40) or "internal",
-                        evidence=clean_text(data.get("evidence"), 1000),
-                        confidence=self._float(data.get("confidence"), 0.6),
-                        review_status=clean_text(data.get("review_status"), 40) or "auto",
-                        source_memory_id=clean_text(data.get("source_memory_id"), 120),
-                        metadata=self._dict(data.get("metadata")),
-                    )
-                elif kind == "timeline":
-                    metadata = self._dict(data.get("metadata"))
-                    metadata.setdefault("message_id", clean_text(data.get("message_id") or data.get("id"), 120))
-                    metadata["portable_import_batch_id"] = batch_id
-                    timeline_id = await self.store.add_timeline_event(
-                        event_type=clean_text(data.get("event_type"), 80),
-                        session_id=clean_text(data.get("session_id"), 200),
-                        scope=clean_text(data.get("scope"), 40),
-                        subject_id=clean_text(data.get("subject_id"), 120),
-                        object_id=clean_text(data.get("object_id"), 120),
-                        content=clean_text(data.get("content"), 4000),
-                        metadata=metadata,
-                        occurred_at=clean_text(data.get("occurred_at"), 80),
-                    )
-                    if clean_text(data.get("summarized_at"), 80):
-                        await self.store.mark_timeline_summarized([timeline_id])
-                elif kind == "acl_rule":
-                    await self.store.upsert_acl_rule(
-                        owner_scope=clean_text(data.get("owner_scope"), 40),
-                        owner_id=clean_text(data.get("owner_id"), 160),
-                        reader_scope=clean_text(data.get("reader_scope"), 40),
-                        reader_id=clean_text(data.get("reader_id"), 160),
-                        effect=clean_text(data.get("effect"), 20) or "allow",
-                        enabled=bool(data.get("enabled", True)),
-                        note=clean_text(data.get("note"), 300),
-                    )
-                elif kind == "acl_policy":
-                    policy_values = {
-                        "window_scope": clean_text(data.get("window_scope"), 40),
-                        "window_id": clean_text(data.get("window_id"), 160),
-                        "read_mode": clean_text(data.get("read_mode"), 20),
-                        "share_mode": clean_text(data.get("share_mode"), 20),
-                    }
-                    for feature in ("capture_enabled", "recall_enabled"):
-                        if feature in data:
-                            policy_values[feature] = data.get(feature)
-                    await self.store.upsert_acl_policy(**policy_values)
-                else:
-                    skipped[kind or "unknown"] += 1
-                    continue
-                imported[kind] += 1
+                op = self._import_operation(kind, data, batch_id)
             except Exception as exc:
                 skipped[kind or "unknown"] += 1
                 if len(errors) < 20:
                     errors.append(f"line {index}: {type(exc).__name__}: {clean_text(exc, 180)}")
+                continue
+            if op is None:
+                skipped[kind or "unknown"] += 1
+                continue
+            op["line"] = index
+            ops.append(op)
+        # 批量写入：分批单事务一次 commit，避免每条记录一个独立事务 + fsync。
+        for start in range(0, len(ops), PORTABLE_IMPORT_BATCH_SIZE):
+            chunk = ops[start : start + PORTABLE_IMPORT_BATCH_SIZE]
+            results = await self.store.import_batch_ops(chunk)
+            for op, result in zip(chunk, results):
+                op_kind = op["kind"]
+                if result.get("ok"):
+                    imported[op_kind] += 1
+                    continue
+                skipped[op_kind] += 1
+                if len(errors) < 20:
+                    code = result.get("code") or "import_op_error"
+                    message = clean_text(result.get("error"), 180)
+                    detail = f": {message}" if message else ""
+                    errors.append(f"line {op.get('line')}: {code}{detail}")
         return {
             "path": str(Path(path).expanduser().resolve()),
             "backup": str(backup),
@@ -497,6 +438,101 @@ class PortableMemoryArchive:
             "skipped": dict(skipped),
             "errors": errors,
         }
+
+    def _import_operation(
+        self, kind: str, data: dict[str, Any], batch_id: str
+    ) -> dict[str, Any] | None:
+        """把一条导入记录转换为批量写入 op；无法导入的记录返回 None。"""
+        if kind == "memory":
+            record = self._memory_record(data, batch_id)
+            if not record.content:
+                return None
+            return {"kind": "memory", "record": record}
+        if kind == "identity":
+            return {
+                "kind": "identity",
+                "params": {
+                    "platform": clean_text(data.get("platform"), 80),
+                    "entity": EntityRef(
+                        kind=clean_text(data.get("entity_kind"), 40) or "user",
+                        id=clean_text(data.get("entity_id"), 120),
+                        name=clean_text(data.get("display_name"), 80),
+                        role=clean_text(data.get("role"), 80) or "unknown",
+                    ),
+                    "aliases": self._list(data.get("aliases")),
+                    "profile": self._dict(data.get("profile")),
+                    "confidence": self._float(data.get("confidence"), 0.6),
+                },
+            }
+        if kind == "relationship":
+            return {
+                "kind": "relationship",
+                "params": {
+                    "subject": EntityRef(
+                        kind=clean_text(data.get("subject_kind"), 40),
+                        id=clean_text(data.get("subject_id"), 120),
+                        name=clean_text(data.get("subject_name"), 80),
+                    ),
+                    "object": EntityRef(
+                        kind=clean_text(data.get("object_kind"), 40),
+                        id=clean_text(data.get("object_id"), 120),
+                        name=clean_text(data.get("object_name"), 80),
+                    ),
+                    "relation_type": clean_text(data.get("relation_type"), 80),
+                    "scope": clean_text(data.get("scope"), 40),
+                    "session_id": clean_text(data.get("session_id"), 200),
+                    "group_id": clean_text(data.get("group_id"), 120),
+                    "visibility": clean_text(data.get("visibility"), 40) or "internal",
+                    "evidence": clean_text(data.get("evidence"), 1000),
+                    "confidence": self._float(data.get("confidence"), 0.6),
+                    "review_status": clean_text(data.get("review_status"), 40) or "auto",
+                    "source_memory_id": clean_text(data.get("source_memory_id"), 120),
+                    "metadata": self._dict(data.get("metadata")),
+                },
+            }
+        if kind == "timeline":
+            metadata = self._dict(data.get("metadata"))
+            metadata.setdefault("message_id", clean_text(data.get("message_id") or data.get("id"), 120))
+            metadata["portable_import_batch_id"] = batch_id
+            return {
+                "kind": "timeline",
+                "params": {
+                    "event_type": clean_text(data.get("event_type"), 80),
+                    "session_id": clean_text(data.get("session_id"), 200),
+                    "scope": clean_text(data.get("scope"), 40),
+                    "subject_id": clean_text(data.get("subject_id"), 120),
+                    "object_id": clean_text(data.get("object_id"), 120),
+                    "content": clean_text(data.get("content"), 4000),
+                    "metadata": metadata,
+                    "occurred_at": clean_text(data.get("occurred_at"), 80),
+                },
+                "summarize": bool(clean_text(data.get("summarized_at"), 80)),
+            }
+        if kind == "acl_rule":
+            return {
+                "kind": "acl_rule",
+                "params": {
+                    "owner_scope": clean_text(data.get("owner_scope"), 40),
+                    "owner_id": clean_text(data.get("owner_id"), 160),
+                    "reader_scope": clean_text(data.get("reader_scope"), 40),
+                    "reader_id": clean_text(data.get("reader_id"), 160),
+                    "effect": clean_text(data.get("effect"), 20) or "allow",
+                    "enabled": bool(data.get("enabled", True)),
+                    "note": clean_text(data.get("note"), 300),
+                },
+            }
+        if kind == "acl_policy":
+            policy_values = {
+                "window_scope": clean_text(data.get("window_scope"), 40),
+                "window_id": clean_text(data.get("window_id"), 160),
+                "read_mode": clean_text(data.get("read_mode"), 20),
+                "share_mode": clean_text(data.get("share_mode"), 20),
+            }
+            for feature in ("capture_enabled", "recall_enabled"):
+                if feature in data:
+                    policy_values[feature] = data.get(feature)
+            return {"kind": "acl_policy", "params": policy_values}
+        return None
 
     @staticmethod
     def _write_line(handle: Any, payload: dict[str, Any]) -> None:

--- a/core/provenance_store.py
+++ b/core/provenance_store.py
@@ -35,18 +35,44 @@ class ProvenanceLedger:
     def __init__(self, path: Path):
         self.path = Path(path)
         self._lock = threading.RLock()
+        # mtime/size 缓存：避免每次 mutation 前全量 read_text + json.loads + 逐条校验。
+        # 所有读写均在 self._lock 内进行，缓存无需额外同步。
+        self._cache_document: dict[str, Any] | None = None
+        self._cache_mtime_ns: int | None = None
+        self._cache_size: int | None = None
 
     def _empty(self) -> dict[str, Any]:
         return {"schema_version": LEDGER_SCHEMA_VERSION, "records": {}, "operations": [], "observations": []}
 
     def _load_locked(self) -> dict[str, Any]:
-        if not self.path.is_file():
+        try:
+            stat_result = self.path.stat()
+        except OSError:
+            # 文件缺失或不可访问：清空缓存并返回空文档。
+            self._cache_document = None
+            self._cache_mtime_ns = None
+            self._cache_size = None
             return self._empty()
+        mtime_ns = stat_result.st_mtime_ns
+        size = stat_result.st_size
+        if (
+            self._cache_document is not None
+            and self._cache_mtime_ns == mtime_ns
+            and self._cache_size == size
+        ):
+            # mtime+size 未变化：跳过全量读与逐条校验，直接深拷贝缓存返回。
+            return deepcopy(self._cache_document)
         try:
             raw = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, ValueError, TypeError):
+            self._cache_document = None
+            self._cache_mtime_ns = None
+            self._cache_size = None
             return self._empty()
         if not isinstance(raw, dict) or raw.get("schema_version") != LEDGER_SCHEMA_VERSION:
+            self._cache_document = None
+            self._cache_mtime_ns = None
+            self._cache_size = None
             return self._empty()
         records: dict[str, dict[str, Any]] = {}
         raw_records = raw.get("records")
@@ -73,12 +99,18 @@ class ProvenanceLedger:
                 safe = self._safe_observation(value)
                 if safe is not None:
                     observations.append(safe)
-        return {
+        document = {
             "schema_version": LEDGER_SCHEMA_VERSION,
             "records": records,
             "operations": operations,
             "observations": observations,
         }
+        # 记录加载时文件的 mtime/size，并缓存文档（存深拷贝副本，
+        # 避免调用方对返回值的修改污染缓存）。
+        self._cache_mtime_ns = mtime_ns
+        self._cache_size = size
+        self._cache_document = deepcopy(document)
+        return document
 
     @staticmethod
     def _safe_observation(value: Any) -> dict[str, Any] | None:
@@ -147,6 +179,16 @@ class ProvenanceLedger:
             encoding="utf-8",
         )
         temporary.replace(self.path)
+        # 写入成功后刷新缓存，避免下一次 mutation 再全量重读。
+        self._cache_document = dict(document)
+        try:
+            stat_result = self.path.stat()
+        except OSError:
+            self._cache_mtime_ns = None
+            self._cache_size = None
+        else:
+            self._cache_mtime_ns = stat_result.st_mtime_ns
+            self._cache_size = stat_result.st_size
 
     def _backup_locked(self) -> bool:
         if not self.path.is_file():

--- a/core/retrieval.py
+++ b/core/retrieval.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import math
 import re
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -103,6 +104,11 @@ class RetrievalEngine:
         # 0.0=关闭（历史行为）；>0 时同主题高相似候选只保留评分最高的一条。
         self.dedupe_content_ratio = max(0.0, min(1.0, float(dedupe_content_ratio or 0.0)))
         self._rank_path_info: dict[str, Any] = {}
+        # haystack 缓存：同一 (memory.id, updated_at) 在一次召回内会被
+        # _term_document_stats/_score/MMR features 多次重建，按键复用可省去
+        # 重复的字段拼接与 lower()。以锁保护以便在线程池中安全访问。
+        self._haystack_cache: dict[tuple[str, str], str] = {}
+        self._haystack_cache_lock = threading.Lock()
         self.last_path_info: dict[str, Any] = {
             "mode": self.retrieval_mode,
             "path": "basic",
@@ -1807,12 +1813,15 @@ class RetrievalEngine:
 
     @staticmethod
     def _cosine_similarity(query_vector: list[float], memory_vector: list[float]) -> float:
+        """余弦相似度。
+
+        查询向量在调用前已由 ``_normalize_vector`` 归一化；库内向量在
+        ``list_embedding_candidate_rows`` 缓存填充时已统一 L2 归一化，
+        因此这里直接做点积即可，避免对每个候选重复归一化遍历。
+        """
         if not query_vector or not memory_vector or len(query_vector) != len(memory_vector):
             return 0.0
-        normalized_memory = RetrievalEngine._normalize_vector(memory_vector)
-        if not normalized_memory:
-            return 0.0
-        score = sum(a * b for a, b in zip(query_vector, normalized_memory))
+        score = sum(a * b for a, b in zip(query_vector, memory_vector))
         return max(-1.0, min(1.0, float(score)))
 
     def _embedding_document_text(self, memory: MemoryRecord) -> str:
@@ -3056,6 +3065,11 @@ class RetrievalEngine:
         }
 
     def _haystack(self, memory: MemoryRecord) -> str:
+        cache_key = (memory.id, memory.updated_at)
+        with self._haystack_cache_lock:
+            cached = self._haystack_cache.get(cache_key)
+            if cached is not None:
+                return cached
         metadata = memory.metadata if isinstance(memory.metadata, dict) else {}
         metadata_text_parts = [
             metadata.get("canonical_summary", ""),
@@ -3073,7 +3087,7 @@ class RetrievalEngine:
             if isinstance(metadata.get("participants"), list)
             else "",
         ]
-        return " ".join(
+        haystack = " ".join(
             [
                 memory.content,
                 memory.evidence,
@@ -3086,6 +3100,11 @@ class RetrievalEngine:
                 memory.group_id,
             ]
         ).lower()
+        with self._haystack_cache_lock:
+            if len(self._haystack_cache) >= 4096:
+                self._haystack_cache.clear()
+            self._haystack_cache[cache_key] = haystack
+        return haystack
 
     @staticmethod
     def _route_families(sources: set[str]) -> frozenset[str]:

--- a/core/service.py
+++ b/core/service.py
@@ -887,8 +887,7 @@ class MemoryCompanionService:
         stage_timer.mark("decorate")
 
         capture_enabled = self._scope_feature_enabled(ctx, "capture")
-        if capture_enabled:
-            await self.note_identity(ctx)
+        # note_identity（身份双写）已移入 _capture_async 后台执行，不阻塞请求关键路径。
         stage_timer.mark("note_identity")
         reply_chain = await self._reply_chain_for_event(event)
         stage_timer.mark("reply_chain")
@@ -964,6 +963,8 @@ class MemoryCompanionService:
         所有异常在此被捕获并记录日志，不会传播到请求路径。
         """
         try:
+            # 身份双写（user+group）合并单事务，随采集链一并移入后台，不阻塞请求关键路径。
+            await self.note_identity(ctx)
             if not self.config.bool("memory_capture.enabled", True):
                 return
             if not self.config.bool("memory_capture.capture_user_messages", True):
@@ -1011,8 +1012,40 @@ class MemoryCompanionService:
                     ),
                     metadata=event_metadata,
                 )
+            # 采集写链收集为批量操作，合并单事务一次 commit，减少独立事务/fsync 次数。
+            write_ops: list[dict[str, Any]] = []
+            derived_jobs: list[tuple[int, MemoryRecord, str]] = []
             if self.config.bool("memory_capture.record_relationship_edges", True):
-                await self.note_relationships(ctx, source_memory_id=memory_id)
+                if ctx.scope == "group" and ctx.user_id and ctx.group_id:
+                    write_ops.append(
+                        {
+                            "kind": "relationship",
+                            "source_memory_id": memory_id,
+                            "params": {
+                                "subject": EntityRef(
+                                    kind="user",
+                                    id=ctx.user_id,
+                                    name=ctx.user_name,
+                                    role="group_member",
+                                ),
+                                "object": EntityRef(
+                                    kind="group",
+                                    id=ctx.group_id,
+                                    name=ctx.group_name,
+                                    role="group",
+                                ),
+                                "relation_type": "member_of_group",
+                                "scope": "group",
+                                "session_id": ctx.session_id,
+                                "group_id": ctx.group_id,
+                                "visibility": "group_public",
+                                "evidence": clean_text(ctx.message_text, 500),
+                                "confidence": 0.8,
+                                "review_status": "auto",
+                                "metadata": {"observed_from": "group_message"},
+                            },
+                        }
+                    )
             if self.config.bool("memory_capture.extract_stable_facts", True):
                 derived_memories = self.classifier.derived_user_memories(
                     ctx,
@@ -1047,47 +1080,69 @@ class MemoryCompanionService:
                         )
                         continue
                     if write_mode == "profile":
-                        profile_result = await self.store.upsert_profile_candidate(derived)
-                        if not profile_result.get("ok"):
-                            self._log_profile_write_gate(
-                                derived,
-                                decision="rejected",
-                                reason=clean_text(profile_result.get("code"), 120),
-                            )
-                            continue
-                        derived_id = clean_text(profile_result.get("memory_id"), 120)
-                        gate_reason = clean_text(profile_result.get("profile_status"), 40)
-                        self._log_profile_write_gate(
-                            derived,
-                            decision="written",
-                            reason=gate_reason,
-                        )
-                        if gate_reason == "active":
-                            stored_profile = await self.store.get_memory(derived_id)
-                            self._schedule_memory_embedding(
-                                derived_id, stored_profile or derived
-                            )
+                        write_ops.append({"kind": "profile", "record": derived})
                     else:
-                        derived_id = await self.store.insert_memory(derived)
-                        self._schedule_memory_embedding(derived_id, derived)
+                        write_ops.append({"kind": "memory", "record": derived})
+                    op_index = len(write_ops) - 1
+                    derived_jobs.append((op_index, derived, write_mode))
                     relation_type = str(derived.metadata.get("relation_type") or "")
                     if relation_type and self.config.bool(
                         "memory_capture.record_relationship_edges", True
                     ):
-                        await self.store.upsert_relationship(
-                            subject=derived.subject,
-                            object=self._bot_entity(ctx),
-                            relation_type=relation_type,
-                            scope=ctx.scope,
-                            session_id=ctx.session_id,
-                            group_id=ctx.group_id,
-                            visibility=derived.visibility,
-                            evidence=derived.evidence,
-                            confidence=derived.confidence,
-                            review_status=derived.review_status,
-                            source_memory_id=derived_id,
-                            metadata={"source": "relationship_claim"},
+                        write_ops.append(
+                            {
+                                "kind": "relationship",
+                                "requires_ok": [op_index],
+                                "source_memory_id_from": op_index,
+                                "params": {
+                                    "subject": derived.subject,
+                                    "object": self._bot_entity(ctx),
+                                    "relation_type": relation_type,
+                                    "scope": ctx.scope,
+                                    "session_id": ctx.session_id,
+                                    "group_id": ctx.group_id,
+                                    "visibility": derived.visibility,
+                                    "evidence": derived.evidence,
+                                    "confidence": derived.confidence,
+                                    "review_status": derived.review_status,
+                                    "metadata": {"source": "relationship_claim"},
+                                },
+                            }
                         )
+            batch_results = await self.store.capture_write_batch(write_ops)
+            # 批量结果后处理：画像门禁日志与 embedding 调度。
+            for op_index, derived, write_mode in derived_jobs:
+                result = batch_results[op_index] if op_index < len(batch_results) else {}
+                if write_mode == "profile":
+                    if not result.get("ok"):
+                        self._log_profile_write_gate(
+                            derived,
+                            decision="rejected",
+                            reason=clean_text(result.get("code"), 120),
+                        )
+                        continue
+                    derived_id = clean_text(result.get("memory_id"), 120)
+                    gate_reason = clean_text(result.get("profile_status"), 40)
+                    self._log_profile_write_gate(
+                        derived,
+                        decision="written",
+                        reason=gate_reason,
+                    )
+                    if gate_reason == "active":
+                        stored_profile = await self.store.get_memory(derived_id)
+                        self._schedule_memory_embedding(
+                            derived_id, stored_profile or derived
+                        )
+                else:
+                    if not result.get("ok"):
+                        logger.warning(
+                            "[MemoryCompanion] 派生记忆批量写入失败: type=%s code=%s",
+                            clean_text(derived.memory_type, 80),
+                            clean_text(result.get("code"), 120),
+                        )
+                        continue
+                    derived_id = clean_text(result.get("memory_id"), 120)
+                    self._schedule_memory_embedding(derived_id, derived)
             await self.portraits.capture_user_message(ctx, event=event, req=req)
             self._ensure_portrait_daily_dispatcher()
             if not self.config.bool("memory_capture.capture_bot_responses", True):
@@ -10923,21 +10978,28 @@ class MemoryCompanionService:
         return "user actively interrupted" in lowered or "partial output before interruption" in lowered
 
     async def note_identity(self, ctx: SessionContext) -> None:
+        identities: list[dict[str, Any]] = []
         if ctx.user_id:
-            await self.store.upsert_identity(
-                platform=ctx.platform,
-                entity=EntityRef(kind="user", id=ctx.user_id, name=ctx.user_name, role="current_sender"),
-                aliases=[ctx.user_name] if ctx.user_name else [],
-                profile={"last_session": ctx.session_id, "last_scope": ctx.scope},
-                confidence=0.7,
+            identities.append(
+                {
+                    "platform": ctx.platform,
+                    "entity": EntityRef(kind="user", id=ctx.user_id, name=ctx.user_name, role="current_sender"),
+                    "aliases": [ctx.user_name] if ctx.user_name else [],
+                    "profile": {"last_session": ctx.session_id, "last_scope": ctx.scope},
+                    "confidence": 0.7,
+                }
             )
         if ctx.group_id:
-            await self.store.upsert_identity(
-                platform=ctx.platform,
-                entity=EntityRef(kind="group", id=ctx.group_id, name=ctx.group_name, role="group"),
-                profile={"last_session": ctx.session_id},
-                confidence=0.7,
+            identities.append(
+                {
+                    "platform": ctx.platform,
+                    "entity": EntityRef(kind="group", id=ctx.group_id, name=ctx.group_name, role="group"),
+                    "profile": {"last_session": ctx.session_id},
+                    "confidence": 0.7,
+                }
             )
+        if identities:
+            await self.store.upsert_identities(identities)
 
     async def note_relationships(self, ctx: SessionContext, source_memory_id: str = "") -> None:
         if ctx.scope == "group" and ctx.user_id and ctx.group_id:

--- a/core/store.py
+++ b/core/store.py
@@ -10,12 +10,14 @@ from copy import deepcopy
 from datetime import datetime, timezone
 import re
 import sqlite3
+import struct
 import threading
 import time
 from pathlib import Path
 from typing import Any
 
 from .identity import parse_scope_from_session
+from .astrbot_compat import logger
 from .memory_atom import (
     DURABILITY_LEVELS,
     SENSITIVITY_LEVELS,
@@ -45,6 +47,50 @@ from .sensitive_data import redact_sensitive_text, redact_sensitive_value
 
 
 _ACL_UNSET = object()
+
+
+# 向量二进制格式常量：little-endian float64 打包，
+# 相比 JSON 文本列可减少约 60% 存储体积并省去 json 解析开销。
+_EMBEDDING_VECTOR_FMT = "<d"
+
+
+def _pack_embedding_vector(values: list[float]) -> bytes:
+    """把向量序列化为二进制 bytes（兼容旧 JSON 文本读取）。"""
+    floats = [float(item) for item in values if isinstance(item, (int, float))]
+    if not floats:
+        return b""
+    return struct.pack(f"<{len(floats)}d", *floats)
+
+
+def _unpack_embedding_vector(raw: Any) -> list[float]:
+    """按二进制格式解析向量；若是旧 JSON 文本则回退 json 解析。"""
+    if isinstance(raw, (bytes, bytearray, memoryview)):
+        payload = bytes(raw)
+        count = len(payload) // 8
+        if count <= 0:
+            return []
+        return list(struct.unpack(f"<{count}d", payload[: count * 8]))
+    if isinstance(raw, str) and raw:
+        payload = json_loads(raw, [])
+        if isinstance(payload, list):
+            vector: list[float] = []
+            for item in payload:
+                try:
+                    vector.append(float(item))
+                except Exception:
+                    return []
+            return vector
+    return []
+
+
+def _normalize_embedding_vector_values(values: list[float]) -> list[float]:
+    """对向量做 L2 归一化，供候选缓存一次性归一化，避免每次召回重复计算。"""
+    if not values:
+        return []
+    norm = math.sqrt(sum(value * value for value in values))
+    if norm <= 0:
+        return []
+    return [value / norm for value in values]
 
 
 class MemoryStore:
@@ -1017,6 +1063,48 @@ class MemoryStore:
             )
             self._conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_portrait_learning_queue_person ON portrait_learning_queue(person_id, state, updated_at)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memories_profile_domain "
+                "ON memories(platform, subject_kind, subject_id, object_kind, "
+                "object_id, scope, group_id, visibility, memory_type, lifecycle)"
+            )
+            # c1: 画像治理/修复按 fact_id 逐条查询，原无索引导致逐 fact 全表扫描
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_portrait_learning_queue_fact "
+                "ON portrait_learning_queue(fact_id, state)"
+            )
+            # c2: 回滚/删除按 source_memory_id 批量 IN 查询，原无索引导致全表扫描
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_relationship_edges_source_memory "
+                "ON relationship_edges(source_memory_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_knowledge_edges_source_memory "
+                "ON knowledge_edges(source_memory_id)"
+            )
+            # c3: 仅按 session_id 过滤 emotion 事件时现有索引（前缀 bot_id）无法命中
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_emotion_events_session "
+                "ON emotion_events(session_id, occurred_at DESC)"
+            )
+            # c4: timeline 仅按 session_id（无 scope）过滤时无索引命中；
+            #     memories 时间窗口查询的 created_at/updated_at 无索引
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_timeline_session_recent "
+                "ON timeline(session_id, occurred_at DESC, created_at DESC)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memories_updated_at ON memories(updated_at)"
+            )
+            # c5: emotion 投递查询使用 LOWER(scope) 导致 scope 列索引失效，
+            #     用表达式索引精确匹配 LOWER(scope) 谓词
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_emotion_events_delivery_scope "
+                "ON emotion_events(bot_id, LOWER(scope), platform)"
             )
             self._redact_existing_sensitive_rows_sync()
             self._cleanup_placeholder_memory_indexes_sync()
@@ -4014,6 +4102,14 @@ class MemoryStore:
             "SELECT * FROM memory_embeddings WHERE memory_id=? ORDER BY provider_id",
             (record.id,),
         ).fetchall()
+        embedding_snapshots: list[dict[str, Any]] = []
+        for row in embedding_rows:
+            snapshot = dict(row)
+            raw_vector = snapshot.get("vector")
+            # 二进制向量转回 JSON 文本，保证快照可 json 序列化且恢复路径兼容
+            if isinstance(raw_vector, (bytes, bytearray, memoryview)):
+                snapshot["vector"] = json_dumps(_unpack_embedding_vector(raw_vector))
+            embedding_snapshots.append(snapshot)
         return {
             "record_kind": "memory",
             "record_id": record.id,
@@ -4022,7 +4118,7 @@ class MemoryStore:
             "guard_only": bool(guard_only),
             "before": self._memory_db_snapshot(record),
             "review_queue": [dict(row) for row in review_rows],
-            "embeddings": [dict(row) for row in embedding_rows],
+            "embeddings": embedding_snapshots,
             "after_fingerprint": "",
         }
 
@@ -5297,7 +5393,13 @@ class MemoryStore:
             review_reason,
         )
 
-    def _insert_memory_sync(self, record: MemoryRecord, review_reason: str = "") -> str:
+    def _insert_memory_sync(
+        self,
+        record: MemoryRecord,
+        review_reason: str = "",
+        _commit: bool = True,
+    ) -> str:
+        # _commit=False 用于批量写链：由外层事务统一提交，避免逐次 fsync。
         record.ensure_defaults()
         data = record.to_db()
         columns = ", ".join(data.keys())
@@ -5402,7 +5504,8 @@ class MemoryStore:
                 )
                 row = self._conn.execute("SELECT * FROM memories WHERE id=?", (duplicate["id"],)).fetchone()
                 self._upsert_memory_fts_row(row)
-                self._conn.commit()
+                if _commit:
+                    self._conn.commit()
                 return str(duplicate["id"])
             self._conn.execute(
                 f"INSERT INTO memories ({columns}) VALUES ({placeholders}) "
@@ -5413,7 +5516,8 @@ class MemoryStore:
                 self._upsert_review_sync(record.id, review_reason or "待人工确认")
             row = self._conn.execute("SELECT * FROM memories WHERE id=?", (record.id,)).fetchone()
             self._upsert_memory_fts_row(row)
-            self._conn.commit()
+            if _commit:
+                self._conn.commit()
         return record.id
 
     def _upsert_review_sync(self, memory_id: str, reason: str) -> None:
@@ -5451,7 +5555,13 @@ class MemoryStore:
             confidence,
         )
 
-    def _upsert_identity_sync(
+    async def upsert_identities(
+        self, identities: list[dict[str, Any]]
+    ) -> list[str]:
+        """批量写入多条身份记录，合并为单事务提交（减少独立 commit）。"""
+        return await asyncio.to_thread(self._upsert_identities_sync, identities)
+
+    def _upsert_identity_row_locked(
         self,
         platform: str,
         entity: EntityRef,
@@ -5459,6 +5569,7 @@ class MemoryStore:
         profile: dict[str, Any],
         confidence: float,
     ) -> str:
+        """写入单行身份记录；调用方须已持有 ``self._lock`` 且处于事务中。"""
         now = utc_now()
         entity_id = clean_text(entity.id, 120)
         if not entity_id:
@@ -5467,51 +5578,83 @@ class MemoryStore:
         aliases = [clean_text(alias, 80) for alias in aliases if clean_text(alias, 80)]
         if entity.name and entity.name not in aliases:
             aliases.append(entity.name)
+        old = self._conn.execute(
+            "SELECT aliases, profile, created_at FROM identities WHERE id=?",
+            (row_id,),
+        ).fetchone()
+        created_at = now
+        if old:
+            created_at = old["created_at"] or now
+            merged_aliases = list(dict.fromkeys(json_loads(old["aliases"], []) + aliases))
+            merged_profile = json_loads(old["profile"], {})
+            merged_profile.update(profile)
+        else:
+            merged_aliases = aliases
+            merged_profile = profile
+        self._conn.execute(
+            """
+            INSERT INTO identities(
+                id, platform, entity_kind, entity_id, display_name, role, aliases,
+                profile, confidence, created_at, updated_at
+            )
+            VALUES(?,?,?,?,?,?,?,?,?,?,?)
+            ON CONFLICT(platform, entity_kind, entity_id) DO UPDATE SET
+                display_name=excluded.display_name,
+                role=excluded.role,
+                aliases=excluded.aliases,
+                profile=excluded.profile,
+                confidence=max(identities.confidence, excluded.confidence),
+                updated_at=excluded.updated_at
+            """,
+            (
+                row_id,
+                platform,
+                entity.kind,
+                entity_id,
+                clean_text(entity.name, 80),
+                clean_text(entity.role, 80),
+                json_dumps(merged_aliases),
+                json_dumps(merged_profile),
+                confidence,
+                created_at,
+                now,
+            ),
+        )
+        return row_id
+
+    def _upsert_identity_sync(
+        self,
+        platform: str,
+        entity: EntityRef,
+        aliases: list[str],
+        profile: dict[str, Any],
+        confidence: float,
+    ) -> str:
         with self._lock:
-            old = self._conn.execute(
-                "SELECT aliases, profile, created_at FROM identities WHERE id=?",
-                (row_id,),
-            ).fetchone()
-            created_at = now
-            if old:
-                created_at = old["created_at"] or now
-                merged_aliases = list(dict.fromkeys(json_loads(old["aliases"], []) + aliases))
-                merged_profile = json_loads(old["profile"], {})
-                merged_profile.update(profile)
-            else:
-                merged_aliases = aliases
-                merged_profile = profile
-            self._conn.execute(
-                """
-                INSERT INTO identities(
-                    id, platform, entity_kind, entity_id, display_name, role, aliases,
-                    profile, confidence, created_at, updated_at
-                )
-                VALUES(?,?,?,?,?,?,?,?,?,?,?)
-                ON CONFLICT(platform, entity_kind, entity_id) DO UPDATE SET
-                    display_name=excluded.display_name,
-                    role=excluded.role,
-                    aliases=excluded.aliases,
-                    profile=excluded.profile,
-                    confidence=max(identities.confidence, excluded.confidence),
-                    updated_at=excluded.updated_at
-                """,
-                (
-                    row_id,
-                    platform,
-                    entity.kind,
-                    entity_id,
-                    clean_text(entity.name, 80),
-                    clean_text(entity.role, 80),
-                    json_dumps(merged_aliases),
-                    json_dumps(merged_profile),
-                    confidence,
-                    created_at,
-                    now,
-                ),
+            row_id = self._upsert_identity_row_locked(
+                platform, entity, aliases, profile, confidence
             )
             self._conn.commit()
         return row_id
+
+    def _upsert_identities_sync(
+        self, identities: list[dict[str, Any]]
+    ) -> list[str]:
+        """批量身份写入：单事务（BEGIN IMMEDIATE + 一次 commit）。"""
+        if not identities:
+            return []
+        with self._lock:
+            with self._transaction_sync():
+                return [
+                    self._upsert_identity_row_locked(
+                        platform=identity.get("platform") or "",
+                        entity=identity.get("entity") or EntityRef(kind="user", id="unknown"),
+                        aliases=identity.get("aliases") or [],
+                        profile=identity.get("profile") or {},
+                        confidence=float(identity.get("confidence") or 0.0),
+                    )
+                    for identity in identities
+                ]
 
     async def list_identities(self, limit: int = 1000, *, offset: int = 0) -> list[dict[str, Any]]:
         return await asyncio.to_thread(self._list_identities_sync, limit, offset)
@@ -5577,6 +5720,7 @@ class MemoryStore:
         review_status: str,
         source_memory_id: str,
         metadata: dict[str, Any],
+        _commit: bool = True,
     ) -> str:
         now = utc_now()
         row_id = new_id("rel")
@@ -5648,8 +5792,105 @@ class MemoryStore:
                     now,
                 ),
             )
-            self._conn.commit()
+            if _commit:
+                self._conn.commit()
         return row_id
+
+    async def capture_write_batch(
+        self, ops: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """批量执行采集写链，合并为单事务一次 commit。
+
+        ops 为有序写操作描述列表，元素形如：
+          - {"kind": "relationship", "source_memory_id": str,
+             "params": {详见 _upsert_relationship_sync 关键字参数}}
+          - {"kind": "profile", "record": MemoryRecord}
+          - {"kind": "memory", "record": MemoryRecord}
+        可附加字段：
+          - "requires_ok": list[int] 仅当这些索引对应的 op 均成功才执行
+          - "source_memory_id_from": int 从该索引 op 的结果中取 memory_id
+        profile 项内部已含 SAVEPOINT（_transaction_sync），在外层事务中自动降级嵌套；
+        memory 项通过 _commit=False 复用内部无 commit 变体。
+        返回与 ops 等长的结果列表；单项失败被 SAVEPOINT 隔离，不拖累整批。
+        """
+        return await asyncio.to_thread(self._capture_write_batch_sync, ops)
+
+    def _capture_write_batch_sync(
+        self, ops: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        if not ops:
+            return results
+        with self._lock:
+            with self._transaction_sync():
+                for index, op in enumerate(ops):
+                    kind = "unknown"
+                    try:
+                        if not isinstance(op, dict):
+                            raise TypeError("batch operation must be a mapping")
+                        kind = clean_text(op.get("kind"), 40) or "unknown"
+                        required_indexes = op.get("requires_ok") or []
+                        if any(
+                            not isinstance(i, int)
+                            or i < 0
+                            or i >= len(results)
+                            or not results[i].get("ok")
+                            for i in required_indexes
+                        ):
+                            results.append(
+                                {"ok": False, "code": "skip_required_op_failed"}
+                            )
+                            continue
+                        with self._transaction_sync():  # 单项 SAVEPOINT 隔离失败
+                            if kind == "relationship":
+                                params = dict(op["params"])
+                                if op.get("source_memory_id_from") is not None:
+                                    src_index = op["source_memory_id_from"]
+                                    src = (
+                                        results[src_index].get("memory_id") or ""
+                                        if src_index < len(results)
+                                        else ""
+                                    )
+                                    params["source_memory_id"] = src
+                                elif op.get("source_memory_id"):
+                                    params["source_memory_id"] = op["source_memory_id"]
+                                elif "source_memory_id" not in params:
+                                    params["source_memory_id"] = ""
+                                row_id = self._upsert_relationship_sync(
+                                    _commit=False, **params
+                                )
+                                results.append({"ok": True, "row_id": row_id})
+                            elif kind == "profile":
+                                results.append(
+                                    self._upsert_profile_candidate_sync(op["record"])
+                                )
+                            elif kind == "memory":
+                                memory_id = self._insert_memory_sync(
+                                    op["record"],
+                                    op.get("review_reason") or "",
+                                    _commit=False,
+                                )
+                                results.append({"ok": True, "memory_id": memory_id})
+                            else:
+                                results.append(
+                                    {"ok": False, "code": f"unknown_batch_op:{kind}"}
+                                )
+                    except Exception as exc:
+                        logger.warning(
+                            "[MemoryCompanion] 批量写入单项失败 index=%s kind=%s error=%s",
+                            index,
+                            kind,
+                            exc,
+                            exc_info=True,
+                        )
+                        results.append(
+                            {
+                                "ok": False,
+                                "code": "batch_op_error",
+                                "error": clean_text(str(exc), 300),
+                            }
+                        )
+        return results
 
     async def list_relationships(
         self,
@@ -7882,7 +8123,7 @@ class MemoryStore:
     async def mark_timeline_summarized(self, event_ids: list[str]) -> int:
         return await asyncio.to_thread(self._mark_timeline_summarized_sync, event_ids)
 
-    def _mark_timeline_summarized_sync(self, event_ids: list[str]) -> int:
+    def _mark_timeline_summarized_sync(self, event_ids: list[str], _commit: bool = True) -> int:
         ids = [clean_text(event_id, 120) for event_id in event_ids if clean_text(event_id, 120)]
         if not ids:
             return 0
@@ -7892,7 +8133,9 @@ class MemoryStore:
                 f"UPDATE timeline SET summarized_at=? WHERE id IN ({placeholders})",
                 [utc_now()] + ids,
             )
-            self._conn.commit()
+            # _commit=False 用于批量导入：由外层事务统一提交，避免逐次 fsync。
+            if _commit:
+                self._conn.commit()
         return int(cur.rowcount or 0)
 
     async def get_summary_failure(self, session_id: str) -> dict[str, Any] | None:
@@ -9743,6 +9986,7 @@ class MemoryStore:
         effect: str,
         enabled: bool,
         note: str,
+        _commit: bool = True,
     ) -> dict[str, Any]:
         now = utc_now()
         owner_scope = clean_text(owner_scope, 40)
@@ -9784,7 +10028,8 @@ class MemoryStore:
                 """,
                 (owner_scope, owner_id, reader_scope, reader_id),
             ).fetchone()
-            self._conn.commit()
+            if _commit:
+                self._conn.commit()
         return self._acl_rule_from_row(row) if row else data
 
     async def delete_acl_rule(self, rule_id: str) -> bool:
@@ -9855,8 +10100,9 @@ class MemoryStore:
         window_id: str,
         read_mode: str,
         share_mode: str,
-        capture_enabled: Any,
-        recall_enabled: Any,
+        capture_enabled: Any = _ACL_UNSET,
+        recall_enabled: Any = _ACL_UNSET,
+        _commit: bool = True,
     ) -> dict[str, Any]:
         window_scope = clean_text(window_scope, 40)
         window_id = clean_text(window_id, 160)
@@ -9907,7 +10153,8 @@ class MemoryStore:
                 "SELECT * FROM memory_acl_policies WHERE window_scope=? AND window_id=?",
                 (window_scope, window_id),
             ).fetchone()
-            self._conn.commit()
+            if _commit:
+                self._conn.commit()
             self._acl_feature_override_cache[(window_scope, window_id)] = (
                 next_capture,
                 next_recall,
@@ -11058,6 +11305,7 @@ class MemoryStore:
         if not memory_id or not provider_id or not text_hash or not values:
             return
         now = utc_now()
+        packed = _pack_embedding_vector(values)
         with self._lock:
             self._conn.execute(
                 """
@@ -11077,7 +11325,7 @@ class MemoryStore:
                     provider_id,
                     text_hash,
                     len(values),
-                    json_dumps(values),
+                    packed,
                     now,
                     now,
                     memory_id,
@@ -11139,16 +11387,9 @@ class MemoryStore:
             ).fetchall()
         result: list[tuple[MemoryRecord, list[float], str]] = []
         for row in rows:
-            payload = json_loads(row["embedding_vector"], [])
-            if not isinstance(payload, list):
-                continue
-            vector: list[float] = []
-            for item in payload:
-                try:
-                    vector.append(float(item))
-                except Exception:
-                    vector = []
-                    break
+            vector = _normalize_embedding_vector_values(
+                _unpack_embedding_vector(row["embedding_vector"])
+            )
             if not vector:
                 continue
             result.append((MemoryRecord.from_row(row), vector, clean_text(row["embedding_text_hash"], 80)))
@@ -11409,6 +11650,96 @@ class MemoryStore:
             )
             self._conn.commit()
         return row_id
+
+    async def import_batch_ops(self, ops: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """批量导入写入（portable JSONL 导入用），合并为单事务一次 commit。
+
+        ops 为有序写入描述列表，元素形如：
+          - {"kind": "memory", "record": MemoryRecord, "review_reason": str}
+          - {"kind": "identity", "params": {platform, entity, aliases, profile, confidence}}
+          - {"kind": "relationship", "params": {详见 _upsert_relationship_sync 关键字参数}}
+          - {"kind": "timeline", "params": {event_type, session_id, scope, subject_id,
+             object_id, content, metadata, occurred_at}, "summarize": bool}
+          - {"kind": "acl_rule", "params": {owner_scope, owner_id, reader_scope,
+             reader_id, effect, enabled, note}}
+          - {"kind": "acl_policy", "params": {window_scope, window_id, read_mode,
+             share_mode, capture_enabled, recall_enabled}}
+        单项失败被 SAVEPOINT 隔离，不拖累整批；全部完成后一次 commit。
+        返回与 ops 等长的结果列表，每项为 {"ok": bool, ...}。
+        """
+        return await asyncio.to_thread(self._import_batch_ops_sync, ops)
+
+    def _import_batch_ops_sync(
+        self, ops: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        if not ops:
+            return results
+        with self._lock:
+            with self._transaction_sync():
+                for index, op in enumerate(ops):
+                    kind = "unknown"
+                    try:
+                        if not isinstance(op, dict):
+                            raise TypeError("batch operation must be a mapping")
+                        kind = clean_text(op.get("kind"), 40) or "unknown"
+                        with self._transaction_sync():  # 单项 SAVEPOINT 隔离失败
+                            if kind == "memory":
+                                memory_id = self._insert_memory_sync(
+                                    op["record"],
+                                    op.get("review_reason") or "",
+                                    _commit=False,
+                                )
+                                results.append({"ok": True, "memory_id": memory_id})
+                            elif kind == "identity":
+                                row_id = self._upsert_identity_row_locked(
+                                    **op["params"]
+                                )
+                                results.append({"ok": True, "row_id": row_id})
+                            elif kind == "relationship":
+                                row_id = self._upsert_relationship_sync(
+                                    _commit=False, **op["params"]
+                                )
+                                results.append({"ok": True, "row_id": row_id})
+                            elif kind == "timeline":
+                                event_id = self._add_timeline_event_sync(
+                                    **op["params"]
+                                )
+                                if op.get("summarize"):
+                                    self._mark_timeline_summarized_sync(
+                                        [event_id], _commit=False
+                                    )
+                                results.append({"ok": True, "event_id": event_id})
+                            elif kind == "acl_rule":
+                                result = self._upsert_acl_rule_sync(
+                                    _commit=False, **op["params"]
+                                )
+                                results.append({"ok": True, "result": result})
+                            elif kind == "acl_policy":
+                                result = self._upsert_acl_policy_sync(
+                                    _commit=False, **op["params"]
+                                )
+                                results.append({"ok": True, "result": result})
+                            else:
+                                results.append(
+                                    {"ok": False, "code": f"unknown_batch_op:{kind}"}
+                                )
+                    except Exception as exc:
+                        logger.warning(
+                            "[MemoryCompanion] 批量导入单项失败 index=%s kind=%s error=%s",
+                            index,
+                            kind,
+                            exc,
+                            exc_info=True,
+                        )
+                        results.append(
+                            {
+                                "ok": False,
+                                "code": "batch_op_error",
+                                "error": clean_text(str(exc), 300),
+                            }
+                        )
+        return results
 
     async def upsert_emotion_event(self, value: Any) -> dict[str, Any]:
         return await self._run_recoverable_database_operation(self._upsert_emotion_event_sync, value)

--- a/tests/test_pr29_optimized.py
+++ b/tests/test_pr29_optimized.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+try:
+    from .package_bootstrap import bootstrap_package
+except ImportError:
+    from package_bootstrap import bootstrap_package
+
+
+ROOT = bootstrap_package()
+
+from astrbot_plugin_memory_companion.core.models import EntityRef, MemoryRecord
+from astrbot_plugin_memory_companion.core.store import MemoryStore
+
+
+def _memory(memory_id: str) -> MemoryRecord:
+    return MemoryRecord(
+        id=memory_id,
+        memory_type="observation",
+        subject=EntityRef(kind="user", id="u1"),
+        object=EntityRef(kind="bot", id="b1"),
+        scope="private",
+        session_id="qq:FriendMessage:u1",
+        platform="qq",
+        visibility="private_pair",
+        lifecycle="stable_memory",
+        content=f"批量事务测试 {memory_id}",
+    )
+
+
+class OptimizedBatchWriteTests(unittest.IsolatedAsyncioTestCase):
+    def make_store(self) -> MemoryStore:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = MemoryStore(Path(temp_dir.name) / "memory.db")
+        store.initialize()
+        self.addCleanup(store.close)
+        return store
+
+    async def test_capture_batch_rolls_back_one_item_and_skips_its_dependency(self) -> None:
+        store = self.make_store()
+        original_insert = store._insert_memory_sync
+
+        def insert_then_fail(
+            record: MemoryRecord,
+            review_reason: str = "",
+            _commit: bool = True,
+        ) -> str:
+            memory_id = original_insert(record, review_reason, _commit=False)
+            if record.id == "batch-fail":
+                raise RuntimeError("injected item failure")
+            return memory_id
+
+        store._insert_memory_sync = insert_then_fail
+        statements: list[str] = []
+        store._conn.set_trace_callback(statements.append)
+        try:
+            results = await store.capture_write_batch(
+                [
+                    {"kind": "memory", "record": _memory("batch-first")},
+                    {"kind": "memory", "record": _memory("batch-fail")},
+                    {
+                        "kind": "relationship",
+                        "requires_ok": [1],
+                        "source_memory_id_from": 1,
+                        "params": {
+                            "subject": EntityRef(kind="user", id="u1"),
+                            "object": EntityRef(kind="bot", id="b1"),
+                            "relation_type": "trusts",
+                            "scope": "private",
+                            "session_id": "qq:FriendMessage:u1",
+                            "group_id": "",
+                            "visibility": "private_pair",
+                            "evidence": "依赖失败项，不应写入",
+                            "confidence": 0.8,
+                            "review_status": "auto",
+                            "metadata": {},
+                        },
+                    },
+                    {},
+                    {"kind": "memory", "record": _memory("batch-last")},
+                ]
+            )
+        finally:
+            store._conn.set_trace_callback(None)
+
+        self.assertEqual([True, False, False, False, True], [item["ok"] for item in results])
+        self.assertEqual("skip_required_op_failed", results[2]["code"])
+        self.assertEqual("unknown_batch_op:unknown", results[3]["code"])
+        self.assertIsNotNone(await store.get_memory("batch-first"))
+        self.assertIsNone(await store.get_memory("batch-fail"))
+        self.assertIsNotNone(await store.get_memory("batch-last"))
+        self.assertEqual([], await store.list_relationships(limit=10))
+        self.assertEqual(
+            1,
+            sum(statement.strip().upper() == "COMMIT" for statement in statements),
+        )
+
+    async def test_import_batch_keeps_timeline_summary_in_outer_transaction(self) -> None:
+        store = self.make_store()
+        statements: list[str] = []
+        store._conn.set_trace_callback(statements.append)
+        try:
+            results = await store.import_batch_ops(
+                [
+                    {
+                        "kind": "timeline",
+                        "params": {
+                            "event_type": "user_message",
+                            "session_id": "qq:FriendMessage:u1",
+                            "scope": "private",
+                            "subject_id": "u1",
+                            "object_id": "b1",
+                            "content": "同事务导入并标记总结",
+                            "metadata": {"message_id": "batch-timeline-1"},
+                            "occurred_at": "2026-09-06T00:00:00+00:00",
+                        },
+                        "summarize": True,
+                    },
+                    {"kind": "memory", "record": _memory("import-memory")},
+                    {},
+                ]
+            )
+        finally:
+            store._conn.set_trace_callback(None)
+
+        self.assertEqual([True, True, False], [item["ok"] for item in results])
+        timeline = await store.recent_timeline(limit=10)
+        self.assertEqual(1, len(timeline))
+        self.assertTrue(timeline[0]["summarized_at"])
+        self.assertIsNotNone(await store.get_memory("import-memory"))
+        self.assertEqual(
+            1,
+            sum(statement.strip().upper() == "COMMIT" for statement in statements),
+        )
+
+    async def test_identity_batch_accepts_omitted_optional_fields(self) -> None:
+        store = self.make_store()
+
+        row_ids = await store.upsert_identities(
+            [
+                {
+                    "platform": "qq",
+                    "entity": EntityRef(kind="group", id="g1", name="测试群"),
+                    "profile": {"last_session": "qq:GroupMessage:g1"},
+                    "confidence": 0.7,
+                }
+            ]
+        )
+
+        self.assertEqual(["qq:group:g1"], row_ids)
+        identities = await store.list_identities(limit=10)
+        self.assertEqual(["测试群"], identities[0]["aliases"])
+
+
+class OptimizedEmbeddingCompatibilityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_binary_and_legacy_json_embeddings_are_both_readable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            store = MemoryStore(Path(temp) / "memory.db")
+            store.initialize()
+            try:
+                binary_memory = _memory("embedding-binary")
+                legacy_memory = _memory("embedding-legacy")
+                await store.insert_memory(binary_memory)
+                await store.insert_memory(legacy_memory)
+                await store.upsert_memory_embedding(
+                    memory_id=binary_memory.id,
+                    provider_id="embedder",
+                    text_hash="binary-hash",
+                    vector=[0.0, 5.0],
+                )
+                await store.upsert_memory_embedding(
+                    memory_id=legacy_memory.id,
+                    provider_id="embedder",
+                    text_hash="legacy-hash",
+                    vector=[3.0, 4.0],
+                )
+
+                raw_binary = store._conn.execute(
+                    "SELECT vector FROM memory_embeddings WHERE memory_id=?",
+                    (binary_memory.id,),
+                ).fetchone()[0]
+                self.assertIsInstance(raw_binary, bytes)
+                store._conn.execute(
+                    "UPDATE memory_embeddings SET vector=? WHERE memory_id=?",
+                    (json.dumps([3.0, 4.0]), legacy_memory.id),
+                )
+                store._conn.commit()
+
+                rows = await store.list_embedding_candidate_rows(provider_id="embedder")
+                vectors = {record.id: vector for record, vector, _ in rows}
+                self.assertEqual([0.0, 1.0], vectors[binary_memory.id])
+                self.assertAlmostEqual(0.6, vectors[legacy_memory.id][0])
+                self.assertAlmostEqual(0.8, vectors[legacy_memory.id][1])
+            finally:
+                store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 整合范围

从 #29 选择性整合已验证的性能改动：

- 身份、采集链和 portable import 批量事务
- embedding 二进制存储，并兼容读取旧 JSON 向量
- 召回候选归一化、haystack 缓存和缺失索引
- audit 深拷贝与 provenance ledger 缓存

## 合并前加固

- 将缺失/非法 batch op 纳入单项隔离，避免中断整批
- 校验依赖索引并在前置项失败时跳过关系写入
- 保留画像域读取的事务一致性
- 保留原 10 列关键词召回覆盖
- 不采用缺少明确 owner 关闭路径的 migration outbox 长连接

## 明确排除

- 不改变记忆半衰期、freshness、新近权重与默认槽位
- 不加入当前 private companion 整合未消费的 group moment portrait 写入链

## 验证

- 新增事务/兼容性测试：4 passed
- operations/store/retrieval/profile/audit：79 passed, 11 subtests passed
- migration recovery：8 passed
- service profile/provenance：8 passed
- 相关模块 py_compile 通过

另外观察到两个 main 基线问题：启动宽限期测试期望与当前实现不一致，以及面板 app.js 的转义文本问题；均不在本 PR 修改范围。

Supersedes the validated performance subset of #29.